### PR TITLE
prompt_on_close_tab option

### DIFF
--- a/data/guake.schemas
+++ b/data/guake.schemas
@@ -88,9 +88,21 @@
             <type>bool</type>
             <default>true</default>
             <locale name="C">
-                <short>Prompt when quiting.</short>
-                <long>Ask for confirmation when guiting Guake and there
-                processes running.</long>
+                <short>Prompt when quitting.</short>
+                <long>Ask for confirmation when quitting Guake.</long>
+            </locale>
+        </schema>
+
+        <schema>
+            <key>/schemas/apps/guake/general/prompt_on_close_tab</key>
+            <applyto>/apps/guake/general/prompt_on_close_Tab</applyto>
+            <owner>guake</owner>
+            <type>int</type>
+            <default>0</default>
+            <locale name="C">
+                <short>Prompt when closing tabs.</short>
+                <long>0: Never 1: If process is running 2: Always. 
+                Also prompts on quit.</long>
             </locale>
         </schema>
 

--- a/data/prefs.glade
+++ b/data/prefs.glade
@@ -184,13 +184,12 @@ guake -r "prod" -e "cd ~/projects/myproject/prod"
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">False</property>
                                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                        <property name="use_action_appearance">False</property>
                                         <property name="draw_indicator">True</property>
                                         <signal name="toggled" handler="on_use_popup_toggled" swapped="no"/>
                                       </widget>
                                       <packing>
-                                        <property name="left_attach">1</property>
-                                        <property name="right_attach">2</property>
+                                        <property name="top_attach">3</property>
+                                        <property name="bottom_attach">4</property>
                                       </packing>
                                     </child>
                                     <child>
@@ -200,25 +199,26 @@ guake -r "prod" -e "cd ~/projects/myproject/prod"
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">False</property>
                                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                        <property name="use_action_appearance">False</property>
                                         <property name="draw_indicator">True</property>
                                         <signal name="toggled" handler="on_use_trayicon_toggled" swapped="no"/>
                                       </widget>
                                     </child>
                                     <child>
                                       <widget class="GtkCheckButton" id="prompt_on_quit">
-                                        <property name="label" translatable="yes">Prompt on quit</property>
+                                        <property name="label" translatable="yes">Always prompt on quit</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">False</property>
                                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                        <property name="use_action_appearance">False</property>
                                         <property name="draw_indicator">True</property>
                                         <signal name="toggled" handler="on_prompt_on_quit_toggled" swapped="no"/>
                                       </widget>
                                       <packing>
+                                        <property name="left_attach">1</property>
+                                        <property name="right_attach">2</property>
                                         <property name="top_attach">1</property>
                                         <property name="bottom_attach">2</property>
+                                        <property name="x_padding">15</property>
                                       </packing>
                                     </child>
                                     <child>
@@ -228,14 +228,13 @@ guake -r "prod" -e "cd ~/projects/myproject/prod"
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">False</property>
                                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                        <property name="use_action_appearance">False</property>
                                         <property name="use_underline">True</property>
                                         <property name="draw_indicator">True</property>
                                         <signal name="toggled" handler="on_use_visible_bell_toggled" swapped="no"/>
                                       </widget>
                                       <packing>
-                                        <property name="top_attach">2</property>
-                                        <property name="bottom_attach">3</property>
+                                        <property name="top_attach">1</property>
+                                        <property name="bottom_attach">2</property>
                                       </packing>
                                     </child>
                                     <child>
@@ -245,16 +244,13 @@ guake -r "prod" -e "cd ~/projects/myproject/prod"
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">False</property>
                                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                        <property name="use_action_appearance">False</property>
                                         <property name="use_underline">True</property>
                                         <property name="draw_indicator">True</property>
                                         <signal name="toggled" handler="on_use_audible_bell_toggled" swapped="no"/>
                                       </widget>
                                       <packing>
-                                        <property name="left_attach">1</property>
-                                        <property name="right_attach">2</property>
-                                        <property name="top_attach">1</property>
-                                        <property name="bottom_attach">2</property>
+                                        <property name="top_attach">2</property>
+                                        <property name="bottom_attach">3</property>
                                       </packing>
                                     </child>
                                     <child>
