### PR TITLE
Swap terms correctly when moving tabs, fixes #473 and #512

### DIFF
--- a/src/guake/guake_notebook.py
+++ b/src/guake/guake_notebook.py
@@ -31,8 +31,7 @@ class GuakeNotebook(Notebook):
         """ We should also reorder elements in term_list
         """
         old_pos = self.get_children().index(child)
-        terms = self.term_list
-        terms[old_pos], terms[position] = terms[position], terms[old_pos]
+        self.term_list.insert(position, self.term_list.pop(old_pos))
         super(GuakeNotebook, self).reorder_child(child, position)
 
     def has_term(self):


### PR DESCRIPTION
#473 and #512 are still present when moving tabs more than one position. Steps to reproduce (same on 0.7.2 and current master):
* create 3 tabs (a, b, c)
* move tab c to the left (c, a, b)
* copy/paste in tabs a and b is interchanged
* close tab b
* now tab a is grey as described in #473