### PR TITLE
Fix the bottom of tab buttons being cut off in Gnome

### DIFF
--- a/data/guake.glade
+++ b/data/guake.glade
@@ -427,7 +427,6 @@
                 <property name="vscrollbar_policy">never</property>
                 <child>
                   <widget class="GtkViewport" id="tabs-viewport">
-                    <property name="height_request">10</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="shadow_type">none</property>


### PR DESCRIPTION
A simple patch that fixes #666 by removing the explicit height request from `tabs-viewport`.

This is the result of this change for me:
* Without scrollbar: ![image](https://cloud.githubusercontent.com/assets/5624721/17408847/c30d5f6c-5a3a-11e6-93fe-62a9c94d7cda.png)
* With scrollbar:
![image](https://cloud.githubusercontent.com/assets/5624721/17409058/8ea23544-5a3b-11e6-971d-094c6aa5456f.png)

I'm not sure if this will have any unintended side effects on other desktops.