### PR TITLE
Fix for compliance with Gnome 3: when hidden, loose focus (and regain it...

### DIFF
--- a/src/guake
+++ b/src/guake
@@ -792,7 +792,8 @@ class Guake(SimpleGladeApp):
         # blank screen before adding the tab.
         if not self.term_list:
             self.add_tab()
-
+        
+        self.window.set_keep_below(False)
         self.window.show_all()
         self.client.notify(KEY('/general/window_height'))
 
@@ -814,6 +815,7 @@ class Guake(SimpleGladeApp):
         """Hides the main window of the terminal and sets the visible
         flag to False.
         """
+        self.window.set_keep_below(True)
         self.window.hide() # Don't use hide_all here!
 
     def get_final_window_rect(self):


### PR DESCRIPTION
... when shown); fix inspired by https://github.com/Guake/guake/issues/89

In gnome-shell, if you hide guake, no other window will get selected. You will see that no window looks as active. You have to use the mouse or Alt-Tab.

This commit solves the issue. Outside gnome-shell, the two lines should simply do no harm (I tested a bit in gnome-fallback).
