### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -97,12 +97,12 @@ default sysconfdir is different from the one chosen by autotools. To
 fix that, you probably have to append the param `--sysconfdir=/etc' to
 your `./configure' call, like this::
 
-    $ ./configure --sysconfidir=/etc && make
+    $ ./configure --sysconfdir=/etc && make
 
-If it is not enought you can call, you can install the gconf schemas
-file by hand doing the following::
+If it is not enought you can install the gconf schemas
+file by hand by doing the following::
 
-    # gconftool-2 --makefile-install-rule data/guake.schemas
+    # GCONF_CONFIG_SOURCE="" gconftool-2 --makefile-install-rule data/guake.schemas
 
 For more install details, please read the `INSTALL` file.
 


### PR DESCRIPTION
-  The `./configure` line telling you to pass `--sysconfdir` contained a typo.
-  The `gconftool-2` line to install the `guake.schemas` did not work, because `--makefile-install-rule` expects you to set the `GCONF_CONFIG_SOURCE`. The man page says:
  
  > Properly  installs  schema  files  on  the command line into the database. GCONF_CONFIG_SOURCE environment variable should be set to a non-default config source or set to the empty string to use the default.
