### PR TITLE
Fix Guake cannot restore from fullscreen #628

### DIFF
--- a/install-lib.py
+++ b/install-lib.py
@@ -30,9 +30,9 @@ isWindows = False
 if sys.platform.startswith('win32'):
     isWindows = True
 
-####################################################################################################
+#
 # Utility functions
-####################################################################################################
+#
 
 
 class bcolors(object):
@@ -124,7 +124,7 @@ def run_background(cmd, cwd=None, shell=False):
 def execute(cmdLine):
     return run([cmdLine], shell=True)
 
-####################################################################################################
+#
 
 
 def addArgumentParser(description=None):
@@ -149,7 +149,7 @@ def parse(parser):
     return (options, args)
 
 
-####################################################################################################
+#
 
 def makedirs(dirPath):
     try:

--- a/src/guake/guake_app.py
+++ b/src/guake/guake_app.py
@@ -1202,6 +1202,7 @@ class Guake(SimpleGladeApp):
         """Callback toggle the fullscreen status of the main
         window. Called by the accel key.
         """
+
         if not self.is_fullscreen:
             self.fullscreen()
         else:
@@ -1228,6 +1229,10 @@ class Guake(SimpleGladeApp):
             self.toolbar.hide()
 
     def unfullscreen(self):
+
+        # Fixes "Guake cannot restore from fullscreen" (#628)
+        self.window.unmaximize()
+
         self.set_final_window_rect()
         self.window.unfullscreen()
         self.is_fullscreen = False

--- a/src/guake/prefs.py
+++ b/src/guake/prefs.py
@@ -247,7 +247,7 @@ class PrefsCallbacks(object):
         """Changes the activity of start_fullscreen in gconf
         """
         self.client.set_bool(KEY('/general/start_fullscreen'), chk.get_active())
-        
+
     def on_use_vte_titles_toggled(self, chk):
         """Save `use_vte_titles` property value in gconf
         """


### PR DESCRIPTION
Hello, I've managed to reproduce and fix this issue on Debian Jessie 8.2 (Linux 3.16.0-4-amd64 / GNOME Shell 3.14.4), for some reason after you hide/show the terminal when is in fullscreen the WindowState changes to maximized and if you "unfullscreen", the window stays maximized.