### PR TITLE
Quick Open breaks opening URL with port number

### DIFF
--- a/src/guake
+++ b/src/guake
@@ -588,7 +588,7 @@ class GuakeTerminal(vte.Terminal):
                         if not os.path.exists(filepath):
                             logging.info("Cannot open file %s, it doesn't exists (current dir: %s)", filepath,
                                          os.path.curdir)
-                            return
+                            continue
                         logging.debug("Opening file %s at line %s", filepath, line_number)
                         resolved_cmdline = cmdline % {"file_path": filepath, "line_number": line_number}
                         logging.debug("Command line: %s", resolved_cmdline)


### PR DESCRIPTION
When Quick Open is enabled, the regex `^(.*)\:([0-9]+)` also matches URLs with a port number (like `http://127.0.0.1:5000/`). guake would then only log an info level message (which is not visible by default) and not try to open the URL as an URL.