@@ -275,7 +271,54 @@ guake -r "prod" -e "cd ~/projects/myproject/prod"
                                       </packing>
                                     </child>
                                     <child>
-                                      <placeholder/>
+                                      <widget class="GtkHBox" id="hbox1">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <child>
+                                          <widget class="GtkLabel" id="lbl_prompt_on_close_tab">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="label" translatable="yes">Prompt on close tab:</property>
+                                          </widget>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">False</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <widget class="GtkLabel" id="space_label2">
+                                            <property name="width_request">10</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                          </widget>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">False</property>
+                                            <property name="position">1</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <widget class="GtkComboBox" id="prompt_on_close_tab">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="items" translatable="yes">Never
+With process running
+Always</property>
+                                            <signal name="changed" handler="on_prompt_on_close_tab_changed" swapped="no"/>
+                                            <signal name="changed" handler="toggle_prompt_on_quit_sensitivity" swapped="no"/>
+                                          </widget>
+                                          <packing>
+                                            <property name="expand">True</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">2</property>
+                                          </packing>
+                                        </child>
+                                      </widget>
+                                      <packing>
+                                        <property name="left_attach">1</property>
+                                        <property name="right_attach">2</property>
+                                      </packing>
                                     </child>
                                   </widget>
                                   <packing>
@@ -334,7 +377,6 @@ guake -r "prod" -e "cd ~/projects/myproject/prod"
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">False</property>
-                                        <property name="use_action_appearance">False</property>
                                         <property name="draw_indicator">True</property>
                                         <signal name="toggled" handler="on_bottom_align_toggled" swapped="no"/>
                                       </widget>
@@ -350,7 +392,6 @@ guake -r "prod" -e "cd ~/projects/myproject/prod"
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">False</property>
-                                        <property name="use_action_appearance">False</property>
                                         <property name="draw_indicator">True</property>
                                         <signal name="toggled" handler="on_mouse_display_toggled" swapped="no"/>
                                         <signal name="toggled" handler="toggle_display_n_sensitivity" swapped="no"/>
@@ -408,7 +449,6 @@ guake -r "prod" -e "cd ~/projects/myproject/prod"
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">False</property>
-                                        <property name="use_action_appearance">False</property>
                                         <property name="draw_indicator">True</property>
                                         <signal name="toggled" handler="on_tab_ontop_toggled" swapped="no"/>
                                       </widget>
@@ -462,7 +502,6 @@ guake -r "prod" -e "cd ~/projects/myproject/prod"
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">False</property>
-                                        <property name="use_action_appearance">False</property>
                                         <property name="use_underline">True</property>
                                         <property name="focus_on_click">False</property>
                                         <property name="active">True</property>
@@ -481,7 +520,6 @@ guake -r "prod" -e "cd ~/projects/myproject/prod"
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">False</property>
-                                        <property name="use_action_appearance">False</property>
                                         <property name="use_underline">True</property>
                                         <property name="active">True</property>
                                         <property name="draw_indicator">True</property>
@@ -499,7 +537,6 @@ guake -r "prod" -e "cd ~/projects/myproject/prod"
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">False</property>
-                                        <property name="use_action_appearance">False</property>
                                         <property name="use_underline">True</property>
                                         <property name="active">True</property>
                                         <property name="draw_indicator">True</property>
@@ -518,7 +555,6 @@ guake -r "prod" -e "cd ~/projects/myproject/prod"
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">False</property>
                                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                        <property name="use_action_appearance">False</property>
                                         <property name="draw_indicator">True</property>
                                         <signal name="toggled" handler="on_window_tabbar_toggled" swapped="no"/>
                                       </widget>
@@ -535,7 +571,6 @@ guake -r "prod" -e "cd ~/projects/myproject/prod"
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">False</property>
                                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                        <property name="use_action_appearance">False</property>
                                         <property name="draw_indicator">True</property>
                                         <signal name="toggled" handler="on_start_fullscreen_toggled" swapped="no"/>
                                       </widget>
@@ -592,7 +627,6 @@ guake -r "prod" -e "cd ~/projects/myproject/prod"
                                             <property name="visible">True</property>
                                             <property name="can_focus">True</property>
                                             <property name="receives_default">False</property>
