### PR TITLE
Allow tabs to be reordered

### DIFF
--- a/src/guake
+++ b/src/guake
@@ -1237,6 +1237,11 @@ class Guake(SimpleGladeApp):
                     lambda *x: self.notebook.set_current_page(
                         self.notebook.page_num(box)
                     ))
+        drag_drop_type = ("text/plain", gtk.TARGET_SAME_APP, 80)
+        bnt.drag_dest_set(gtk.DEST_DEFAULT_ALL, [drag_drop_type], gtk.gdk.ACTION_MOVE)
+        bnt.connect("drag_data_received", self.on_drop_tab)
+        bnt.drag_source_set(gtk.gdk.BUTTON1_MASK, [drag_drop_type], gtk.gdk.ACTION_MOVE)
+        bnt.connect("drag_data_get", self.on_drag_tab)
         bnt.show()
 
         self.tabs.pack_start(bnt, expand=False, padding=1)
@@ -1245,6 +1250,21 @@ class Guake(SimpleGladeApp):
         self.notebook.set_current_page(self.notebook.page_num(box))
         box.terminal.grab_focus()
         self.load_config()
+       
+    def on_drag_tab(self, widget, context, selection, targetType, eventTime):
+        tab_pos = self.tabs.get_children().index(widget)
+        selection.set(selection.target, 32, str(tab_pos))
+       
+    def on_drop_tab(self, widget, context, x, y, selection, targetType, data):
+        old_tab_pos = int(selection.get_text())
+        new_tab_pos = self.tabs.get_children().index(widget)
+        self.move_tab(old_tab_pos, new_tab_pos)
+       
+    def move_tab(self, old_tab_pos, new_tab_pos):
+        self.notebook.reorder_child(self.notebook.get_nth_page(old_tab_pos), new_tab_pos)
+        self.pid_list.insert(new_tab_pos, self.pid_list.pop(old_tab_pos))
+        self.term_list.insert(new_tab_pos, self.term_list.pop(old_tab_pos))
+        self.tabs.reorder_child(self.tabs.get_children()[old_tab_pos], new_tab_pos)
 
     def delete_tab(self, pagepos, kill=True):
         """This function will destroy the notebook page, terminal and


### PR DESCRIPTION
This makes it possible to reorder tabs in guake by dragging them around in the tab-bar.
