### PR TITLE
fix: Install to /usr instead of /usr/local

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -85,6 +85,8 @@ ALL_LINGUAS="ca cs_CZ de el es fa fr gl hr hu id it ja nb_NO nl pa pl pt_BR ru s
 AC_SUBST([GETTEXT_PACKAGE])
 AC_SUBST([ALL_LINGUAS])
 
+AC_PREFIX_DEFAULT(/usr)
+
 dnl output files
 AC_CONFIG_FILES([
     Makefile

--- a/m4/acinclude.m4
+++ b/m4/acinclude.m4
@@ -13,7 +13,7 @@ AC_DEFUN([AS_AC_EXPAND],
   prefix_save=$prefix
   exec_prefix_save=$exec_prefix
 
-  dnl if no prefix given, then use /usr/local, the default prefix
+  dnl if no prefix given, then use /usr, the default prefix
   if test "x$prefix" = "xNONE"; then
     prefix=$ac_default_prefix
   fi


### PR DESCRIPTION
- Changed the default install path to /usr by hardcoding
  ac_default_prefix

Signed-off-by: mr.Shu mr@shu.io
