### PR TITLE
Properly handle ctrl (primary) on ubuntu 12+

### DIFF
--- a/src/globalhotkeys/eggaccelerators.c
+++ b/src/globalhotkeys/eggaccelerators.c
@@ -177,6 +177,19 @@ is_hyper (const gchar *string)
 	  (string[6] == '>'));
 }
 
+is_primary (const gchar *string)
+{
+ return ((string[0] == '<') &&
+ (string[1] == 'p' || string[1] == 'P') &&
+ (string[2] == 'r' || string[2] == 'R') &&
+ (string[3] == 'i' || string[3] == 'I') &&
+ (string[4] == 'm' || string[4] == 'M') &&
+ (string[5] == 'a' || string[5] == 'A') &&
+ (string[6] == 'r' || string[6] == 'R') &&
+ (string[7] == 'y' || string[7] == 'Y') &&
+ (string[8] == '>'));
+}
+
 static inline gboolean
 is_keycode (const gchar *string)
 {
@@ -310,6 +323,12 @@ egg_accelerator_parse_virtual (const gchar            *accelerator,
 	      len -= 7;
 	      mods |= EGG_VIRTUAL_SUPER_MASK;
 	    }
+          else if (len >= 9 && is_primary (accelerator))
+      {
+        accelerator += 9;
+        len -= 9;
+        mods |= EGG_VIRTUAL_CONTROL_MASK;
+      }
 	  else
 	    {
 	      gchar last_ch;


### PR DESCRIPTION
Without this, keystrokes that include control tend to not fire properly.  For example, binding to ctrl+space ends up triggering on just space before this patch.

[Do ran into this as well](https://bugs.launchpad.net/do/+bug/903566)
