### PR TITLE
changed method get_uri in filechooser to get_filename

### DIFF
--- a/src/guake/prefs.py
+++ b/src/guake/prefs.py
@@ -408,7 +408,7 @@ class PrefsCallbacks(object):
                                ERASE_BINDINGS[val])
 
     def on_custom_command_file_chooser_file_changed(self, filechooser):
-        self.client.set_string(KEY('/general/custom_command_file'), filechooser.get_uri())
+        self.client.set_string(KEY('/general/custom_command_file'), filechooser.get_filename())
 
 
 class PrefsDialog(SimpleGladeApp):


### PR DESCRIPTION
gtkfilechooser.get_filename() should return the full path of the file selected (I hope it works coherently across multiple OS like Windows), in this way the  with open(file_name) as f: method you wrote should work.
Please let me know if this is a valid fix for you. Then I'll try to write some code to group the commands within a dedicated menuitem and other stuff we discussed before.

