### PR TITLE
Merge for a-la guake-indicator custom commands #564

### DIFF
--- a/data/guake.schemas
+++ b/data/guake.schemas
@@ -987,5 +987,20 @@
             </locale>
         </schema>
 
+        <schema>
+            <key>/schemas/apps/guake/general/custom_command_file</key>
+            <applyto>/apps/guake/general/custom_command_file</applyto>
+            <owner>guake</owner>
+            <type>string</type>
+            <default>~/.config/guake/custom_command.json</default>
+            <locale name="C">
+                <short>Path to the default custom command json file.</short>
+                <long>Path to the default custom command json file.
+                If is blank or the json file is not in a proper format
+                the terminal context menu will be built without custom commands.
+                If the file is a valid json with recognized structure theterminak
+                context menu will be buit with the commands read inside.</long>
+            </locale>
+        </schema>
     </schemalist>
 </gconfschemafile>

--- a/data/prefs.glade
+++ b/data/prefs.glade
@@ -524,24 +524,6 @@ Always</property>
                                       </packing>
                                     </child>
                                     <child>
-                                      <widget class="GtkCheckButton" id="use_vte_titles">
-                                        <property name="label" translatable="yes">Use VTE titles for tab names</property>
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="receives_default">False</property>
-                                        <property name="use_action_appearance">False</property>
-                                        <property name="use_underline">True</property>
-                                        <property name="active">True</property>
-                                        <property name="draw_indicator">True</property>
-                                        <signal name="toggled" handler="on_use_vte_titles_toggled" swapped="no"/>
-                                      </widget>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">False</property>
-                                        <property name="position">1</property>
-                                      </packing>
-                                    </child>
-                                    <child>
                                       <widget class="GtkCheckButton" id="window_losefocus">
                                         <property name="label" translatable="yes">Hide on lose focus</property>
                                         <property name="visible">True</property>
@@ -552,6 +534,24 @@ Always</property>
                                         <property name="active">True</property>
                                         <property name="draw_indicator">True</property>
                                         <signal name="toggled" handler="on_window_losefocus_toggled" swapped="no"/>
+                                      </widget>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">False</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <widget class="GtkCheckButton" id="use_vte_titles">
+                                        <property name="label" translatable="yes">Use VTE titles for tab names</property>
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                        <property name="use_action_appearance">False</property>
+                                        <property name="use_underline">True</property>
+                                        <property name="active">True</property>
+                                        <property name="draw_indicator">True</property>
+                                        <signal name="toggled" handler="on_use_vte_titles_toggled" swapped="no"/>
                                       </widget>
                                       <packing>
                                         <property name="expand">False</property>
@@ -820,6 +820,41 @@ Always</property>
                         <property name="expand">True</property>
                         <property name="fill">True</property>
                         <property name="position">4</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <widget class="GtkHBox" id="hbox5">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <child>
+                          <widget class="GtkLabel" id="label12">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="label" translatable="yes">Custom command file path: </property>
+                          </widget>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <widget class="GtkFileChooserButton" id="custom_command_file_chooser">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <signal name="file_set" handler="on_custom_command_file_chooser_file_changed" swapped="no"/>
+                          </widget>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                      </widget>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">5</property>
                       </packing>
                     </child>
                   </widget>
@@ -1432,12 +1467,6 @@ Blink off</property>
                                   </packing>
                                 </child>
                                 <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
                                   <widget class="GtkLabel" id="label35">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
@@ -1453,6 +1482,12 @@ Blink off</property>
                                     <property name="x_options">GTK_FILL</property>
                                     <property name="y_options"/>
                                   </packing>
+                                </child>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                                <child>
+                                  <placeholder/>
                                 </child>
                               </widget>
                             </child>

--- a/src/guake/gconfhandler.py
+++ b/src/guake/gconfhandler.py
@@ -94,6 +94,10 @@ class GConfHandler(object):
 
         notify_add(KEY('/general/compat_backspace'), self.backspace_changed)
         notify_add(KEY('/general/compat_delete'), self.delete_changed)
+        notify_add(KEY('/general/custom_command_file'), self.custom_command_file_changed)
+
+    def custom_command_file_changed(self,client, connection_id, entry, data):
+        self.guake.read_custom_commands_file()
 
     def show_resizer_toggled(self, client, connection_id, entry, data):
         """If the gconf var show_resizer be changed, this method will

--- a/src/guake/guake_app.py
+++ b/src/guake/guake_app.py
@@ -38,6 +38,8 @@ import pygtk
 import subprocess
 import sys
 import xdg.Exceptions
+import json
+from os.path import expanduser
 
 from urllib import quote_plus
 from urllib import url2pathname
@@ -244,6 +246,25 @@ class Guake(SimpleGladeApp):
         # holds the timestamp of the previous show/hide action
         self.prev_showhide_time = 0
 
+        # custom context-menu row creation
+        def context_menu_row_creation(cmd):
+            item = gtk.MenuItem()
+            button = gtk.MenuItem(cmd)
+            button.show()
+            item.connect("activate", self.execute_context_menu_cmd,cmd)
+            item.add(button)
+            item.show()
+            self.get_widget('context-menu').append(item)
+
+        # Set up context menu
+        try:
+            with open(expanduser("~")+'/.config/guake/custom_command.json') as data_file:    
+                data = json.load(data_file)
+            for single_cmd in data['cmds']:
+                context_menu_row_creation(single_cmd)
+        except :
+            print("Custom command file not found")
+
         # double click stuff
         def double_click(hbox, event):
             """Handles double clicks on tabs area and when receive
