### PR TITLE
Add option for paste on right-click #713

### DIFF
--- a/data/prefs.glade
+++ b/data/prefs.glade
@@ -144,7 +144,7 @@
                                   <widget class="GtkTable" id="table5">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
-                                    <property name="n_rows">4</property>
+                                    <property name="n_rows">5</property>
                                     <property name="n_columns">2</property>
                                     <child>
                                       <widget class="GtkEntry" id="startup_script">
@@ -175,6 +175,21 @@ guake -r "prod" -e "cd ~/projects/myproject/prod"
                                         <property name="right_attach">2</property>
                                         <property name="top_attach">3</property>
                                         <property name="bottom_attach">4</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <widget class="GtkCheckButton" id="paste_on_rclick">
+                                        <property name="label" translatable="yes">Paste on right click (Ctrl+RClick for ctx menu)</property>
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                        <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+                                        <property name="draw_indicator">True</property>
+                                        <signal name="toggled" handler="on_paste_on_rclick_toggled" swapped="no"/>
+                                      </widget>
+                                      <packing>
+                                        <property name="top_attach">4</property>
+                                        <property name="bottom_attach">5</property>
                                       </packing>
                                     </child>
                                     <child>

--- a/src/guake/prefs.py
+++ b/src/guake/prefs.py
@@ -198,6 +198,11 @@ class PrefsCallbacks(object):
         """
         self.client.set_bool(KEY('/general/use_trayicon'), chk.get_active())
 
+    def on_paste_on_rclick_toggled(self, chk):
+        """Changes the activity of paste_on_rclick in gconf
+        """
+        self.client.set_bool(KEY('/general/paste_on_rclick'), chk.get_active())
+
     def on_use_popup_toggled(self, chk):
         """Changes the activity of use_popup in gconf
         """
@@ -718,6 +723,10 @@ class PrefsDialog(SimpleGladeApp):
         # tray icon
         value = self.client.get_bool(KEY('/general/use_trayicon'))
         self.get_widget('use_trayicon').set_active(value)
+
+        # paste_on_rclick
+        value = self.client.get_bool(KEY('/general/paste_on_rclick'))
+        self.get_widget('paste_on_rclick').set_active(value)
 
         # popup
         value = self.client.get_bool(KEY('/general/use_popup'))


### PR DESCRIPTION
Adds an option in the preferences to enable pasting on right-click. The context menu can still be accessed via a ctrl+right-click.
