### PR TITLE
prevent Guake.is_using_unity() crashing when env variables are missing

### DIFF
--- a/src/guake/guake_app.py
+++ b/src/guake/guake_app.py
@@ -802,11 +802,11 @@ class Guake(SimpleGladeApp):
 
         # http://askubuntu.com/questions/70296/is-there-an-environment-variable-that-is-set-for-unity
         if float(linux_distrib[1]) - 0.01 < 11.10:
-            if os.environ.get('DESKTOP_SESSION').lower() == "gnome".lower():
+            if os.environ.get('DESKTOP_SESSION', '').lower() == "gnome".lower():
                 log.debug("Unity detected")
                 return True
         else:
-            if os.environ.get('XDG_CURRENT_DESKTOP').lower() == "unity".lower():
+            if os.environ.get('XDG_CURRENT_DESKTOP', '').lower() == "unity".lower():
                 log.debug("Unity detected")
                 return True
         return False


### PR DESCRIPTION
Before this commit, guake will crash if the environment variable `DESKTOP_SESSION` or `XDG_CURRENT_DESKTOP` is missing.

Tracebacks:

```
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/guake/gconfhandler.py", line 148, in size_changed
    self.guake.set_final_window_rect()
  File "/usr/local/lib/python2.7/dist-packages/guake/guake_app.py", line 841, in set_final_window_rect
    if self.is_using_unity():
  File "/usr/local/lib/python2.7/dist-packages/guake/guake_app.py", line 809, in is_using_unity
    if os.environ.get('XDG_CURRENT_DESKTOP').lower() == "unity".lower():
AttributeError: 'NoneType' object has no attribute 'lower'
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/guake/gconfhandler.py", line 148, in size_changed
    self.guake.set_final_window_rect()
  File "/usr/local/lib/python2.7/dist-packages/guake/guake_app.py", line 841, in set_final_window_rect
    if self.is_using_unity():
  File "/usr/local/lib/python2.7/dist-packages/guake/guake_app.py", line 809, in is_using_unity
    if os.environ.get('XDG_CURRENT_DESKTOP').lower() == "unity".lower():
AttributeError: 'NoneType' object has no attribute 'lower'
^CTraceback (most recent call last):
  File "/usr/lib/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/usr/local/lib/python2.7/dist-packages/guake/main.py", line 239, in <module>
    exec_main()
  File "/usr/local/lib/python2.7/dist-packages/guake/main.py", line 236, in exec_main
    gtk.main()
KeyboardInterrupt
```