### PR TITLE
Fixing problems with pasting from clipboard after tabs reorder

### DIFF
--- a/src/guake/guake_notebook.py
+++ b/src/guake/guake_notebook.py
@@ -24,6 +24,14 @@ class GuakeNotebook(Notebook):
         # used to kill the process when closing a tab
         self.pid_list = []
 
+    def reorder_child(self, child, position):
+        """ We should also reorder elements in term_list
+        """
+        old_pos = self.get_children().index(child)
+        terms = self.term_list
+        terms[old_pos], terms[position] = terms[position], terms[old_pos]
+        super(GuakeNotebook, self).reorder_child(child, position)
+
     def has_term(self):
         return self.term_list
 


### PR DESCRIPTION
Open Guake with 2 tabs. Paste some text in theese terminals, everything is ok.
Swap them. Now when you try to paste text in the first tab, it will be pasted in the second tab.

This is because we don't change order of GuakeNotebook's term_list when the order of GuakeNotebook's pages changes. When we paste something, accel_paste_clipboard() method calls (guake_app.py), it detects terminal in GuakeNotebook by the **index of the current page**.

I redefined reorder_child() method of GuakeNotebook. So when you reorder pages in GuakeNotebook, terminals will reorder automatically.