### PR TITLE
Add missing dependency (python-notify) to dev.sh

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -86,6 +86,7 @@ For compiling from these sources, please install the following packages (Ubuntu 
     sudo apt-get install python-vte python-gconf
     sudo apt-get install notify-osd
     sudo apt-get install libutempter0
+    sudo apt-get install python-notify
     # uncomment for Python 3
     # sudo apt-get install python3-dev
     # uncomment for glade Gtk-2 editor

--- a/dev.sh
+++ b/dev.sh
@@ -35,6 +35,7 @@ if [[ $EXEC_AUTOGEN == true ]]; then
     sudo apt-get install -y python-gtk2 python-gtk2-dev python-vte glade python-glade2
     sudo apt-get install -y python-vte python-gconf python-appindicator
     sudo apt-get install -y notify-osd libutempter0 glade-gtk2
+    sudo apt-get install -y python-notify
     if [[ -f Makefile ]]; then
         make clean
     fi


### PR DESCRIPTION
I installed Ubuntu GNOME 15.04 32-bit in a virtual machine, cloned the guake project and ran `dev.sh` script. However, it failed when it tried to launch guake due to `python-notify` not being installed.

It is correctly listed as a dependency on <http://packages.ubuntu.com/vivid/guake> though, so installing guake with apt would bring in the dependency.