### PR TITLE
Fixed guake.glade for xfce and re-added tab png icon on tab bar

### DIFF
--- a/data/guake.glade
+++ b/data/guake.glade
@@ -90,7 +90,7 @@
         </child>
       </widget>
     </child>
-        <child>
+    <child>
       <widget class="GtkImageMenuItem" id="context_reset_terminal">
         <property name="label" translatable="yes">Reset terminal</property>
         <property name="visible">True</property>

--- a/data/guake.glade
+++ b/data/guake.glade
@@ -427,6 +427,7 @@
                 <property name="vscrollbar_policy">never</property>
                 <child>
                   <widget class="GtkViewport" id="tabs-viewport">
+                    <property name="height_request">10</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="shadow_type">none</property>

--- a/src/guake/guake_app.py
+++ b/src/guake/guake_app.py
@@ -189,6 +189,9 @@ class Guake(SimpleGladeApp):
             menu.prepend(show)
             self.tray_icon.set_menu(menu)
 
+        ipath = pixmapfile('add_tab.png')
+        self.get_widget('image2').set_from_file(ipath)
+        
         # important widgets
         self.window = self.get_widget('window-root')
         self.mainframe = self.get_widget('mainframe')


### PR DESCRIPTION
This PL request is should solve this issue:

New Tab icon not found and very big tab bar #599 and issue #616 , the latter was a duplicate.

