### PR TITLE
set default value for /apps/guake/general/debug_mode

### DIFF
--- a/data/guake.schemas
+++ b/data/guake.schemas
@@ -5,7 +5,7 @@
             <applyto>/apps/guake/general/debug_mode</applyto>
             <owner>guake</owner>
             <type>bool</type>
-            <default></default>
+            <default>false</default>
             <locale name="C">
                 <short>Enable debug mode</short>
                 <long>When debug mode is enabled, logs are printed in the


### PR DESCRIPTION
The default value for /apps/guake/general/debug_mode is not set, which gives a warning while installing it from an RPM on Fedora and RHEL.