### PR TITLE
Fixes #598 Very big icon tray

### DIFF
--- a/data/pixmaps/Makefile.am
+++ b/data/pixmaps/Makefile.am
@@ -1,6 +1,7 @@
 pixmapsdir = $(datadir)/pixmaps/guake
 pixmaps_DATA = \
 	guake.png \
+	guake-tray.svg \
 	guake-tray.png \
 	guake-notification.png \
 	add_tab.png \

--- a/src/guake/guake_app.py
+++ b/src/guake/guake_app.py
@@ -168,9 +168,8 @@ class Guake(SimpleGladeApp):
         self.preventHide = False
 
         # trayicon! Using SVG handles better different OS trays
-        # img = pixmapfile('guake-tray.svg')
-        # trayicon!
-        img = pixmapfile('guake-tray.png')
+        img = pixmapfile('guake-tray.svg')
+
         try:
             import appindicator
         except ImportError:


### PR DESCRIPTION
Hello! I've tested in Ubuntu 14.04, Linux Mint 17.1 Rebecca and Debian Jessie 8.2 and it works as expected, the SVG file scales better for different tray sizes. Solved the installation problem too :wink: :smiley: 