-                                            <property name="use_action_appearance">False</property>
                                             <property name="draw_indicator">True</property>
                                             <signal name="toggled" handler="on_window_halign_value_changed" swapped="no"/>
                                           </widget>
@@ -608,7 +642,6 @@ guake -r "prod" -e "cd ~/projects/myproject/prod"
                                             <property name="visible">True</property>
                                             <property name="can_focus">True</property>
                                             <property name="receives_default">False</property>
-                                            <property name="use_action_appearance">False</property>
                                             <property name="active">True</property>
                                             <property name="draw_indicator">True</property>
                                             <property name="group">radiobutton_align_left</property>
@@ -626,7 +659,6 @@ guake -r "prod" -e "cd ~/projects/myproject/prod"
                                             <property name="visible">True</property>
                                             <property name="can_focus">True</property>
                                             <property name="receives_default">False</property>
-                                            <property name="use_action_appearance">False</property>
                                             <property name="draw_indicator">True</property>
                                             <property name="group">radiobutton_align_left</property>
                                             <signal name="toggled" handler="on_window_halign_value_changed" swapped="no"/>
@@ -870,7 +902,6 @@ guake -r "prod" -e "cd ~/projects/myproject/prod"
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">False</property>
                                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                        <property name="use_action_appearance">False</property>
                                         <property name="use_underline">True</property>
                                         <property name="draw_indicator">True</property>
                                       </widget>
@@ -887,7 +918,6 @@ guake -r "prod" -e "cd ~/projects/myproject/prod"
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">False</property>
                                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                        <property name="use_action_appearance">False</property>
                                         <property name="use_underline">True</property>
                                         <property name="draw_indicator">True</property>
                                       </widget>
@@ -983,7 +1013,6 @@ guake -r "prod" -e "cd ~/projects/myproject/prod"
                                     <property name="can_focus">True</property>
                                     <property name="receives_default">False</property>
                                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                    <property name="use_action_appearance">False</property>
                                     <property name="draw_indicator">True</property>
                                     <signal name="toggled" handler="on_use_scrollbar_toggled" swapped="no"/>
                                   </widget>
@@ -1086,7 +1115,6 @@ guake -r "prod" -e "cd ~/projects/myproject/prod"
                                     <property name="can_focus">True</property>
                                     <property name="receives_default">False</property>
                                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                    <property name="use_action_appearance">False</property>
                                     <property name="draw_indicator">True</property>
                                     <signal name="toggled" handler="on_scroll_output_toggled" swapped="no"/>
                                   </widget>
@@ -1103,7 +1131,6 @@ guake -r "prod" -e "cd ~/projects/myproject/prod"
                                     <property name="can_focus">True</property>
                                     <property name="receives_default">False</property>
                                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                    <property name="use_action_appearance">False</property>
                                     <property name="draw_indicator">True</property>
                                     <signal name="toggled" handler="on_scroll_keystroke_toggled" swapped="no"/>
                                   </widget>
@@ -1192,12 +1219,14 @@ guake -r "prod" -e "cd ~/projects/myproject/prod"
                                 <property name="column_spacing">13</property>
                                 <property name="row_spacing">6</property>
                                 <child>
+                                  <placeholder/>
+                                </child>
+                                <child>
                                   <widget class="GtkCheckButton" id="use_default_font">
                                     <property name="label" translatable="yes">Use the system fixed width font</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
                                     <property name="receives_default">False</property>
-                                    <property name="use_action_appearance">False</property>
                                     <property name="yalign">1</property>
                                     <property name="draw_indicator">True</property>
                                     <signal name="toggled" handler="on_use_default_font_toggled" swapped="no"/>
@@ -1229,7 +1258,6 @@ guake -r "prod" -e "cd ~/projects/myproject/prod"
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
                                     <property name="receives_default">True</property>
-                                    <property name="use_action_appearance">False</property>
                                     <property name="focus_on_click">False</property>
                                     <property name="title" translatable="yes">Choose some font</property>
                                     <signal name="font_set" handler="on_font_style_font_set" swapped="no"/>
@@ -1283,7 +1311,6 @@ guake -r "prod" -e "cd ~/projects/myproject/prod"
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">True</property>
-                                        <property name="use_action_appearance">False</property>
                                         <property name="color">#000000000000</property>
                                         <signal name="color_set" handler="on_background_color_color_set" swapped="no"/>
                                       </widget>
