### PR TITLE
added support for Alt-N shortcuts for the first ten tabs

### DIFF
--- a/src/guake
+++ b/src/guake
@@ -1283,9 +1283,9 @@ class Guake(SimpleGladeApp):
             tabaccel += 1
 
     def disconnect_accels(self):
-	"""Disconnect accelerators (to be called upon deleting a tab)"""
-	for i in range(10):
-	    self.gototabgroup.disconnect_key(ord(str(i)), gtk.gdk.MOD1_MASK)
+        """Disconnect accelerators (to be called upon deleting a tab)"""
+        for i in range(10):
+            self.gototabgroup.disconnect_key(ord(str(i)), gtk.gdk.MOD1_MASK)
 
     def delete_shell(self, pid):
         """This function will kill the shell on a tab, trying to send


### PR DESCRIPTION
This patch enables Alt-N shortcuts for the first ten tabs -- Alt-1 for first tab, Alt-2 for second tab,..., Alt-0 for 10th tab -- just like in Firefox and GNOME-Terminal.
