### PR TITLE
[FIXED] Terminal appears on wrong monitor if primary screen is right of secondary one Ticket #177

### DIFF
--- a/src/guake
+++ b/src/guake
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8; -*-
 """
 Copyright (C) 2007-2012 Lincoln de Sousa <lincoln@minaslivre.org>


### PR DESCRIPTION
#177

Terminal appears on wrong monitor if primary screen is right of secondary one
Applied this patch:
http://guake.org/attachment/ticket/201/0002-make-guake-appear-on-primary-screen.patch

works fine with dual monitor, one 1600x900 another one 1366x738. which primary monitor you choose, guake show on that one!
