### PR TITLE
Fix #578 : open new tab in current directory

### DIFF
--- a/data/prefs.glade
+++ b/data/prefs.glade
@@ -956,6 +956,7 @@ Always</property>
                                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                         <property name="use_underline">True</property>
                                         <property name="draw_indicator">True</property>
+                                        <signal name="toggled" handler="on_open_tab_cwd_toggled" swapped="no"/>
                                       </widget>
                                       <packing>
                                         <property name="expand">True</property>

--- a/data/prefs.glade
+++ b/data/prefs.glade
@@ -913,6 +913,7 @@ Always</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">False</property>
                                         <property name="items" translatable="yes"/>
+                                        <signal name="changed" handler="on_default_shell_changed" swapped="no"/>
                                       </widget>
                                       <packing>
                                         <property name="expand">True</property>

--- a/data/prefs.glade
+++ b/data/prefs.glade
@@ -941,6 +941,7 @@ Always</property>
                                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                         <property name="use_underline">True</property>
                                         <property name="draw_indicator">True</property>
+					<signal name="toggled" handler="on_use_login_shell_toggled" swapped="no"/>
                                       </widget>
                                       <packing>
                                         <property name="expand">True</property>

--- a/src/guake/prefs.py
+++ b/src/guake/prefs.py
@@ -247,6 +247,11 @@ class PrefsCallbacks(object):
         """Changes the activity of start_fullscreen in gconf
         """
         self.client.set_bool(KEY('/general/start_fullscreen'), chk.get_active())
+        
+    def on_use_vte_titles_toggled(self, chk):
+        """Save `use_vte_titles` property value in gconf
+        """
+        self.client.set_bool(KEY('/general/use_vte_titles'), chk.get_active())
 
     def on_mouse_display_toggled(self, chk):
         """Set the 'appear on mouse display' preference in gconf. This


### PR DESCRIPTION
The check-box for 'open new tab in current directory' in `data/prefs.glade` is not linked to the appropriate listener. This pull request fixes the issue by adding the appropriate listener to the check-box in the `prefs.glade` file