### PR TITLE
changed guake glade file with horizontal scroll bar

### DIFF
--- a/data/guake.glade
+++ b/data/guake.glade
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glade-interface>
-  <!-- interface-requires gtk+ 2.10 -->
+  <!-- interface-requires gtk+ 2.16 -->
   <!-- interface-naming-policy project-wide -->
   <widget class="GtkMenu" id="context-menu">
     <property name="visible">True</property>
@@ -13,7 +13,7 @@
         <property name="can_focus">False</property>
         <property name="use_action_appearance">False</property>
         <property name="use_stock">False</property>
-        <signal name="activate" handler="accel_copy_clipboard"/>
+        <signal name="activate" handler="accel_copy_clipboard" swapped="no"/>
         <child internal-child="image">
           <widget class="GtkImage" id="copy_icon">
             <property name="visible">True</property>
@@ -31,7 +31,7 @@
         <property name="can_focus">False</property>
         <property name="use_action_appearance">False</property>
         <property name="use_stock">False</property>
-        <signal name="activate" handler="accel_paste_clipboard"/>
+        <signal name="activate" handler="accel_paste_clipboard" swapped="no"/>
         <child internal-child="image">
           <widget class="GtkImage" id="paste_icon">
             <property name="visible">True</property>
@@ -55,7 +55,7 @@
         <property name="can_focus">False</property>
         <property name="use_action_appearance">False</property>
         <property name="use_stock">False</property>
-        <signal name="activate" handler="accel_toggle_fullscreen"/>
+        <signal name="activate" handler="accel_toggle_fullscreen" swapped="no"/>
         <child internal-child="image">
           <widget class="GtkImage" id="toggle_fullscreen_icon">
             <property name="visible">True</property>
@@ -79,7 +79,7 @@
         <property name="can_focus">False</property>
         <property name="use_action_appearance">False</property>
         <property name="use_stock">False</property>
-        <signal name="activate" handler="save_tab"/>
+        <signal name="activate" handler="save_tab" swapped="no"/>
         <child internal-child="image">
           <widget class="GtkImage" id="save_tab_icon">
             <property name="visible">True</property>
@@ -97,7 +97,7 @@
         <property name="can_focus">False</property>
         <property name="use_action_appearance">False</property>
         <property name="use_stock">False</property>
-        <signal name="activate" handler="find_tab"/>
+        <signal name="activate" handler="find_tab" swapped="no"/>
         <child internal-child="image">
           <widget class="GtkImage" id="find_tab_icon">
             <property name="visible">True</property>
@@ -121,7 +121,7 @@
         <property name="can_focus">False</property>
         <property name="use_action_appearance">False</property>
         <property name="use_stock">False</property>
-        <signal name="activate" handler="add_tab"/>
+        <signal name="activate" handler="add_tab" swapped="no"/>
         <child internal-child="image">
           <widget class="GtkImage" id="add_tab_icon">
             <property name="visible">True</property>
@@ -139,7 +139,7 @@
         <property name="can_focus">False</property>
         <property name="use_action_appearance">False</property>
         <property name="use_stock">False</property>
-        <signal name="activate" handler="accel_rename_current_tab"/>
+        <signal name="activate" handler="accel_rename_current_tab" swapped="no"/>
         <child internal-child="image">
           <widget class="GtkImage" id="tab_rename_icon">
             <property name="visible">True</property>
@@ -157,7 +157,7 @@
         <property name="can_focus">False</property>
         <property name="use_action_appearance">False</property>
         <property name="use_stock">False</property>
-        <signal name="activate" handler="close_tab"/>
+        <signal name="activate" handler="close_tab" swapped="no"/>
         <child internal-child="image">
           <widget class="GtkImage" id="close_tab_icon">
             <property name="visible">True</property>
@@ -181,7 +181,7 @@
         <property name="can_focus">False</property>
         <property name="use_action_appearance">False</property>
         <property name="use_stock">False</property>
-        <signal name="activate" handler="browse_on_web"/>
+        <signal name="activate" handler="browse_on_web" swapped="no"/>
         <child internal-child="image">
           <widget class="GtkImage" id="browse_on_web_icon">
             <property name="visible">True</property>
@@ -199,7 +199,7 @@
         <property name="can_focus">False</property>
         <property name="use_action_appearance">False</property>
         <property name="use_stock">False</property>
