### PR TITLE
Added XML escaping for key combinations shown in GTK dialogs.

### DIFF
--- a/src/guake
+++ b/src/guake
@@ -47,6 +47,7 @@ from urllib import quote_plus
 from urllib import url2pathname
 from urlparse import urlsplit
 from xdg.DesktopEntry import DesktopEntry
+from xml.sax.saxutils import escape as xml_escape
 
 import guake.globalhotkeys
 import guake.notifier
@@ -410,7 +411,7 @@ class GConfKeyHandler(object):
         key = entry.get_value().get_string()
         if not self.guake.hotkeys.bind(key, self.guake.show_hide):
             raise ShowableError(_('key binding error'),
-                                _('Unable to bind global <b>%s</b> key') % key,
+                                _('Unable to bind global <b>%s</b> key') % xml_escape(key),
                                 -1)
 
     def reload_accelerators(self, *args):
@@ -816,7 +817,7 @@ class Guake(SimpleGladeApp):
                 _('Guake!'),
                 _('A problem happened when binding <b>%s</b> key.\n'
                   'Please use Guake Preferences dialog to choose another '
-                  'key') % label, filename)
+                  'key') % xml_escape(label), filename)
             self.client.set_bool(KEY('/general/use_trayicon'), True)
 
         elif self.client.get_bool(KEY('/general/use_popup')):
@@ -825,7 +826,7 @@ class Guake(SimpleGladeApp):
             guake.notifier.show_message(
                 _('Guake!'),
                 _('Guake is now running,\n'
-                  'press <b>%s</b> to use it.') % label, filename)
+                  'press <b>%s</b> to use it.') % xml_escape(label), filename)
 
     def set_background_transparency(self, transparency):
         for i in self.term_list:


### PR DESCRIPTION
Hi devs-

I ran into this bug --- https://bugs.launchpad.net/ubuntu/+source/guake/+bug/1018643 --- and spent a little while investigating it.  Essentially, some users (including me) are having global-keyboard-shortcut conflicts when they try to customize the show/hide shortcut in Guake.  That's not Guake's problem (though it'd be great, as a future feature request, to provide the user with some feedback about what other shortcut, set elsewhere, is causing the problem).  However, in the dialog box that Guake attempts to create, if the shortcut uses the "Super" key, GTK throws a fit and the dialog box comes out mangled.

The issue is that GTK uses HTML syntax to format body text in dialog boxes, and the string "less-than Super greater-than" breaks its HTML parser.  The solution is to XML-escape the name of the keyboard combination, which is what I've done in this pull request.  I tried to make my changes very narrow, so I hope this would be an easy merge.

Thanks for working on such a useful tool!

-Jadrian
