### PR TITLE
Fixed issue with gap between menubar and guake window in Ubuntu 13.04

### DIFF
--- a/data/guake.glade
+++ b/data/guake.glade
@@ -9,7 +9,7 @@
     <property name="skip_pager_hint">True</property>
     <property name="urgency_hint">True</property>
     <property name="decorated">False</property>
-    <property name="gravity">static</property>
+    <property name="gravity">north</property>
     <child>
       <widget class="GtkVBox" id="mainframe">
         <property name="visible">True</property>


### PR DESCRIPTION
Something was changed in fresh Ubuntu 13.04 GTK and Guake window where showing with a gap between menu bar, see issue #93. Fixed by changing window parameters.