-        <signal name="activate" handler="search_on_web"/>
+        <signal name="activate" handler="search_on_web" swapped="no"/>
         <child internal-child="image">
           <widget class="GtkImage" id="search_on_web_icon">
             <property name="visible">True</property>
@@ -224,7 +224,7 @@
         <property name="use_action_appearance">False</property>
         <property name="use_underline">True</property>
         <property name="use_stock">True</property>
-        <signal name="activate" handler="show_prefs"/>
+        <signal name="activate" handler="show_prefs" swapped="no"/>
       </widget>
     </child>
     <child>
@@ -235,7 +235,7 @@
         <property name="use_action_appearance">False</property>
         <property name="use_underline">True</property>
         <property name="use_stock">True</property>
-        <signal name="activate" handler="show_about"/>
+        <signal name="activate" handler="show_about" swapped="no"/>
       </widget>
     </child>
     <child>
@@ -251,7 +251,7 @@
         <property name="can_focus">False</property>
         <property name="use_action_appearance">False</property>
         <property name="use_stock">False</property>
-        <signal name="activate" handler="accel_quit"/>
+        <signal name="activate" handler="accel_quit" swapped="no"/>
         <child internal-child="image">
           <widget class="GtkImage" id="close_icon">
             <property name="visible">True</property>
@@ -273,7 +273,7 @@
         <property name="can_focus">False</property>
         <property name="use_action_appearance">False</property>
         <property name="use_stock">False</property>
-        <signal name="activate" handler="add_tab"/>
+        <signal name="activate" handler="add_tab" swapped="no"/>
         <child internal-child="image">
           <widget class="GtkImage" id="tab_add_icon">
             <property name="visible">True</property>
@@ -291,9 +291,9 @@
         <property name="can_focus">False</property>
         <property name="use_action_appearance">False</property>
         <property name="use_stock">False</property>
-        <signal name="activate" handler="on_rename_current_tab_activate"/>
+        <signal name="activate" handler="on_rename_current_tab_activate" swapped="no"/>
         <child internal-child="image">
-          <widget class="GtkImage" id="tab_rename_icon">
+          <widget class="GtkImage" id="tab_rename_icon1">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="stock">gtk-edit</property>
@@ -309,7 +309,7 @@
         <property name="can_focus">False</property>
         <property name="use_action_appearance">False</property>
         <property name="use_stock">False</property>
-        <signal name="activate" handler="on_close_activate"/>
+        <signal name="activate" handler="on_close_activate" swapped="no"/>
         <child internal-child="image">
           <widget class="GtkImage" id="tab_close_icon">
             <property name="visible">True</property>
@@ -332,7 +332,7 @@
         <property name="use_action_appearance">False</property>
         <property name="use_underline">True</property>
         <property name="use_stock">True</property>
-        <signal name="activate" handler="show_prefs"/>
+        <signal name="activate" handler="show_prefs" swapped="no"/>
       </widget>
     </child>
     <child>
@@ -343,7 +343,7 @@
         <property name="use_action_appearance">False</property>
         <property name="use_underline">True</property>
         <property name="use_stock">True</property>
-        <signal name="activate" handler="show_about"/>
+        <signal name="activate" handler="show_about" swapped="no"/>
       </widget>
     </child>
     <child>
@@ -359,7 +359,7 @@
         <property name="can_focus">False</property>
         <property name="use_action_appearance">False</property>
         <property name="use_stock">False</property>
-        <signal name="activate" handler="accel_quit"/>
+        <signal name="activate" handler="accel_quit" swapped="no"/>
         <child internal-child="image">
           <widget class="GtkImage" id="tray_quit_icon">
             <property name="visible">True</property>
@@ -394,7 +394,7 @@
             <property name="show_tabs">False</property>
             <property name="show_border">False</property>
             <property name="enable_popup">True</property>
-            <signal name="switch_page" handler="select_current_tab"/>
+            <signal name="switch_page" handler="select_current_tab" swapped="no"/>
           </widget>
           <packing>
             <property name="expand">True</property>
@@ -423,14 +423,38 @@
               </packing>
             </child>
             <child>
-              <widget class="GtkEventBox" id="event-tabs">
+              <widget class="GtkScrolledWindow" id="tabs-scrolledwindow">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="events">GDK_BUTTON_PRESS_MASK | GDK_STRUCTURE_MASK</property>
+                <property name="can_focus">True</property>
+                <property name="hscrollbar_policy">automatic</property>
+                <property name="vscrollbar_policy">never</property>
                 <child>
