### PR TITLE
fix mouse scroll inside less and vim

### DIFF
--- a/src/guake
+++ b/src/guake
@@ -1208,6 +1208,7 @@ class Guake(SimpleGladeApp):
                              self.on_drag_data_received,
                              box)
         box.show()
+        box.terminal.set_alternate_screen_scroll(True)
 
         self.term_list.append(box.terminal)
 


### PR DESCRIPTION
Mouse scrolling does not work inside less and vim.
This one line change fix it.
