### PR TITLE
Add the missing "System" category required by FDO menu specification

### DIFF
--- a/data/guake.desktop.in
+++ b/data/guake.desktop.in
@@ -10,6 +10,6 @@ TryExec=guake
 Exec=guake
 Icon=guake
 Type=Application
-Categories=GNOME;GTK;Utility;TerminalEmulator;
+Categories=GNOME;GTK;System;Utility;TerminalEmulator;
 StartupNotify=true
 X-GNOME-Autostart-enabled=false


### PR DESCRIPTION
Just run "desktop-file-validate guake.desktop" and see the warning message if this commit is not present. Also see http://standards.freedesktop.org/menu-spec/latest/apa.html .

Actually, I think the better fix is just only using the "System" catetory and remove the "Utilitiy" category. That avoids the duplicated entries in both menus/categories. And that is exactly what xterm is doing. I will leave the removing thing for the maintainer to decide.
