### PR TITLE
Fix #349. Now the command "wall" work properly.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,6 +80,7 @@ For compiling from these sources, please install the following packages (Ubuntu 
     sudo apt-get install python-gtk2 python-gtk2-dev python-vte glade python-glade2 python-appindicator
     sudo apt-get install python-vte
     sudo apt-get install notify-osd
+    sudo apt-get install libutempter
     # uncomment for Python 3
     # sudo apt-get install python3-dev
     # uncomment for glade Gtk-2 editor

--- a/src/guake.py
+++ b/src/guake.py
@@ -78,19 +78,19 @@ from guake.prefs import LKEY
 from guake.prefs import PrefsDialog
 from guake.simplegladeapp import SimpleGladeApp
 from guake.simplegladeapp import bindtextdomain
-libutempter = None;
+libutempter = None
 try:
-    from atexit import register as at_exit_call;
-    from ctypes import cdll;
-    libutempter = cdll.LoadLibrary('libutempter.so.0');
+    from atexit import register as at_exit_call
+    from ctypes import cdll
+    libutempter = cdll.LoadLibrary('libutempter.so.0')
     if libutempter is not None:
         # We absolutly need to remove the old tty from the utmp !!!!!!!!!!
-        at_exit_call(libutempter.utempter_remove_added_record);
+        at_exit_call(libutempter.utempter_remove_added_record)
 except Exception as e:
-    libutempter = None;
-    sys.stderr.write('[WARN] Unable to load the library libutempter !\n');
-    sys.stderr.write('[WARN] The <wall> command will not work in guake !\n');
-    sys.stderr.write('[WARN] '+str(e)+'\n');
+    libutempter = None
+    sys.stderr.write('[WARN] Unable to load the library libutempter !\n')
+    sys.stderr.write('[WARN] The <wall> command will not work in guake !\n')
+    sys.stderr.write('[WARN] ' + str(e) + '\n')
 
 GCONF_MONOSPACE_FONT_PATH = '/desktop/gnome/interface/monospace_font_name'
 DCONF_MONOSPACE_FONT_PATH = 'org.gnome.desktop.interface'
@@ -1464,7 +1464,7 @@ class Guake(SimpleGladeApp):
         `delete_tab' method to do the work.
         """
         if libutempter is not None:
-            libutempter.utempter_remove_record(term.get_pty());
+            libutempter.utempter_remove_record(term.get_pty())
         self.delete_tab(self.notebook.page_num(widget), kill=False)
 
     def on_terminal_title_changed(self, vte, box):
@@ -1718,7 +1718,7 @@ class Guake(SimpleGladeApp):
         pid = box.terminal.fork_command(**final_params)
         if libutempter is not None:
             # After the fork_command we add this new tty to utmp !
-            libutempter.utempter_add_record(box.terminal.get_pty(), os.uname()[1]);
+            libutempter.utempter_add_record(box.terminal.get_pty(), os.uname()[1])
         box.terminal.pid = pid
         self.pid_list.append(pid)
 


### PR DESCRIPTION
The bug comes from a poor implementation of VTE in GTK2.
This bug does not exist in GTK3.

Guake now has a dependency on the library libutempter.
