### PR TITLE
use full path to tray icon with libappindicator

### DIFF
--- a/src/guake/guake_app.py
+++ b/src/guake/guake_app.py
@@ -167,10 +167,10 @@ class Guake(SimpleGladeApp):
         self.preventHide = False
 
         # trayicon!
+        img = pixmapfile('guake-tray.png')
         try:
             import appindicator
         except ImportError:
-            img = pixmapfile('guake-tray.png')
             self.tray_icon = gtk.status_icon_new_from_file(img)
             self.tray_icon.set_tooltip(_('Guake Terminal'))
             self.tray_icon.connect('popup-menu', self.show_menu)
@@ -178,7 +178,7 @@ class Guake(SimpleGladeApp):
         else:
             self.tray_icon = appindicator.Indicator(
                 _("guake-indicator"), _("guake-tray"), appindicator.CATEGORY_OTHER)
-            self.tray_icon.set_icon("guake-tray")
+            self.tray_icon.set_icon(img)
             self.tray_icon.set_status(appindicator.STATUS_ACTIVE)
             menu = self.get_widget('tray-menu')
             show = gtk.MenuItem(_('Show'))


### PR DESCRIPTION
Resolve issue #433, broken tray icon when using python libappindicator bindings.

According to http://people.canonical.com/~ted/libappindicator/current/AppIndicator.html `set_icon` takes an "icon-name", which presumably is not actually intended to be a filename (?) Hard to tell.  Giving it the full path works.