### PR TITLE
New uuid related dbus functions in dbusiface.py

### DIFF
--- a/src/guake/dbusiface.py
+++ b/src/guake/dbusiface.py
@@ -66,7 +66,7 @@ class DbusManager(dbus.service.Object):
 
     @dbus.service.method(DBUS_NAME, in_signature='s')
     def add_tab(self, directory=''):
-        self.guake.add_tab(directory)
+        return self.guake.add_tab(directory)
 
     @dbus.service.method(DBUS_NAME, in_signature='i')
     def select_tab(self, tab_index=0):
@@ -123,3 +123,11 @@ class DbusManager(dbus.service.Object):
     @dbus.service.method(DBUS_NAME, in_signature='i', out_signature='s')
     def get_gtktab_name(self, tab_index=0):
         return self.guake.tabs.get_children()[tab_index].get_label()
+
+    @dbus.service.method(DBUS_NAME, out_signature='s')
+    def get_selected_uuidtab(self):
+        return self.guake.get_selected_uuidtab()
+
+    @dbus.service.method(DBUS_NAME, in_signature='ss')
+    def execute_command_by_uuid(self, tab_uuid, command):
+        self.guake.execute_command_by_uuid(tab_uuid,command)

--- a/src/guake/guake_app.py
+++ b/src/guake/guake_app.py
@@ -542,6 +542,22 @@ class Guake(SimpleGladeApp):
             terminal.feed_child(command)
             break
 
+    def execute_command_by_uuid(self,tab_uuid,command):
+        """Execute the `command' in the tab whose terminal has the `tab_uuid' uuid
+        """
+        if command[-1] != '\n':
+            command += '\n'
+        try:
+            tab_uuid = uuid.UUID(tab_uuid)
+            tab_index, = (index for index, t in enumerate(self.notebook.iter_terminals()) if t.get_uuid() == tab_uuid)
+            tab = self.tabs.get_children()[tab_index]
+        except ValueError:
+            pass
+        else:
+            terminals = self.notebook.get_terminals_for_tab(tab_index)
+            for current_vte in terminals:
+                current_vte.feed_child(command);
+
     def on_resizer_drag(self, widget, event):
         """Method that handles the resize drag. It does not actuall
         moves the main window. It just set the new window size in
@@ -1627,6 +1643,8 @@ class Guake(SimpleGladeApp):
         if self.is_fullscreen:
             self.fullscreen()
 
+        return str(box.terminal.get_uuid());
+
     def save_tab(self, directory=None):
         self.preventHide = True
         current_term = self.notebook.get_current_terminal()
@@ -1755,6 +1773,13 @@ class Guake(SimpleGladeApp):
         pos = self.get_selected_tab()
         self.select_tab(0)
         self.select_tab(pos)
+
+    def get_selected_uuidtab(self):
+        """Returns the uuid of the current selected terminal
+        """
+        pagepos = self.notebook.get_current_page()
+        terminals = self.notebook.get_terminals_for_tab(pagepos)
+        return str(terminals[0].get_uuid());
 
     def select_current_tab(self, notebook, user_data, page):
         """When current self.notebook page is changed, the tab bar


### PR DESCRIPTION
I'd like to propose this pull request for a better Guake indicator integration (http://guake-indicator.ozzyboshi.com/).
Taking advantage of the UUIDs, Guake indicator can now track down the Guake tabs and virtual terminals even if the user moves or rearrange them in different orders, so a merge of this code would be very helpful for my project but also for anyone who wants to control Guake remotely.

This is a short summary of the changes I made:
  - The add_tab dbus function now returns the uuid of the newly created tab
  - The new get_selected_uuidtab dbus function returns the uuid of the currently selected terminal
  - The new execute_command_by_uuid function lets you execute a command in a terminal previously selected by his uuid

In order to build the get_selected_uuidtab and execute_command_by_uuid functions, two new intance methods on the main Guake class with the same name were added on guake_app.py.
The add_tab Guake instance method now returns the uuid created in order to feed add_tab dbus function.

