### PR TITLE
Fix #636 by killing preview terminal

### DIFF
--- a/src/guake/guake_notebook.py
+++ b/src/guake/guake_notebook.py
@@ -5,11 +5,8 @@ from __future__ import print_function
 import logging
 import os
 import posix
-import signal
 
 from gtk import Notebook
-from thread import start_new_thread
-from time import sleep
 
 log = logging.getLogger(__name__)
 
@@ -75,48 +72,13 @@ class GuakeNotebook(Notebook):
 
     def delete_tab(self, pagepos, kill=True):
         for terminal in self.get_terminals_for_tab(pagepos):
-            pid = terminal.get_pid()
             if kill:
-                start_new_thread(self.delete_shell, (pid,))
+                terminal.kill()
 
             terminal.destroy()
 
         self.remove_page(pagepos)
         self.term_list.pop(pagepos)
-
-    def delete_shell(self, pid):
-        """This function will kill the shell on a tab, trying to send
-        a sigterm and if it doesn't work, a sigkill. Between these two
-        signals, we have a timeout of 3 seconds, so is recommended to
-        call this in another thread. This doesn't change any thing in
-        UI, so you can use python's start_new_thread.
-        """
-        try:
-            os.kill(pid, signal.SIGHUP)
-        except OSError:
-            pass
-        num_tries = 30
-
-        while num_tries > 0:
-            try:
-                # Try to wait for the pid to be closed. If it does not
-                # exist anymore, an OSError is raised and we can
-                # safely ignore it.
-                if os.waitpid(pid, os.WNOHANG)[0] != 0:
-                    break
-            except OSError:
-                break
-            sleep(0.1)
-            num_tries -= 1
-
-        if num_tries == 0:
-            try:
-                os.kill(pid, signal.SIGKILL)
-                os.waitpid(pid, 0)
-            except OSError:
-                # if this part of code was reached, means that SIGTERM
-                # did the work and SIGKILL wasnt needed.
-                pass
 
     def append_tab(self, terminal):
         self.term_list.append(terminal)

--- a/src/guake/prefs.py
+++ b/src/guake/prefs.py
@@ -443,6 +443,9 @@ class PrefsDialog(SimpleGladeApp):
 
         self.client = gconf.client_get_default()
 
+        # window cleanup handler
+        self.get_widget('config-window').connect('destroy', self.on_destroy)
+
         # setting evtbox title bg
         eventbox = self.get_widget('eventbox-title')
         eventbox.modify_bg(gtk.STATE_NORMAL,
@@ -521,6 +524,10 @@ class PrefsDialog(SimpleGladeApp):
         """Calls the main window hide function.
         """
         self.get_widget('config-window').hide()
+
+    def on_destroy(self, window):
+        self.demo_terminal.kill()
+        self.demo_terminal.destroy()
 
     def update_preview(self, file_chooser, preview):
         """Used by filechooser to preview image files

--- a/src/guake/terminal.py
+++ b/src/guake/terminal.py
@@ -28,6 +28,7 @@ import logging
 import os
 import pango
 import re
+import signal
 import subprocess
 import uuid
 import vte
@@ -35,6 +36,8 @@ import vte
 
 from guake.common import clamp
 from guake.globals import KEY
+from thread import start_new_thread
+from time import sleep
 
 log = logging.getLogger(__name__)
 
@@ -268,6 +271,44 @@ class GuakeTerminal(vte.Terminal):
 
     def decrease_font_size(self):
         self.font_scale -= 1
+
+    def kill(self):
+        pid = self.get_pid()
+        start_new_thread(self.delete_shell, (pid,))
+
+    def delete_shell(self, pid):
+        """This function will kill the shell on a tab, trying to send
+        a sigterm and if it doesn't work, a sigkill. Between these two
+        signals, we have a timeout of 3 seconds, so is recommended to
+        call this in another thread. This doesn't change any thing in
+        UI, so you can use python's start_new_thread.
+        """
+        try:
+            os.kill(pid, signal.SIGHUP)
+        except OSError:
+            pass
+        num_tries = 30
+
+        while num_tries > 0:
+            try:
+                # Try to wait for the pid to be closed. If it does not
+                # exist anymore, an OSError is raised and we can
+                # safely ignore it.
+                if os.waitpid(pid, os.WNOHANG)[0] != 0:
+                    break
+            except OSError:
+                break
+            sleep(0.1)
+            num_tries -= 1
+
+        if num_tries == 0:
+            try:
+                os.kill(pid, signal.SIGKILL)
+                os.waitpid(pid, 0)
+            except OSError:
+                # if this part of code was reached, means that SIGTERM
+                # did the work and SIGKILL wasnt needed.
+                pass
 
 
 class GuakeTerminalBox(gtk.HBox):


### PR DESCRIPTION
Fixes #636.

The issue lies in the terminal preview embedded in the preferences window. Even when the terminal was destroyed, in certain situations the shell process did not. This was especially true when the shell process was something that expected to be long-lived, like tmux.

This fixes the issue by ensuring that the shell process is killed whenever the preferences window is destroyed.