### PR TITLE
Fixed D-Bus method get_tab_name which could return illegal NoneType value instead of string

### DIFF
--- a/src/dbusiface.py
+++ b/src/dbusiface.py
@@ -70,7 +70,7 @@ class DbusManager(dbus.service.Object):
 
     @dbus.service.method(DBUS_NAME, in_signature='i', out_signature='s')
     def get_tab_name(self, tab_index=0):
-        return self.guake.term_list[int(tab_index)].get_window_title()
+        return self.guake.term_list[int(tab_index)].get_window_title() or ''
 
     @dbus.service.method(DBUS_NAME, in_signature='s')
     def rename_current_tab(self, new_text):


### PR DESCRIPTION
When you first create a new tab in Guake, the `get_window_title()` method may return `None` while it is still loading a bash shell -- after which it works as expected and returns the string tab name.

Therefore, in the intervening period after creating a new terminal tab and before the tab finishes loading, this exception is raised in the D-Bus service after our dbusiface.py passes a `NoneType` instead of a string:

```
Gio.IOErrorEnum: GDBus.Error:org.freedesktop.DBus.Python.TypeError: Traceback (most recent call last):
  File /usr/lib/python2.7/dist-packages/dbus/service.py, line 751, in _message_cb
    _method_reply_return(connection, message, method_name, signature, *retval)
  File /usr/lib/python2.7/dist-packages/dbus/service.py, line 254, in _method_reply_return
    reply.append(signature=signature, *retval)
TypeError: Expected a string or unicode object
```

This pull request merely returns an empty string `''` if it receives a `NoneType` from `get_window_title()`.