@@ -1314,7 +1341,6 @@ guake -r "prod" -e "cd ~/projects/myproject/prod"
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">True</property>
-                                        <property name="use_action_appearance">False</property>
                                         <property name="color">#000000000000</property>
                                         <signal name="color_set" handler="on_font_color_color_set" swapped="no"/>
                                       </widget>
@@ -1384,6 +1410,9 @@ Underline</property>
                                   </packing>
                                 </child>
                                 <child>
+                                  <placeholder/>
+                                </child>
+                                <child>
                                   <widget class="GtkComboBox" id="cursor_blink_mode">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
@@ -1399,12 +1428,6 @@ Blink off</property>
                                     <property name="bottom_attach">3</property>
                                     <property name="y_options"/>
                                   </packing>
-                                </child>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
-                                  <placeholder/>
                                 </child>
                               </widget>
                             </child>
@@ -1454,6 +1477,9 @@ Blink off</property>
                                 <property name="n_columns">2</property>
                                 <property name="column_spacing">12</property>
                                 <property name="row_spacing">6</property>
+                                <child>
+                                  <placeholder/>
+                                </child>
                                 <child>
                                   <widget class="GtkLabel" id="label17">
                                     <property name="visible">True</property>
@@ -1510,7 +1536,6 @@ Blink off</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">True</property>
-                                        <property name="use_action_appearance">False</property>
                                         <property name="xalign">0.25</property>
                                         <property name="yalign">0.25</property>
                                         <property name="color">#000000000000</property>
@@ -1523,7 +1548,6 @@ Blink off</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">True</property>
-                                        <property name="use_action_appearance">False</property>
                                         <property name="color">#000000000000</property>
                                         <signal name="color_set" handler="on_palette_color_set" swapped="no"/>
                                       </widget>
@@ -1538,7 +1562,6 @@ Blink off</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">True</property>
-                                        <property name="use_action_appearance">False</property>
                                         <property name="color">#000000000000</property>
                                         <signal name="color_set" handler="on_palette_color_set" swapped="no"/>
                                       </widget>
@@ -1553,7 +1576,6 @@ Blink off</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">True</property>
-                                        <property name="use_action_appearance">False</property>
                                         <property name="color">#000000000000</property>
                                         <signal name="color_set" handler="on_palette_color_set" swapped="no"/>
                                       </widget>
@@ -1570,7 +1592,6 @@ Blink off</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">True</property>
-                                        <property name="use_action_appearance">False</property>
                                         <property name="color">#000000000000</property>
                                         <signal name="color_set" handler="on_palette_color_set" swapped="no"/>
                                       </widget>
@@ -1587,7 +1608,6 @@ Blink off</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">True</property>
-                                        <property name="use_action_appearance">False</property>
                                         <property name="color">#000000000000</property>
                                         <signal name="color_set" handler="on_palette_color_set" swapped="no"/>
                                       </widget>
@@ -1602,7 +1622,6 @@ Blink off</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">True</property>
-                                        <property name="use_action_appearance">False</property>
                                         <property name="color">#000000000000</property>
                                         <signal name="color_set" handler="on_palette_color_set" swapped="no"/>
                                       </widget>
@@ -1619,7 +1638,6 @@ Blink off</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">True</property>
-                                        <property name="use_action_appearance">False</property>
                                         <property name="color">#000000000000</property>
                                         <signal name="color_set" handler="on_palette_color_set" swapped="no"/>
                                       </widget>
@@ -1634,7 +1652,6 @@ Blink off</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">True</property>
-                                        <property name="use_action_appearance">False</property>
                                         <property name="color">#000000000000</property>
                                         <signal name="color_set" handler="on_palette_color_set" swapped="no"/>
                                       </widget>
@@ -1649,7 +1666,6 @@ Blink off</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">True</property>
-                                        <property name="use_action_appearance">False</property>
                                         <property name="color">#000000000000</property>
                                         <signal name="color_set" handler="on_palette_color_set" swapped="no"/>
                                       </widget>
