### PR TITLE
Shorter "Open Link" menu

### DIFF
--- a/src/guake/guake_app.py
+++ b/src/guake/guake_app.py
@@ -646,7 +646,7 @@ class Guake(SimpleGladeApp):
         link = self.getCurrentTerminalLinkUnderCursor()
         if link:
             self.get_widget('context_browse_on_web').set_visible(True)
-            self.get_widget('context_browse_on_web').set_label(_("Open Link: {}".format(link)))
+            self.get_widget('context_browse_on_web').set_label(_("Open Link: '{}...'".format(link[:25])))
             self.get_widget('separator_search').set_visible(True)
         else:
             self.get_widget('context_browse_on_web').set_label(_("Open Link..."))

--- a/src/guake/guake_app.py
+++ b/src/guake/guake_app.py
@@ -646,7 +646,10 @@ class Guake(SimpleGladeApp):
         link = self.getCurrentTerminalLinkUnderCursor()
         if link:
             self.get_widget('context_browse_on_web').set_visible(True)
-            self.get_widget('context_browse_on_web').set_label(_("Open Link: '{}...'".format(link[:25])))
+            if len(link) >= 28:
+                self.get_widget('context_browse_on_web').set_label(_("Open Link: '{}...'".format(link[:25])))
+            else:
+                self.get_widget('context_browse_on_web').set_label(_("Open Link: {}".format(link)))
             self.get_widget('separator_search').set_visible(True)
         else:
             self.get_widget('context_browse_on_web').set_label(_("Open Link..."))


### PR DESCRIPTION
Long URL cause right click menu is very ugly.
We should make URL shorter, only need display 25 first characters.

### Screenshots
#### Now
![Original](http://i.imgur.com/Q28voAn.png)
#### After
![Patched](http://i.imgur.com/ThlHni8.png)