### PR TITLE
fix fullscreen follow mouse

### DIFF
--- a/src/guake/guake_app.py
+++ b/src/guake/guake_app.py
@@ -784,8 +784,7 @@ class Guake(SimpleGladeApp):
         self.hidden = False
 
         # setting window in all desktops
-        if not self.is_fullscreen:
-            window_rect = self.set_final_window_rect()
+        window_rect = self.set_final_window_rect()
         self.get_widget('window-root').stick()
 
         # add tab must be called before window.show to avoid a
@@ -806,9 +805,11 @@ class Guake(SimpleGladeApp):
                 if isinstance(tab, gtk.RadioButton):
                     tab.modify_bg(gtk.STATE_ACTIVE, gtk.gdk.Color(str(self.selected_color)))
 
+        # move the window even when in fullscreen-mode
+        self.window.move(window_rect.x, window_rect.y)
+
         # this work arround an issue in fluxbox
         if not self.is_fullscreen:
-            self.window.move(window_rect.x, window_rect.y)
             self.client.notify(KEY('/general/window_height'))
 
         try:


### PR DESCRIPTION
i noticed that when in full-screen-mode the window doesn't follow the mouse. i don't know if this is intended behavior or a bug. seems to me that if you want to fix Guake to a specific monitor you can set that up in the config.

to change the behavior i had to change something in a part which had a comment about a work-around for an issue in fluxbox, i don't have fluxbox so i wasn't able to test any regressions there.

please let me know if this is an OK way to make the full-screen-mode follow the mouse