### PR TITLE
Use default value for Unity icon-size if it is not present in dconf

### DIFF
--- a/src/guake/guake_app.py
+++ b/src/guake/guake_app.py
@@ -955,7 +955,7 @@ class Guake(SimpleGladeApp):
                          '/org/compiz/profiles/unity/plugins/unityshell/launcher-hide-mode']))
                     unity_dock = int(subprocess.check_output(
                         ['/usr/bin/dconf', 'read',
-                         '/org/compiz/profiles/unity/plugins/unityshell/icon-size']))
+                         '/org/compiz/profiles/unity/plugins/unityshell/icon-size']) or "48")
                     found = True
                 except:
                     # in case of error, just ignore it, 'found' will not be set to True and so


### PR DESCRIPTION
If Unity icon size was never changed, dconf property `/org/compiz/profiles/unity/plugins/unityshell/icon-size` is absent. This causes `int()` call to throw an exception and `found` will be `False` even though it should be `True`.