### PR TITLE
Now use spawn_sync from newer versions of VTE

### DIFF
--- a/guake/gtk3test.py
+++ b/guake/gtk3test.py
@@ -40,7 +40,7 @@ class MyWindow(Gtk.Window):
         Gtk.Window.__init__(self, title="Hello World")
 
         terminal = Terminal()
-        terminal.fork_command_full(
+        terminal.spawn_sync(
             Vte.PtyFlags.DEFAULT,
             os.environ['HOME'],
             ["/bin/bash"],

--- a/guake/test_terminal.py
+++ b/guake/test_terminal.py
@@ -22,7 +22,7 @@ def test():
     terminal = Vte.Terminal()
     print("terminal: %s", dir(terminal))
 
-    terminal.fork_command_full(
+    terminal.spawn_sync(
         Vte.PtyFlags.DEFAULT,
         os.environ['HOME'],
         ["/bin/bash"],


### PR DESCRIPTION
I was giving a try at the gtk3 version of guake (not on branch gtk3, how odd), and I couldn't because of newer version of VTE renamed `fork_command_full`.