@@ -1666,7 +1682,6 @@ Blink off</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">True</property>
-                                        <property name="use_action_appearance">False</property>
                                         <property name="color">#000000000000</property>
                                         <signal name="color_set" handler="on_palette_color_set" swapped="no"/>
                                       </widget>
@@ -1683,7 +1698,6 @@ Blink off</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">True</property>
-                                        <property name="use_action_appearance">False</property>
                                         <property name="color">#000000000000</property>
                                         <signal name="color_set" handler="on_palette_color_set" swapped="no"/>
                                       </widget>
@@ -1698,7 +1712,6 @@ Blink off</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">True</property>
-                                        <property name="use_action_appearance">False</property>
                                         <property name="color">#000000000000</property>
                                         <signal name="color_set" handler="on_palette_color_set" swapped="no"/>
                                       </widget>
@@ -1713,7 +1726,6 @@ Blink off</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">True</property>
-                                        <property name="use_action_appearance">False</property>
                                         <property name="color">#000000000000</property>
                                         <signal name="color_set" handler="on_palette_color_set" swapped="no"/>
                                       </widget>
@@ -1730,7 +1742,6 @@ Blink off</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">True</property>
-                                        <property name="use_action_appearance">False</property>
                                         <property name="color">#000000000000</property>
                                         <signal name="color_set" handler="on_palette_color_set" swapped="no"/>
                                       </widget>
@@ -1747,7 +1758,6 @@ Blink off</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">True</property>
-                                        <property name="use_action_appearance">False</property>
                                         <property name="color">#000000000000</property>
                                         <signal name="color_set" handler="on_palette_color_set" swapped="no"/>
                                       </widget>
@@ -1763,7 +1773,6 @@ Blink off</property>
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">True</property>
                                         <property name="tooltip" translatable="yes">Font color</property>
-                                        <property name="use_action_appearance">False</property>
                                         <property name="color">#000000000000</property>
                                         <signal name="color_set" handler="on_palette_color_set" swapped="no"/>
                                       </widget>
@@ -1779,7 +1788,6 @@ Blink off</property>
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">True</property>
                                         <property name="tooltip" translatable="yes">Background color</property>
-                                        <property name="use_action_appearance">False</property>
                                         <property name="color">#000000000000</property>
                                         <signal name="color_set" handler="on_palette_color_set" swapped="no"/>
                                       </widget>
@@ -1827,7 +1835,6 @@ Blink off</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
                                     <property name="receives_default">False</property>
-                                    <property name="use_action_appearance">False</property>
                                     <property name="draw_indicator">True</property>
                                     <signal name="toggled" handler="on_use_palette_font_and_background_color_toggled" swapped="no"/>
                                     <signal name="toggled" handler="toggle_use_font_background_sensitivity" swapped="no"/>
@@ -1872,9 +1879,6 @@ Blink off</property>
                                     <property name="top_attach">3</property>
                                     <property name="bottom_attach">4</property>
                                   </packing>
-                                </child>
-                                <child>
-                                  <placeholder/>
                                 </child>
                               </widget>
                             </child>
@@ -1989,7 +1993,6 @@ Blink off</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">True</property>
-                                        <property name="use_action_appearance">False</property>
                                         <signal name="clicked" handler="clear_background_image" swapped="no"/>
                                         <child>
                                           <widget class="GtkImage" id="image1">
@@ -2173,7 +2176,6 @@ Blink off</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">False</property>
-                                        <property name="use_action_appearance">False</property>
                                         <property name="draw_indicator">True</property>
                                         <signal name="toggled" handler="on_quick_open_enable_toggled" swapped="no"/>
                                         <signal name="toggled" handler="toggle_quick_open_command_line_sensitivity" swapped="no"/>
@@ -2268,7 +2270,6 @@ For example, for sublime, use &lt;b&gt;subl %(file_path)s:%(line_number)s&lt;/b&
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">False</property>
-                                        <property name="use_action_appearance">False</property>
                                         <property name="draw_indicator">True</property>
                                         <signal name="toggled" handler="on_quick_open_in_current_terminal_toggled" swapped="no"/>
                                       </widget>
@@ -2559,7 +2560,6 @@ Control-H</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
                                     <property name="receives_default">False</property>
