### PR TITLE
Manage unity dock

### DIFF
--- a/src/guake
+++ b/src/guake
@@ -831,14 +831,14 @@ class Guake(SimpleGladeApp):
         # wanna use
         window_rect = screen.get_monitor_geometry(0)
         if os.environ.get('DESKTOP_SESSION')  == "ubuntu":
-            unity_hide = self.client.get_int(KEY('/apps/compiz-1/plugins/' + \
+            unity_hide = self.client.get_int(KEY('/apps/compiz-1/plugins/' \
                 'unityshell/screen0/options/launcher_hide_mode'))
             # launcher_hide_mode = 1 => autohide
             if unity_hide != 1:
                 # Size of the icons for Unity in Ubuntu <= 12.04
                 # TODO Ubuntu 12.10 use dconf :
                 # /org/compiz/profiles/unity/plugins/unityshell/icon-size
-                unity_icon_size = self.client.get_int(KEY('/apps/compiz-1/' + \
+                unity_icon_size = self.client.get_int(KEY('/apps/compiz-1/' \
                     'plugins/unityshell/screen0/options/icon_size'))
                 unity_dock = unity_icon_size + 17
                 window_rect.width = window_rect.width - unity_dock


### PR DESCRIPTION
manage unity dock for Ubuntu <= 12.04

For the moment, with unity and a single head computer, the right part of the guake terminal can't be see.

This patch try to change the guake size to manage place taken by the unity panel.

Some work must be done to manage the futur version (12.10) who use dconf (sadly I'm using this version :/).
