### PR TITLE
Include bpython and ipython as interpreters.

### DIFF
--- a/src/prefs.py
+++ b/src/prefs.py
@@ -32,8 +32,8 @@ from guake.globals import NAME, LOCALE_DIR, GCONF_PATH, KEY, ALIGN_LEFT, ALIGN_R
 from guake.common import *
 
 # A regular expression to match possible python interpreters when
-# filling interpreters combo in preferences
-PYTHONS = re.compile('^python\d\.\d$')
+# filling interpreters combo in preferences (including bpython and ipython)
+PYTHONS = re.compile('^[a-z]python$|^python\d\.\d$')
 
 # Path to the shells file, it will be used to start to populate
 # interpreters combo, see the next variable, its important to fill the


### PR DESCRIPTION
I always run 'bpython' once I open guake.  This patch makes it possible to set that as the default interpreter so its already open when I run guake.
