### PR TITLE
fix non-pep8-compliant spacing.  Followup to #434

### DIFF
--- a/src/guake/prefs.py
+++ b/src/guake/prefs.py
@@ -317,13 +317,13 @@ class PrefsCallbacks(object):
             }
             self.client.set_int(KEY('/general/window_halignment'),
                                 which_align[halign_button.get_name()])
-    
-    def on_use_visible_bell_toggled(self,chk):
+
+    def on_use_visible_bell_toggled(self, chk):
         """Changes the value of use_visible_bell in gconf
         """
         self.client.set_bool(KEY('/general/use_visible_bell'), chk.get_active())
-        
-    def on_use_audible_bell_toggled(self,chk):
+
+    def on_use_audible_bell_toggled(self, chk):
         """Changes the value of use_audible_bell in gconf
         """
         self.client.set_bool(KEY('/general/use_audible_bell'), chk.get_active())
@@ -673,7 +673,7 @@ class PrefsDialog(SimpleGladeApp):
         # start fullscreen
         value = self.client.get_bool(KEY('/general/start_fullscreen'))
         self.get_widget('start_fullscreen').set_active(value)
-        
+
         # use visible bell
         value = self.client.get_bool(KEY('/general/use_visible_bell'))
         self.get_widget('use_visible_bell').set_active(value)


### PR DESCRIPTION
My previous pull request (#434) causes a Travis CI build failure due to non-pep8 compliant spacing in src/guake/prefs.py.  This pull request fixes that.  Passes ./valdate.py.

Sorry about that.

Steve