-                                    <property name="use_action_appearance">False</property>
                                     <property name="use_underline">True</property>
                                     <signal name="clicked" handler="on_reset_compat_defaults_clicked" swapped="no"/>
                                     <signal name="clicked" handler="reload_erase_combos" swapped="no"/>
@@ -2623,7 +2623,6 @@ Control-H</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">False</property>
-                    <property name="use_action_appearance">False</property>
                     <property name="use_stock">True</property>
                     <signal name="clicked" handler="gtk_widget_destroy" object="config-window" swapped="yes"/>
                   </widget>

--- a/src/guake/guake_notebook.py
+++ b/src/guake/guake_notebook.py
@@ -48,16 +48,18 @@ class GuakeNotebook(Notebook):
 
     def get_running_fg_processes(self):
         total_procs = 0
-        term_idx = 0
         for page_index in range(self.get_tab_count()):
-            terminals = self.get_terminals_for_tab(page_index)
-            for terminal in terminals:
-                fdpty = terminal.get_pty()
-                term_pid = terminal.get_pid()
-                fgpid = posix.tcgetpgrp(fdpty)
-                if not (fgpid == -1 or fgpid == term_pid):
-                    total_procs += 1
-                term_idx += 1
+            total_procs += self.get_running_fg_processes_tab(page_index)
+        return total_procs
+
+    def get_running_fg_processes_tab(self, index):
+        total_procs = 0
+        for terminal in self.get_terminals_for_tab(index):
+            fdpty = terminal.get_pty()
+            term_pid = terminal.get_pid()
+            fgpid = posix.tcgetpgrp(fdpty)
+            if not (fgpid == -1 or fgpid == term_pid):
+                total_procs += 1
         return total_procs
 
     def iter_terminals(self):

--- a/src/guake/prefs.py
+++ b/src/guake/prefs.py
@@ -201,6 +201,11 @@ class PrefsCallbacks(object):
         """
         self.client.set_bool(KEY('/general/prompt_on_quit'), chk.get_active())
 
+    def on_prompt_on_close_tab_changed(self, combo):
+        """Set the `prompt_on_close_tab' property in gconf
+        """
+        self.client.set_int(KEY('/general/prompt_on_close_tab'), combo.get_active())
+
     def on_window_ontop_toggled(self, chk):
         """Changes the activity of window_ontop in gconf
         """
@@ -506,6 +511,12 @@ class PrefsDialog(SimpleGladeApp):
         else:
             file_chooser.set_preview_widget_active(False)
 
+    def toggle_prompt_on_quit_sensitivity(self, combo):
+        """If toggle_on_close_tabs is set to 2 (Always), prompt_on_quit has no
+        effect.
+        """
+        self.get_widget('prompt_on_quit').set_sensitive(combo.get_active() != 2)
+
     def toggle_style_sensitivity(self, chk):
         """If the user chooses to use the gnome default font
         configuration it means that he will not be able to use the
@@ -690,6 +701,11 @@ class PrefsDialog(SimpleGladeApp):
         # prompt on quit
         value = self.client.get_bool(KEY('/general/prompt_on_quit'))
         self.get_widget('prompt_on_quit').set_active(value)
+
+        # prompt on close_tab
+        value = self.client.get_int(KEY('/general/prompt_on_close_tab'))
+        self.get_widget('prompt_on_close_tab').set_active(value)
+        self.get_widget('prompt_on_quit').set_sensitive(value != 2)
 
         # ontop
         value = self.client.get_bool(KEY('/general/window_ontop'))


### PR DESCRIPTION
A feature I was missing from gnome-terminal. Like prompt_on_quit, but for individual terminals. Values are "never" (default), "with process running", and "always".

Additionally, if set to "with process running", the quit-prompt will be shown
when quitting Guake if there are any subprocesses running. If set to "always",
it essentially overrides the prompt_on_quit option.

The option is in the GUI as a dropdown, just above prompt_on_quit. prompt_on_quit now behaves more a sub-option of prompt_on_close_tab.

If one of the two prompts is open (close tab or quit Guake) and the other opens, the first will be destroyed. Otherwise I found Guake wouldn't quit until the close-tab prompt was dismissed.

I changed the prompt text slightly; it includes the number of tabs open when quitting.

Please let me know what you think if you get a chance :)