### PR TITLE
Do not crash if no notifications daemon is running (fix Debian bug #6822...

### DIFF
--- a/src/guake
+++ b/src/guake
@@ -23,6 +23,7 @@ from __future__ import absolute_import
 
 import pygtk
 import gobject
+import glib
 pygtk.require('2.0')
 gobject.threads_init()
 
@@ -649,7 +650,7 @@ class Guake(SimpleGladeApp):
                   'Please use Guake Preferences dialog to choose another '
                   'key (The trayicon was enabled)') % label, filename)
             self.client.set_bool(KEY('/general/use_trayicon'), True)
-            notification.show()
+            self.notify(notification)
 
         elif self.client.get_bool(KEY('/general/use_popup')):
             # Pop-up that shows that guake is working properly (if not
@@ -658,7 +659,16 @@ class Guake(SimpleGladeApp):
                 _('Guake!'),
                 _('Guake is now running,\n'
                   'press <b>%s</b> to use it.') % label, filename)
+            self.notify(notification)
+
+    def notify(self, notification):
+        try:
             notification.show()
+        except glib.GError:
+            # Notifications daemon not (still?) running. This is fine, for
+            # instance if guake always starts automatically with the
+            # session, the notification is not particularly useful.
+            pass
 
     def execute_command(self, command, tab=None):
         """Execute the `command' in the `tab'. If tab is None, the


### PR DESCRIPTION
Solve Debian bug #682271:
http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=682271

That bug is a problem for two kinds of users:
1) those who don't run a notifications daemon (including me some of the times that I happen to restart a gnome-shell session without restarting the system),
2) those who automatically start guake at the start of the session, when the daemon is not ready.

In those cases, the notification is not produced. I don't really think that's a problem, actually - useless notifications appearing when you login are not something particularly nice.
