### PR TITLE
Kill signal update

### DIFF
--- a/src/guake
+++ b/src/guake
@@ -1697,7 +1697,7 @@ class Guake(SimpleGladeApp):
         UI, so you can use python's start_new_thread.
         """
         try:
-            os.kill(pid, signal.SIGTERM)
+            os.kill(pid, signal.SIGHUP)
         except OSError:
             pass
         num_tries = 30


### PR DESCRIPTION
Uses SIGHUP instead of SIGTERM in delete_shell.
Fixes #353
