### PR TITLE
Add use VTE titles setting in configuration panel.

### DIFF
--- a/data/prefs.glade
+++ b/data/prefs.glade
@@ -324,6 +324,23 @@
                                   </packing>
                                 </child>
                                 <child>
+                                  <widget class="GtkCheckButton" id="use_vte_titles">
+                                    <property name="label" translatable="yes">Use virtual terminal titles</property>
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">True</property>
+                                    <property name="receives_default">False</property>
+                                    <property name="use_underline">True</property>
+                                    <property name="active">True</property>
+                                    <property name="draw_indicator">True</property>
+                                    <signal name="toggled" handler="on_use_vte_titles_toggled"/>
+                                  </widget>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">False</property>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
+                                <child>
                                   <widget class="GtkCheckButton" id="window_tabbar">
                                     <property name="label" translatable="yes">Show tab bar</property>
                                     <property name="visible">True</property>

--- a/src/guake
+++ b/src/guake
@@ -124,6 +124,7 @@ class GConfHandler(object):
         #notify_add(KEY('/general/use_login_shell'), self.login_shell_toggled)
         #notify_add(KEY('/general/use_popup'), self.popup_toggled)
         #notify_add(KEY('/general/window_losefocus'), self.losefocus_toggled)
+        #notify_add(KEY('/general/use_vte_titles'), self.use_vte_titles_changed)
 
         notify_add(KEY('/general/show_resizer'), self.show_resizer_toggled)
 

--- a/src/prefs.py
+++ b/src/prefs.py
@@ -167,6 +167,11 @@ class PrefsCallbacks(object):
         """
         self.client.set_bool(KEY('/general/window_losefocus'), chk.get_active())
 
+    def on_use_vte_titles_toggled(self, chk):
+        """Changes the activity of use_vte_titles in gconf
+        """
+        self.client.set_bool(KEY('/general/use_vte_titles'), chk.get_active())
+
     def on_window_tabbar_toggled(self, chk):
         """Changes the activity of window_tabbar in gconf
         """
@@ -478,6 +483,10 @@ class PrefsDialog(SimpleGladeApp):
         # losefocus
         value = self.client.get_bool(KEY('/general/window_losefocus'))
         self.get_widget('window_losefocus').set_active(value)
+
+        # use VTE titles
+        value = self.client.get_bool(KEY('/general/use_vte_titles'))
+        self.get_widget('use_vte_titles').set_active(value)
 
         # tabbar
         value = self.client.get_bool(KEY('/general/window_tabbar'))


### PR DESCRIPTION
I wanted to have the setting use VTE title accessible with the settings and not hided inside the gconf-editor tool.
