### PR TITLE
Fix for toolbar visibility in full screen mode.

### DIFF
--- a/src/guake/guake_app.py
+++ b/src/guake/guake_app.py
@@ -904,7 +904,7 @@ class Guake(SimpleGladeApp):
         # fullscreen mode, but tabbar will only be shown if a
         # hidden gconf key is false.
         self.resizer.hide()
-        if not self.client.get_bool(KEY('general/toolbar_visible_in_fullscreen')):
+        if not self.client.get_bool(KEY('/general/toolbar_visible_in_fullscreen')):
             self.toolbar.hide()
 
     def unfullscreen(self):


### PR DESCRIPTION
Basically there is a typo for gconf key reference where '/' is missing at the beginning.