### PR TITLE
Closes #47 new feature max tab name length

### DIFF
--- a/data/guake.schemas
+++ b/data/guake.schemas
@@ -424,6 +424,18 @@
                 <long>Any terminal program can set the terminal's title via special escape sequences. Some shells (e.g. bash) display user's prompt there (though you can adjust that to any arbitrary text in bashrc or similar) and update it automatically as the prompt changes. So you can have easy automatically updating meaningful tab titles with this option turned on.</long>
             </locale>
         </schema>
+        
+        <schema>
+            <key>/schemas/apps/guake/general/max_tab_name_length</key>
+            <applyto>/apps/guake/general/max_tab_name_length</applyto>
+            <owner>guake</owner>
+            <type>int</type>
+            <default>0</default>
+            <locale name="C">
+                <short>Set max length of the tabs names</short>
+                <long>Controls the maximum length of the tabs names. Maximum length: 100, Minimum length: 1. 0 = unlimited length.</long>
+            </locale>
+        </schema>
 
         <schema>
             <key>/schemas/apps/guake/style/cursor_blink_mode</key>

--- a/data/prefs.glade
+++ b/data/prefs.glade
@@ -532,6 +532,52 @@ Always</property>
                                       </packing>
                                     </child>
                                     <child>
+                                      <widget class="GtkHBox" id="hbox_max_tab_name_length">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <child>
+                                          <widget class="GtkLabel" id="lbl_max_tab_name_length">
+                                            <property name="width_request">150</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="xalign">0</property>
+                                            <property name="label" translatable="yes">Max tab name length:</property>
+                                            <property name="use_markup">True</property>
+                                          </widget>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">False</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <widget class="GtkSpinButton" id="max_tab_name_length">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+                                            <property name="primary_icon_activatable">False</property>
+                                            <property name="secondary_icon_activatable">False</property>
+                                            <property name="primary_icon_sensitive">True</property>
+                                            <property name="secondary_icon_sensitive">True</property>
+                                            <property name="adjustment">0 0 100 1 1 0</property>
+                                            <property name="snap_to_ticks">True</property>
+                                            <property name="numeric">True</property>
+                                            <signal name="value_changed" handler="on_max_tab_name_length_changed" swapped="no"/>
+                                          </widget>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">2</property>
+                                          </packing>
+                                        </child>
+                                      </widget>
+                                      <packing>
+                                        <property name="expand">True</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">2</property>
+                                      </packing>
+                                    </child>
+                                    <child>
                                       <widget class="GtkCheckButton" id="window_losefocus">
                                         <property name="label" translatable="yes">Hide on lose focus</property>
                                         <property name="visible">True</property>

--- a/src/guake/prefs.py
+++ b/src/guake/prefs.py
@@ -255,6 +255,12 @@ class PrefsCallbacks(object):
         """
         self.client.set_bool(KEY('/general/use_vte_titles'), chk.get_active())
 
+    def on_max_tab_name_length_changed(self, spin):
+        """Changes the value of max_tab_name_length in gconf
+        """
+        val = int(spin.get_value())
+        self.client.set_int(KEY('/general/max_tab_name_length'), val)
+
     def on_mouse_display_toggled(self, chk):
         """Set the 'appear on mouse display' preference in gconf. This
         property supercedes any value stored in display_n.
@@ -739,6 +745,10 @@ class PrefsDialog(SimpleGladeApp):
         # use VTE titles
         value = self.client.get_bool(KEY('/general/use_vte_titles'))
         self.get_widget('use_vte_titles').set_active(value)
+
+        # max tab name length
+        value = self.client.get_int(KEY('/general/max_tab_name_length'))
+        self.get_widget('max_tab_name_length').set_value(value)
 
         value = self.client.get_float(KEY('/general/window_height_f'))
         if not value:


### PR DESCRIPTION
Hello! :smiley: I have implemented the requested feature that limit the tab names to the Nth character.
I have implemented this way:
* Added a Spin button in preferences to set the value, in the General --> Main Window section.
* Values allowed are from 0 to 100. 
* 0 equals unlimited length.
* Every time when the value is changed, it triggers the function that sets the new name of the tabs.
* When a tab it's renamed, stores the name in a new *attr* of the tab and shows the name cut at the Nth char.

That's all! Don't hesitate to ask about any changes :wink: 