@@ -341,6 +362,10 @@ class Guake(SimpleGladeApp):
                 _('Guake Terminal'),
                 _('Guake is now running,\n'
                   'press <b>%s</b> to use it.') % xml_escape(label), filename)
+
+    # execute contextual menu call
+    def execute_context_menu_cmd (self,item,cmd) :
+        self.execute_command(cmd)
 
     def setupLogging(self):
         if self.debug_mode:

--- a/src/guake/guake_app.py
+++ b/src/guake/guake_app.py
@@ -39,8 +39,7 @@ import pygtk
 import subprocess
 import sys
 import xdg.Exceptions
-
-from os.path import expanduser
+import urllib2
 
 from urllib import quote_plus
 from urllib import url2pathname
@@ -275,18 +274,19 @@ class Guake(SimpleGladeApp):
 
         # Set up context menu
         context_menu_row_creation.cmd_counter=0
-        custom_commands=None
-        print(os.path.expanduser(self.client.get_string(KEY('/general/custom_command_file'))))
+
         try:
-            with open(os.path.expanduser(self.client.get_string(KEY('/general/custom_command_file')))) as data_file:
-                custom_commands = json.load(data_file)     
+            data_file = urllib2.urlopen(self.client.get_string(KEY('/general/custom_command_file')))
+            custom_commands = json.load(data_file)
+            if custom_commands!=None:
+                for single_cmd in custom_commands['cmds']:
+                    context_menu_row_creation(single_cmd)
         except:
             print("Valid custom command file not found")
 
-        if custom_commands!=None:
-            for single_cmd in custom_commands['cmds']:
-                context_menu_row_creation(single_cmd)
-
+        finally:
+            if data_file:
+                data_file.close()
 
         # double click stuff
         def double_click(hbox, event):

--- a/src/guake/guake_app.py
+++ b/src/guake/guake_app.py
@@ -372,6 +372,7 @@ class Guake(SimpleGladeApp):
 
     # function to read file stored at /general/custom_command_file and launch the context menu builder
     def read_custom_commands_file(self):
+        data_file=None
         try:
             data_file = urllib2.urlopen(self.client.get_string(KEY('/general/custom_command_file')))
             custom_commands = json.load(data_file)

--- a/src/guake/guake_app.py
+++ b/src/guake/guake_app.py
@@ -276,17 +276,13 @@ class Guake(SimpleGladeApp):
         # Set up context menu
         context_menu_row_creation.cmd_counter=0
         custom_commands=None
+        print(os.path.expanduser(self.client.get_string(KEY('/general/custom_command_file'))))
         try:
-            with open(self.client.get_string(KEY('/general/custom_command_file'))) as data_file:
+            with open(os.path.expanduser(self.client.get_string(KEY('/general/custom_command_file')))) as data_file:
                 custom_commands = json.load(data_file)     
-        except :
-            try:
-                with open(expanduser("~")+'/.config/guake/custom_command.json') as data_file:
-                    custom_commands = json.load(data_file)
-            except:
-                print("Valid custom command file not found")
+        except:
+            print("Valid custom command file not found")
 
-        print(custom_commands)
         if custom_commands!=None:
             for single_cmd in custom_commands['cmds']:
                 context_menu_row_creation(single_cmd)

--- a/src/guake/prefs.py
+++ b/src/guake/prefs.py
@@ -402,6 +402,8 @@ class PrefsCallbacks(object):
         self.client.set_string(KEY('/general/compat_delete'),
                                ERASE_BINDINGS[val])
 
+    def on_custom_command_file_chooser_file_changed(self,filechooser):
+        self.client.set_string(KEY('/general/custom_command_file'),filechooser.get_uri())
 
 class PrefsDialog(SimpleGladeApp):
 
@@ -890,6 +892,13 @@ class PrefsDialog(SimpleGladeApp):
 
         # it's a separated method, to be reused.
         self.reload_erase_combos()
+
+        #custom command context-menu configuration file
+        value = os.path.expanduser(self.client.get_string(KEY('/general/custom_command_file')))
+        custom_cmd_filter = gtk.FileFilter()
+        custom_cmd_filter.add_pattern("*.json")
+        self.get_widget('custom_command_file_chooser').add_filter(custom_cmd_filter)
+        self.get_widget('custom_command_file_chooser').set_uri(value)
 
     # -- populate functions --
 


### PR DESCRIPTION
Hello please consider my pull request,this should solve Guake issue #564 
Here what i've done:

1. added new gconf setting for storing config file URI (and not path as previously discussed)
2. added new button on the prefs window that allow the user to select the config json file
3.every time the user changes the file guake will reload the context menu with new commands

for now the user has to edit manually the json file, you should publish the instruction to build it somewhere.
It is very easy to build one: just create a json file witjh  an array named cmds, example

{
 "cmds":[ "ls","df","ping google.it","lpass login","lpass_logout","df -h" ]
}

I am considering to change it and put an array of objects, one field for the context menu description and another with the real command to send to guake, let me know what you think.

I'd like to put a new button or label on the prefs window next to the  select file command to advertise guake-indicator, do you think it is possible?
