### PR TITLE
correction for Fedora install from F23.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -154,7 +154,8 @@ RedHat/Fedora
 For Fedora 19 and above, Guake is available in the official repositories and can be installed by
 running::
 
-    sudo yum install guake
+    sudo yum install guake		# for Fedora 19 - 21
+    sudo dnf install guake		# for Fedora 23 and above
 
 For compiling from these sources, please install the following packages (Fedora 19)::
 


### PR DESCRIPTION
From Fedora 23 the repositories are accessible through "dnf" in stead of "yum". 1 small correction to a readme to show the diff.