### PR TITLE
Do not install the autostart file

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -18,10 +18,6 @@ desktopdir = $(datadir)/applications
 desktop_in_files = guake.desktop.in guake-prefs.desktop.in
 desktop_DATA = $(desktop_in_files:.desktop.in=.desktop)
 
-autostartdir = $(sysconfdir)/xdg/autostart
-autostart_in_files = guake.desktop.in
-autostart_DATA = $(autostart_in_files:.desktop.in=.desktop)
-
 @INTLTOOL_SCHEMAS_RULE@
 schemadir = $(sysconfdir)/gconf/schemas
 schema_DATA = guake.schemas

--- a/data/guake.desktop.in
+++ b/data/guake.desktop.in
@@ -12,4 +12,3 @@ Icon=guake
 Type=Application
 Categories=GNOME;GTK;Utility;TerminalEmulator;
 StartupNotify=true
-X-GNOME-Autostart-enabled=false


### PR DESCRIPTION
It is easy to make guake auto start through DE settings if this file is not
installed, but it is hard to disable the auto start through DE settings if this
file is installed.

Also it is confusing to disable the autostart in GNOME. If one user uses both
GNOME and KDE, he/she probably would like to use and auto start guake
when using GNOME , or yakuake when using KDE.

Also see http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=586131