-                  <widget class="GtkHBox" id="hbox-tabs">
+                  <widget class="GtkViewport" id="tabs-viewport">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
+                    <property name="shadow_type">none</property>
+                    <child>
+                      <widget class="GtkEventBox" id="event-tabs">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="events">GDK_BUTTON_PRESS_MASK | GDK_STRUCTURE_MASK</property>
+                        <child>
+                          <widget class="GtkHBox" id="hbox-tabs">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                          </widget>
+                        </child>
+                      </widget>
+                    </child>
                   </widget>
                 </child>
               </widget>
@@ -448,7 +472,7 @@
                 <property name="tooltip" translatable="yes">Add a new tab</property>
                 <property name="use_action_appearance">False</property>
                 <property name="relief">none</property>
-                <signal name="clicked" handler="add_tab"/>
+                <signal name="clicked" handler="add_tab" swapped="no"/>
                 <child>
                   <widget class="GtkImage" id="image2">
                     <property name="visible">True</property>


### PR DESCRIPTION
Dear guake mantainer,
I would like you to give a look to my data/guake.glade file.
I't almost identical to the original except that a horizontal scroll bar is shown when the tabs go out of the screen. This could be useful if someone like me opens a lot of tabs with long tab names on small screen horizontal resolutions (my monitor is 4:3), in this case you can't select the hidden out-of-screen tabs with your mouse but you are forced to use keyboard shortcuts.
I use this glade file on my pc and i had no problems so far.
I changed the gtk requirements because glade gave me the error at the bottom of this email.
I hope you find my glade file valuable and worth enough to be included in the next guake release.
I am willing to give you further details if something is not clear, just contact me by email or github.

[tray-menu:about-menuitem] Property 'Use Action Appearance' of object class 'Image Menu Item' was introduced in gtk+ 2.16
[tab-menu:add] Property 'Use Action Appearance' of object class 'Image Menu Item' was introduced in gtk+ 2.16
[window-root:mainframe:toolbar:button1] Property 'Use Action Appearance' of object class 'Button' was introduced in gtk+ 2.16
[tab-menu:close] Property 'Use Action Appearance' of object class 'Image Menu Item' was introduced in gtk+ 2.16
[context-menu:context_about] Property 'Use Action Appearance' of object class 'Image Menu Item' was introduced in gtk+ 2.16
[context-menu:context_add_tab] Property 'Use Action Appearance' of object class 'Image Menu Item' was introduced in gtk+ 2.16
[context-menu:context_browse_on_web] Property 'Use Action Appearance' of object class 'Image Menu Item' was introduced in gtk+ 2.16
[context-menu:context_close] Property 'Use Action Appearance' of object class 'Image Menu Item' was introduced in gtk+ 2.16
[context-menu:context_close_tab] Property 'Use Action Appearance' of object class 'Image Menu Item' was introduced in gtk+ 2.16
[context-menu:context_copy] Property 'Use Action Appearance' of object class 'Image Menu Item' was introduced in gtk+ 2.16
[context-menu:context_find_tab] Property 'Use Action Appearance' of object class 'Image Menu Item' was introduced in gtk+ 2.16
[context-menu:context_paste] Property 'Use Action Appearance' of object class 'Image Menu Item' was introduced in gtk+ 2.16
[context-menu:context_preferences] Property 'Use Action Appearance' of object class 'Image Menu Item' was introduced in gtk+ 2.16
[context-menu:context_rename_tab] Property 'Use Action Appearance' of object class 'Image Menu Item' was introduced in gtk+ 2.16
[context-menu:context_save_tab] Property 'Use Action Appearance' of object class 'Image Menu Item' was introduced in gtk+ 2.16
[context-menu:context_search_on_web] Property 'Use Action Appearance' of object class 'Image Menu Item' was introduced in gtk+ 2.16
[context-menu:context_toggle_fullscreen] Property 'Use Action Appearance' of object class 'Image Menu Item' was introduced in gtk+ 2.16
[tray-menu:prefs-menuitem] Property 'Use Action Appearance' of object class 'Image Menu Item' was introduced in gtk+ 2.16
[tray-menu:quit-menuitem] Property 'Use Action Appearance' of object class 'Image Menu Item' was introduced in gtk+ 2.16
[tab-menu:rename] Property 'Use Action Appearance' of object class 'Image Menu Item' was introduced in gtk+ 2.16