### PR TITLE
Fixing 'resizer' position in tabs-on-top mode and resizing while bottom-aligned

### DIFF
--- a/src/guake/gconfhandler.py
+++ b/src/guake/gconfhandler.py
@@ -145,6 +145,7 @@ class GConfHandler(object):
         be called and will call the move function in guake.
         """
         self.guake.set_final_window_rect()
+        self.guake.set_tab_position()
 
     def size_changed(self, client, connection_id, entry, data):
         """If the gconf var window_height or window_width are changed,

--- a/src/guake/guake_app.py
+++ b/src/guake/guake_app.py
@@ -567,15 +567,24 @@ class Guake(SimpleGladeApp):
         screen = self.window.get_screen()
         x, y, _ = screen.get_root_window().get_pointer()
         screen_no = screen.get_monitor_at_point(x, y)
-
+        valignment = self.client.get_int(KEY('/general/window_valignment'))
+        
         max_height = screen.get_monitor_geometry(screen_no).height
-        percent = y / (max_height / 100)
+        if valignment == ALIGN_BOTTOM:
+            percent = 100 * (max_height - y) / max_height
+        else:
+            percent = 100 * y / max_height
 
         if percent < 1:
             percent = 1
 
         window_rect = self.window.get_size()
-        self.window.resize(window_rect[0], y)
+        window_pos = self.window.get_position()
+        if valignment == ALIGN_BOTTOM:
+            self.window.resize(window_rect[0], max_height-y)
+            self.window.move(window_pos[0], y)
+        else:
+            self.window.resize(window_rect[0], y)
         self.client.set_int(KEY('/general/window_height'), int(percent))
         self.client.set_float(KEY('/general/window_height_f'), float(percent))
 
@@ -1839,7 +1848,14 @@ class Guake(SimpleGladeApp):
             self.mainframe.reorder_child(self.notebook, 2)
         else:
             self.mainframe.reorder_child(self.notebook, 0)
-        self.mainframe.pack_start(self.notebook, expand=True, fill=True, padding=0)
+
+        # make sure resizer is at right position depending on window alignment
+        if self.client.get_int(KEY('/general/window_valignment')) == ALIGN_BOTTOM:
+            self.mainframe.reorder_child(self.resizer, 0)
+        else:
+            self.mainframe.reorder_child(self.resizer, -1)
+
+        # self.mainframe.pack_start(self.notebook, expand=True, fill=True, padding=0)
 
     def reset_terminal(self, directory=None):
         self.preventHide = True


### PR DESCRIPTION
Hello,
I noticed that the little resizer handle will not be at the bottom when you switch the tab-bar to the top, and also that the window will not behave correctly when resizing it while bottom-aligned. I wrote some quick fixes, although they could be better.
I still get some flickering on bottom-align resize because something tries to adjust for my taskbar... and the code to always push the resizer element to the bottom might be better of in a small helper function on its own instead of in set_tab_position.
(With a little more polish, maybe) this would fix issue #723 and 2nd/3rd point of issue #382.