### PR TITLE
Abbreviate tab names

### DIFF
--- a/data/guake.glade
+++ b/data/guake.glade
@@ -432,6 +432,7 @@
                     <property name="shadow_type">none</property>
                     <child>
                       <widget class="GtkEventBox" id="event-tabs">
+                        <property name="height_request">10</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="events">GDK_BUTTON_PRESS_MASK | GDK_STRUCTURE_MASK</property>

--- a/data/prefs.glade
+++ b/data/prefs.glade
@@ -524,6 +524,7 @@ Always</property>
                                         <property name="active">True</property>
                                         <property name="draw_indicator">True</property>
                                         <signal name="toggled" handler="on_use_vte_titles_toggled" swapped="no"/>
+                                        <signal name="toggled" handler="toggle_use_vte_titles" swapped="no"/>
                                       </widget>
                                       <packing>
                                         <property name="expand">False</property>
@@ -532,12 +533,28 @@ Always</property>
                                       </packing>
                                     </child>
                                     <child>
+                                      <widget class="GtkCheckButton" id="abbreviate_tab_names">
+                                        <property name="label" translatable="yes">Abbreviate directories in tab names</property>
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                        <property name="use_underline">True</property>
+                                        <property name="active">True</property>
+                                        <property name="draw_indicator">True</property>
+                                        <signal name="toggled" handler="on_abbreviate_tab_names_toggled" swapped="no"/>
+                                      </widget>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">False</property>
+                                        <property name="position">2</property>
+                                      </packing>
+                                    </child>
+                                    <child>
                                       <widget class="GtkHBox" id="hbox_max_tab_name_length">
                                         <property name="visible">True</property>
                                         <property name="can_focus">False</property>
                                         <child>
                                           <widget class="GtkLabel" id="lbl_max_tab_name_length">
-                                            <property name="width_request">160</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
                                             <property name="xalign">0</property>
@@ -574,7 +591,7 @@ Always</property>
                                       <packing>
                                         <property name="expand">True</property>
                                         <property name="fill">True</property>
-                                        <property name="position">2</property>
+                                        <property name="position">3</property>
                                       </packing>
                                     </child>
                                     <child>

--- a/po/ca.po
+++ b/po/ca.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Guake 0.4.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-12-01 16:49+0100\n"
+"POT-Creation-Date: 2016-08-17 21:41+0000\n"
 "PO-Revision-Date: 2013-03-07 07:41+0000\n"
 "Last-Translator: Raül Cambeiro <xrulet@gmail.com>\n"
 "Language-Team: Catalan (http://www.transifex.com/projects/p/guake/language/"
@@ -101,7 +101,7 @@ msgstr "Copia"
 msgid "Paste"
 msgstr "Enganxa"
 
-#: ../data/guake.glade.h:3
+#: ../data/guake.glade.h:3 ../src/guake/prefs.py:79
 msgid "Toggle Fullscreen"
 msgstr "Commuta la pantalla completa"
 
@@ -109,7 +109,7 @@ msgstr "Commuta la pantalla completa"
 msgid "Save to File..."
 msgstr ""
 
-#: ../data/guake.glade.h:5
+#: ../data/guake.glade.h:5 ../src/guake/prefs.py:85
 #, fuzzy
 msgid "Reset terminal"
 msgstr "Terminal Guake"
@@ -140,7 +140,7 @@ msgstr ""
 msgid "Search on Web"
 msgstr ""
 
-#: ../data/guake.glade.h:12
+#: ../data/guake.glade.h:12 ../src/guake/prefs.py:83
 msgid "Quit"
 msgstr "Surt"
 
@@ -266,202 +266,206 @@ msgid "Use VTE titles for tab names"
 msgstr ""
 
 #: ../data/prefs.glade.h:33
-msgid "Max tab name length:"
+msgid "Abbreviate directories in tab names"
 msgstr ""
 
 #: ../data/prefs.glade.h:34
+msgid "Max tab name length:"
+msgstr ""
+
+#: ../data/prefs.glade.h:35
 msgid "Hide on lose focus"
 msgstr "Amaga-la en perdre el focus"
 
-#: ../data/prefs.glade.h:35
+#: ../data/prefs.glade.h:36
 msgid "Show tab bar"
 msgstr "Mostra la barra de pestanyes"
 
-#: ../data/prefs.glade.h:36
+#: ../data/prefs.glade.h:37
 #, fuzzy
 msgid "Start fullscreen"
 msgstr "Commuta la pantalla completa"
 
-#: ../data/prefs.glade.h:37
+#: ../data/prefs.glade.h:38
 msgid "<b>Main Window</b>"
 msgstr "<b>Finestra principal</b>"
 
-#: ../data/prefs.glade.h:38
+#: ../data/prefs.glade.h:39
 msgid "Left"
 msgstr ""
 
-#: ../data/prefs.glade.h:39
+#: ../data/prefs.glade.h:40
 msgid "Center"
 msgstr ""
 
-#: ../data/prefs.glade.h:40
+#: ../data/prefs.glade.h:41
 msgid "Right"
 msgstr ""
 
-#: ../data/prefs.glade.h:41
+#: ../data/prefs.glade.h:42
 #, fuzzy
 msgid "<b>Main Window Horizontal Alignment</b>"
 msgstr "<b>Alçària de la finestra principal</b>"
 
-#: ../data/prefs.glade.h:42
+#: ../data/prefs.glade.h:43
 #, fuzzy
 msgid "<b>Main Window Height</b>"
 msgstr "<b>Alçària de la finestra principal</b>"
 
-#: ../data/prefs.glade.h:43
+#: ../data/prefs.glade.h:44
 #, fuzzy
 msgid "<b>Main Window Width</b>"
 msgstr "<b>Alçària de la finestra principal</b>"
 
-#: ../data/prefs.glade.h:44
+#: ../data/prefs.glade.h:45
 msgid "Custom command file path: "
 msgstr ""
 
-#: ../data/prefs.glade.h:45
+#: ../data/prefs.glade.h:46
 msgid "Please select a json file"
 msgstr ""
 
-#: ../data/prefs.glade.h:46
+#: ../data/prefs.glade.h:47 ../src/guake/prefs.py:75
 msgid "General"
 msgstr "General"
 
-#: ../data/prefs.glade.h:47
+#: ../data/prefs.glade.h:48
 msgid "Default interpreter:"
 msgstr "Intèrpret per defecte:"
 
-#: ../data/prefs.glade.h:48
+#: ../data/prefs.glade.h:49
 msgid "_Run command as a login shell"
 msgstr "_Executa una ordre com a intèrpret d'inici de sessió"
 
-#: ../data/prefs.glade.h:49
+#: ../data/prefs.glade.h:50
 msgid "_Open new tab in current directory"
 msgstr "_Obre les pestanyes noves en el directori actual"
 
-#: ../data/prefs.glade.h:50
+#: ../data/prefs.glade.h:51
 msgid "<b>Shell</b>"
 msgstr "<b>Intèrpret d'ordres</b>"
 
-#: ../data/prefs.glade.h:51
+#: ../data/prefs.glade.h:52
 msgid "Shell"
 msgstr ""
 
-#: ../data/prefs.glade.h:52
+#: ../data/prefs.glade.h:53
 msgid "Show scrollbar"
 msgstr "Mostra la barra de desplaçament"
 
-#: ../data/prefs.glade.h:53
+#: ../data/prefs.glade.h:54
 msgid "Scrollback lines:"
 msgstr "Línies emmagatzemades:"
 
-#: ../data/prefs.glade.h:54
+#: ../data/prefs.glade.h:55
 msgid "On output"
 msgstr "Segons la sortida"
 
-#: ../data/prefs.glade.h:55
+#: ../data/prefs.glade.h:56
 msgid "On key stroke"
 msgstr "En prémer una tecla"
 
-#: ../data/prefs.glade.h:56
+#: ../data/prefs.glade.h:57
 msgid "<b>Scroll</b>"
 msgstr "<b>Desplaçament</b>"
 
-#: ../data/prefs.glade.h:57
+#: ../data/prefs.glade.h:58
 msgid "Scrolling"
 msgstr "Desplaçament"
 
-#: ../data/prefs.glade.h:58
+#: ../data/prefs.glade.h:59
 msgid "Use the system fixed width font"
 msgstr "Utilitza el tipus de lletra d'amplada fixa del sistema"
 
-#: ../data/prefs.glade.h:59
+#: ../data/prefs.glade.h:60
 msgid "Font:"
 msgstr "Tipus de lletra:"
 
-#: ../data/prefs.glade.h:60
+#: ../data/prefs.glade.h:61
 msgid "Choose some font"
 msgstr "Trieu el tipus de lletra"
 
-#: ../data/prefs.glade.h:61
+#: ../data/prefs.glade.h:62
 msgid "Text color:"
 msgstr "Color del text:"
 
-#: ../data/prefs.glade.h:62
+#: ../data/prefs.glade.h:63
 msgid "Background color:"
 msgstr "Color de fons:"
 
-#: ../data/prefs.glade.h:63
+#: ../data/prefs.glade.h:64
 msgid "Cursor shape:"
 msgstr ""
 
-#: ../data/prefs.glade.h:64
+#: ../data/prefs.glade.h:65
 msgid ""
 "Block\n"
 "I-Beam\n"
 "Underline"
 msgstr ""
 
-#: ../data/prefs.glade.h:67
+#: ../data/prefs.glade.h:68
 msgid ""
 "Follow GTK+ setting\n"
 "Blink on\n"
 "Blink off"
 msgstr ""
 
-#: ../data/prefs.glade.h:70
+#: ../data/prefs.glade.h:71
 msgid "Cursor blink mode:"
 msgstr ""
 
-#: ../data/prefs.glade.h:71
+#: ../data/prefs.glade.h:72
 msgid "Allow bold font"
 msgstr ""
 
-#: ../data/prefs.glade.h:72
+#: ../data/prefs.glade.h:73
 msgid "<b>Palette</b>"
 msgstr "<b>Paleta</b>"
 
-#: ../data/prefs.glade.h:73
+#: ../data/prefs.glade.h:74
 msgid "Built-in schemes:"
 msgstr "Esquemes integrats:"
 
-#: ../data/prefs.glade.h:74
+#: ../data/prefs.glade.h:75
 msgid "Color palette:"
 msgstr "Paleta de colors:"
 
-#: ../data/prefs.glade.h:75
+#: ../data/prefs.glade.h:76
 #, fuzzy
 msgid "Font color"
 msgstr "Color del text:"
 
-#: ../data/prefs.glade.h:76
+#: ../data/prefs.glade.h:77
 #, fuzzy
 msgid "Background color"
 msgstr "Color de fons:"
 
-#: ../data/prefs.glade.h:77
+#: ../data/prefs.glade.h:78
 msgid "Use font and background color from the palette"
 msgstr ""
 
-#: ../data/prefs.glade.h:78
+#: ../data/prefs.glade.h:79
 msgid "Demo:"
 msgstr ""
 
-#: ../data/prefs.glade.h:79
+#: ../data/prefs.glade.h:80
 msgid "<b>Effects</b>"
 msgstr "<b>Efectes</b>"
 
-#: ../data/prefs.glade.h:80
+#: ../data/prefs.glade.h:81
 msgid "Transparency:"
 msgstr "Transparència:"
 
-#: ../data/prefs.glade.h:81
+#: ../data/prefs.glade.h:82
 msgid "Background image:"
 msgstr "Imatge de fons:"
 
-#: ../data/prefs.glade.h:82
+#: ../data/prefs.glade.h:83 ../src/guake/prefs.py:130
 msgid "Appearance"
 msgstr "Aparença"
 
-#: ../data/prefs.glade.h:83
+#: ../data/prefs.glade.h:84
 msgid ""
 "<small>Quick open is a feature allowing you to open a file directly into "
 "your favorite text editor by clicking on its filename when it appears in "
@@ -469,15 +473,15 @@ msgid ""
 "extract filename below.</small>"
 msgstr ""
 
-#: ../data/prefs.glade.h:84
+#: ../data/prefs.glade.h:85
 msgid "Enable Quick Open when Ctrl+clicking on a filename in the terminal"
 msgstr ""
 
-#: ../data/prefs.glade.h:85
+#: ../data/prefs.glade.h:86
 msgid "Editor command line:"
 msgstr ""
 
-#: ../data/prefs.glade.h:87
+#: ../data/prefs.glade.h:88
 #, no-c-format
 msgid ""
 "<small><i>Use the following elements in the open editor command line:\n"
@@ -489,36 +493,36 @@ msgid ""
 "</i></small>"
 msgstr ""
 
-#: ../data/prefs.glade.h:93
+#: ../data/prefs.glade.h:94
 msgid "Quick open in current terminal"
 msgstr ""
 
-#: ../data/prefs.glade.h:94
+#: ../data/prefs.glade.h:95
 msgid ""
 "Here is the list of supported patterns: (to add your own, please contact the "
 "Guake's authors)"
 msgstr ""
 
-#: ../data/prefs.glade.h:95
+#: ../data/prefs.glade.h:96
 #, fuzzy
 msgid "<b>Quick Open</b>"
 msgstr "<b>Paleta</b>"
 
-#: ../data/prefs.glade.h:96
+#: ../data/prefs.glade.h:97
 msgid "Quick Open"
 msgstr ""
 
-#: ../data/prefs.glade.h:97
+#: ../data/prefs.glade.h:98
 msgid ""
 "To change a shortcut simply click on its name.\n"
 "To disable a shortcut, press the \"Backspace\" key."
 msgstr ""
 
-#: ../data/prefs.glade.h:99
+#: ../data/prefs.glade.h:100
 msgid "Keyboard shortcuts"
 msgstr "Dreceres de teclat"
 
-#: ../data/prefs.glade.h:100
+#: ../data/prefs.glade.h:101
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -530,7 +534,7 @@ msgstr ""
 "d'aquelles aplicacions i sistemes operatius que esperen un comportament "
 "diferent del terminal.</i></small>"
 
-#: ../data/prefs.glade.h:101
+#: ../data/prefs.glade.h:102
 msgid ""
 "ASCII DEL\n"
 "Escape sequence\n"
@@ -540,38 +544,37 @@ msgstr ""
 "Seqüència d'escapament\n"
 "Control-H"
 
-#: ../data/prefs.glade.h:104
+#: ../data/prefs.glade.h:105
 msgid "_Backspace key generates:"
 msgstr "La tecla de _retrocés genera:"
 
-#: ../data/prefs.glade.h:105
+#: ../data/prefs.glade.h:106
 msgid "_Delete key generates:"
 msgstr "La tecla de _supressió genera:"
 
-#: ../data/prefs.glade.h:106
+#: ../data/prefs.glade.h:107
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "Reinicia les _opcions de compatibilitat als valors predeterminats"
 
-#: ../data/prefs.glade.h:107
+#: ../data/prefs.glade.h:108
 msgid "<b>Keyboard compatibility</b>"
 msgstr "<b>Compatibilitat del teclat</b>"
 
-#: ../data/prefs.glade.h:108
+#: ../data/prefs.glade.h:109
 msgid "Compatibility"
 msgstr "Compatibilitat"
 
-#: ../src/guake/about.py:47 ../src/guake/gconfhandler.py:427
-#: ../src/guake/guake_app.py:177 ../src/guake/guake_app.py:348
+#: ../src/guake/about.py:47 ../src/guake/gconfhandler.py:435
+#: ../src/guake/guake_app.py:181 ../src/guake/guake_app.py:376
 msgid "Guake Terminal"
 msgstr "Terminal Guake"
 
-#. Adding a new radio button to the tabbar
-#: ../src/guake/gconfhandler.py:365 ../src/guake/guake_app.py:1548
+#: ../src/guake/gconfhandler.py:368 ../src/guake/guake_app.py:1363
 #, fuzzy
 msgid "Terminal"
 msgstr "Terminal %s"
 
-#: ../src/guake/gconfhandler.py:428
+#: ../src/guake/gconfhandler.py:436
 #, python-format
 msgid ""
 "A problem happened when binding <b>%s</b> key.\n"
@@ -581,54 +584,54 @@ msgstr ""
 "Empreu la finestra Preferències del Guake per triar una altra tecla (la "
 "icona de la safata era habilitada)."
 
-#: ../src/guake/guake_app.py:128
+#: ../src/guake/guake_app.py:132
 #, fuzzy
 msgid "Do you want to close the tab?"
 msgstr "De debò voleu sortir del Guake?"
 
-#: ../src/guake/guake_app.py:131
+#: ../src/guake/guake_app.py:135
 #, fuzzy
 msgid "Do you really want to quit Guake?"
 msgstr "De debò voleu sortir del Guake?"
 
-#: ../src/guake/guake_app.py:133
+#: ../src/guake/guake_app.py:137
 #, fuzzy
 msgid " and one tab open"
 msgstr "Afegeix una pestanya nova"
 
-#: ../src/guake/guake_app.py:135
+#: ../src/guake/guake_app.py:139
 #, python-brace-format
 msgid " and {0} tabs open"
 msgstr ""
 
-#: ../src/guake/guake_app.py:138
+#: ../src/guake/guake_app.py:142
 #, fuzzy
 msgid "There are no processes running"
 msgstr "<b>Encara hi ha un procés en execució.</b>"
 
-#: ../src/guake/guake_app.py:140
+#: ../src/guake/guake_app.py:144
 #, fuzzy
 msgid "There is a process still running"
 msgstr "<b>Encara hi ha un procés en execució.</b>"
 
-#: ../src/guake/guake_app.py:142
+#: ../src/guake/guake_app.py:146
 #, fuzzy, python-brace-format
 msgid "There are {0} processes still running"
 msgstr "<b>Encara hi ha %d processos en execució.</b>"
 
-#: ../src/guake/guake_app.py:182
+#: ../src/guake/guake_app.py:186
 msgid "guake-indicator"
 msgstr ""
 
-#: ../src/guake/guake_app.py:182
+#: ../src/guake/guake_app.py:186
 msgid "guake-tray"
 msgstr ""
 
-#: ../src/guake/guake_app.py:186
+#: ../src/guake/guake_app.py:190
 msgid "Show"
 msgstr ""
 
-#: ../src/guake/guake_app.py:349
+#: ../src/guake/guake_app.py:377
 #, python-format
 msgid ""
 "Guake is now running,\n"
@@ -637,129 +640,133 @@ msgstr ""
 "El Guake està en execució,\n"
 "premeu <b>%s</b> per fer-lo servir."
 
-#: ../src/guake/guake_app.py:611
+#: ../src/guake/guake_app.py:665
 #, python-format
 msgid "Search on Web: '%s'"
 msgstr ""
 
-#: ../src/guake/guake_app.py:616
+#: ../src/guake/guake_app.py:670
 msgid "Search on Web (no selection)"
 msgstr ""
 
-#: ../src/guake/guake_app.py:622
+#: ../src/guake/guake_app.py:678
+msgid "Open Link: '{}...'"
+msgstr ""
+
+#: ../src/guake/guake_app.py:680
 msgid "Open Link: {}"
 msgstr ""
 
-#: ../src/guake/guake_app.py:625
+#: ../src/guake/guake_app.py:683
 msgid "Open Link..."
 msgstr ""
 
-#: ../src/guake/guake_app.py:1300
+#: ../src/guake/guake_app.py:1402
 msgid "Rename tab"
 msgstr "Canvia el nom de la pestanya"
 
-#: ../src/guake/guake_app.py:1591
+#: ../src/guake/guake_app.py:1716
 msgid "Save to..."
 msgstr ""
 
-#: ../src/guake/guake_app.py:1598 ../src/guake/prefs.py:930
+#: ../src/guake/guake_app.py:1723 ../src/guake/prefs.py:998
 msgid "All files"
 msgstr ""
 
-#: ../src/guake/guake_app.py:1603
+#: ../src/guake/guake_app.py:1728
 msgid "Text and Logs"
 msgstr ""
 
-#: ../src/guake/guake_app.py:1621
+#: ../src/guake/guake_app.py:1746
 msgid "Find"
 msgstr ""
 
-#: ../src/guake/guake_app.py:1623
+#: ../src/guake/guake_app.py:1748
 msgid "Forward"
 msgstr ""
 
-#: ../src/guake/guake_app.py:1624
+#: ../src/guake/guake_app.py:1749
 msgid "Backward"
 msgstr ""
 
-#: ../src/guake/main.py:67
+#: ../src/guake/main.py:68
 msgid "Put Guake in fullscreen mode"
 msgstr ""
 
-#: ../src/guake/main.py:71
+#: ../src/guake/main.py:72
 msgid "Toggles the visibility of the terminal window"
 msgstr "Commuta la visibilitat de la finestra del terminal"
 
-#: ../src/guake/main.py:75
+#: ../src/guake/main.py:76
 #, fuzzy
 msgid "Shows Guake main window"
 msgstr "Mostra la finestra de preferències del Guake"
 
-#: ../src/guake/main.py:79
+#: ../src/guake/main.py:80
 #, fuzzy
 msgid "Hides Guake main window"
 msgstr "Mostra la finestra de preferències del Guake"
 
-#: ../src/guake/main.py:83
+#: ../src/guake/main.py:84
 msgid "Shows Guake preference window"
 msgstr "Mostra la finestra de preferències del Guake"
 
-#: ../src/guake/main.py:87
+#: ../src/guake/main.py:88
 msgid "Shows Guake's about info"
 msgstr "Mostra informació diversa del Guake"
 
-#: ../src/guake/main.py:91
+#: ../src/guake/main.py:92
 #, fuzzy
 msgid "Add a new tab (with current directory set to NEW_TAB)"
 msgstr "_Obre les pestanyes noves en el directori actual"
 
-#: ../src/guake/main.py:95
+#: ../src/guake/main.py:96
 msgid "Select a tab (SELECT_TAB is the index of the tab)"
 msgstr ""
 
-#: ../src/guake/main.py:99
+#: ../src/guake/main.py:100
 msgid "Return the selected tab index."
 msgstr "Retorna l'índex de la pestanya seleccionada."
 
-#: ../src/guake/main.py:103
+#: ../src/guake/main.py:104
 msgid "Execute an arbitrary command in the selected tab."
 msgstr "Executa una ordre arbitrària a la pestanya seleccionada."
 
-#: ../src/guake/main.py:107
+#: ../src/guake/main.py:108
 msgid "Specify the tab to rename. Default is 0."
 msgstr ""
 
-#: ../src/guake/main.py:111
+#: ../src/guake/main.py:112
 msgid "Set the hexadecimal (#rrggbb) background color of the selected tab."
 msgstr ""
 
-#: ../src/guake/main.py:116
+#: ../src/guake/main.py:117
 msgid "Set the hexadecimal (#rrggbb) foreground color of the selected tab."
 msgstr ""
 
-#: ../src/guake/main.py:122
+#: ../src/guake/main.py:123
 msgid ""
 "Rename the specified tab. Reset to default if TITLE is a single dash \"-\"."
 msgstr ""
 
-#: ../src/guake/main.py:128
+#: ../src/guake/main.py:129
 msgid ""
 "Rename the current tab. Reset to default if TITLE is a single dash \"-\"."
 msgstr ""
 
-#: ../src/guake/main.py:133
+#: ../src/guake/main.py:134
 msgid "Says to Guake go away =("
 msgstr "Fa que el Guake desaparegui"
 
-#: ../src/guake/main.py:137
+#: ../src/guake/main.py:138
 msgid "Do not execute the start up script"
 msgstr ""
 
-#: ../src/guake/main.py:231
+#: ../src/guake/main.py:235
 msgid "Guake can not init!"
 msgstr "No s'ha pogut iniciar el Guake."
 
-#: ../src/guake/main.py:232
+#: ../src/guake/main.py:236
 #, fuzzy
 msgid ""
 "Gconf Error.\n"
@@ -773,32 +780,190 @@ msgstr ""
 msgid "<user shell>"
 msgstr "<intèrpret de l'usuari>"
 
-#: ../src/guake/prefs.py:467
+#: ../src/guake/prefs.py:77
+msgid "Toggle Guake visibility"
+msgstr "Commuta la visibilitat del Guake"
+
+#: ../src/guake/prefs.py:81
+#, fuzzy
+msgid "Toggle Hide on Lose Focus"
+msgstr "Amaga-la en perdre el focus"
+
+#: ../src/guake/prefs.py:88
+msgid "Tab management"
+msgstr "Gestió de pestanyes"
+
+#: ../src/guake/prefs.py:90
+#, fuzzy
+msgid "New tab"
+msgstr "Pestanya nova"
+
+#: ../src/guake/prefs.py:92
+msgid "Close tab"
+msgstr "Tanca la pestanya"
+
+#: ../src/guake/prefs.py:94
+msgid "Rename current tab"
+msgstr "Canvia el nom a la pestanya actual"
+
+#: ../src/guake/prefs.py:97
+msgid "Navigation"
+msgstr "Navegació"
+
+#: ../src/guake/prefs.py:99
+msgid "Go to previous tab"
+msgstr "Vés a la pestanya anterior"
+
+#: ../src/guake/prefs.py:101
+msgid "Go to next tab"
+msgstr "Vés a la pestanya següent"
+
+#: ../src/guake/prefs.py:103
+#, fuzzy
+msgid "Move current tab left"
+msgstr "Canvia el nom a la pestanya actual"
+
+#: ../src/guake/prefs.py:105
+#, fuzzy
+msgid "Move current tab right"
+msgstr "Canvia el nom a la pestanya actual"
+
+#: ../src/guake/prefs.py:107
+#, fuzzy
+msgid "Go to first tab"
+msgstr "Vés a la pestanya següent"
+
+#: ../src/guake/prefs.py:109
+#, fuzzy
+msgid "Go to second tab"
+msgstr "Vés a la pestanya següent"
+
+#: ../src/guake/prefs.py:111
+#, fuzzy
+msgid "Go to third tab"
+msgstr "Vés a la pestanya següent"
+
+#: ../src/guake/prefs.py:113
+#, fuzzy
+msgid "Go to fourth tab"
+msgstr "Vés a la pestanya següent"
+
+#: ../src/guake/prefs.py:115
+#, fuzzy
+msgid "Go to fifth tab"
+msgstr "Vés a la pestanya següent"
+
+#: ../src/guake/prefs.py:117
+#, fuzzy
+msgid "Go to sixth tab"
+msgstr "Vés a la pestanya següent"
+
+#: ../src/guake/prefs.py:119
+#, fuzzy
+msgid "Go to seventh tab"
+msgstr "Vés a la pestanya següent"
+
+#: ../src/guake/prefs.py:121
+#, fuzzy
+msgid "Go to eighth tab"
+msgstr "Vés a la pestanya següent"
+
+#: ../src/guake/prefs.py:123
+#, fuzzy
+msgid "Go to ninth tab"
+msgstr "Vés a la pestanya següent"
+
+#: ../src/guake/prefs.py:125
+#, fuzzy
+msgid "Go to tenth tab"
+msgstr "Vés a la pestanya següent"
+
+#: ../src/guake/prefs.py:127
+#, fuzzy
+msgid "Go to last tab"
+msgstr "Vés a la pestanya següent"
+
+#: ../src/guake/prefs.py:132
+msgid "Zoom out"
+msgstr ""
+
+#: ../src/guake/prefs.py:134
+msgid "Zoom in"
+msgstr ""
+
+#: ../src/guake/prefs.py:136
+msgid "Zoom in (alternative)"
+msgstr ""
+
+#: ../src/guake/prefs.py:138
+msgid "Increase height"
+msgstr ""
+
+#: ../src/guake/prefs.py:140
+msgid "Decrease height"
+msgstr ""
+
+#: ../src/guake/prefs.py:142
+#, fuzzy
+msgid "Increase transparency"
+msgstr "Transparència:"
+
+#: ../src/guake/prefs.py:144
+#, fuzzy
+msgid "Decrease transparency"
+msgstr "Transparència:"
+
+#: ../src/guake/prefs.py:146
+#, fuzzy
+msgid "Toggle transparency"
+msgstr "Transparència:"
+
+#: ../src/guake/prefs.py:149
+msgid "Clipboard"
+msgstr "Porta-retalls"
+
+#: ../src/guake/prefs.py:151
+msgid "Copy text to clipboard"
+msgstr "Copia text al porta-retalls"
+
+#: ../src/guake/prefs.py:153
+msgid "Paste text from clipboard"
+msgstr "Enganxa el text del porta-retalls"
+
+#: ../src/guake/prefs.py:156
+msgid "Extra features"
+msgstr ""
+
+#: ../src/guake/prefs.py:159
+msgid "Search select text on web"
+msgstr ""
+
+#: ../src/guake/prefs.py:519
 msgid "Action"
 msgstr "Acció"
 
-#: ../src/guake/prefs.py:477
+#: ../src/guake/prefs.py:529
 msgid "Shortcut"
 msgstr "Drecera"
 
-#: ../src/guake/prefs.py:619 ../src/guake/prefs.py:665
+#: ../src/guake/prefs.py:678 ../src/guake/prefs.py:724
 msgid "Custom"
 msgstr ""
 
-#: ../src/guake/prefs.py:926
+#: ../src/guake/prefs.py:994
 msgid "JSON files"
 msgstr ""
 
-#: ../src/guake/prefs.py:1019
+#: ../src/guake/prefs.py:1088
 #, python-format
 msgid "The shortcut \"%s\" is already in use."
 msgstr "La drecera \"%s\" ja s'està fent servir."
 
-#: ../src/guake/prefs.py:1020
+#: ../src/guake/prefs.py:1089
 msgid "Error setting keybinding."
 msgstr "S'ha produït un error en definir la drecera."
 
-#: ../src/guake/prefs.py:1032
+#: ../src/guake/prefs.py:1101
 #, python-format
 msgid ""
 "The shortcut \"%s\" cannot be used because it will become impossible to type "
@@ -838,33 +1003,3 @@ msgstr ""
 
 #~ msgid "Rename the selected tab."
 #~ msgstr "Canvia el nom de la pestanya seleccionada."
-
-#~ msgid "Toggle Guake visibility"
-#~ msgstr "Commuta la visibilitat del Guake"
-
-#~ msgid "Tab management"
-#~ msgstr "Gestió de pestanyes"
-
-#~ msgid "Close tab"
-#~ msgstr "Tanca la pestanya"
-
-#~ msgid "Rename current tab"
-#~ msgstr "Canvia el nom a la pestanya actual"
-
-#~ msgid "Navigation"
-#~ msgstr "Navegació"
-
-#~ msgid "Go to previous tab"
-#~ msgstr "Vés a la pestanya anterior"
-
-#~ msgid "Go to next tab"
-#~ msgstr "Vés a la pestanya següent"
-
-#~ msgid "Clipboard"
-#~ msgstr "Porta-retalls"
-
-#~ msgid "Copy text to clipboard"
-#~ msgstr "Copia text al porta-retalls"
-
-#~ msgid "Paste text from clipboard"
-#~ msgstr "Enganxa el text del porta-retalls"

--- a/po/cs.po
+++ b/po/cs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Guake 0.4.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-12-01 16:49+0100\n"
+"POT-Creation-Date: 2016-08-17 21:41+0000\n"
 "PO-Revision-Date: 2016-05-25 22:08+0200\n"
 "Last-Translator: Martin Lukeš <martin.meridius@gmail.com>\n"
 "Language-Team: Czech (Czech Republic) (http://www.transifex.com/projects/p/"
@@ -100,7 +100,7 @@ msgstr "Kopírovat"
 msgid "Paste"
 msgstr "Vložit"
 
-#: ../data/guake.glade.h:3
+#: ../data/guake.glade.h:3 ../src/guake/prefs.py:79
 msgid "Toggle Fullscreen"
 msgstr "Přepnout na celou obrazovku"
 
@@ -108,7 +108,7 @@ msgstr "Přepnout na celou obrazovku"
 msgid "Save to File..."
 msgstr "Uložit do souboru..."
 
-#: ../data/guake.glade.h:5
+#: ../data/guake.glade.h:5 ../src/guake/prefs.py:85
 msgid "Reset terminal"
 msgstr "Inicializovat a vymazat"
 
@@ -136,7 +136,7 @@ msgstr "Otevřít odkaz..."
 msgid "Search on Web"
 msgstr "Najít na webu"
 
-#: ../data/guake.glade.h:12
+#: ../data/guake.glade.h:12 ../src/guake/prefs.py:83
 msgid "Quit"
 msgstr "Ukončit"
 
@@ -269,130 +269,134 @@ msgid "Use VTE titles for tab names"
 msgstr "Použít názvy VTE pro názvy karet"
 
 #: ../data/prefs.glade.h:33
+msgid "Abbreviate directories in tab names"
+msgstr ""
+
+#: ../data/prefs.glade.h:34
 msgid "Max tab name length:"
 msgstr "Maximální délka názvu karty:"
 
-#: ../data/prefs.glade.h:34
+#: ../data/prefs.glade.h:35
 msgid "Hide on lose focus"
 msgstr "Skrýt při ztrátě aktivity okna"
 
-#: ../data/prefs.glade.h:35
+#: ../data/prefs.glade.h:36
 msgid "Show tab bar"
 msgstr "Zobrazit lištu karet"
 
-#: ../data/prefs.glade.h:36
+#: ../data/prefs.glade.h:37
 msgid "Start fullscreen"
 msgstr "Spustit na celou obrazovku"
 
-#: ../data/prefs.glade.h:37
+#: ../data/prefs.glade.h:38
 msgid "<b>Main Window</b>"
 msgstr "<b>Okno s terminálem</b>"
 
-#: ../data/prefs.glade.h:38
+#: ../data/prefs.glade.h:39
 msgid "Left"
 msgstr "Vlevo"
 
-#: ../data/prefs.glade.h:39
+#: ../data/prefs.glade.h:40
 msgid "Center"
 msgstr "Na střed"
 
-#: ../data/prefs.glade.h:40
+#: ../data/prefs.glade.h:41
 msgid "Right"
 msgstr "Vpravo"
 
-#: ../data/prefs.glade.h:41
+#: ../data/prefs.glade.h:42
 msgid "<b>Main Window Horizontal Alignment</b>"
 msgstr "<b>Vodorovné umístění okna s terminálem</b>"
 
-#: ../data/prefs.glade.h:42
+#: ../data/prefs.glade.h:43
 msgid "<b>Main Window Height</b>"
 msgstr "<b>Výška okna s terminálem</b>"
 
-#: ../data/prefs.glade.h:43
+#: ../data/prefs.glade.h:44
 msgid "<b>Main Window Width</b>"
 msgstr "<b>Šířka okna s terminálem</b>"
 
-#: ../data/prefs.glade.h:44
+#: ../data/prefs.glade.h:45
 msgid "Custom command file path: "
 msgstr "Cesta k souboru s vlastním příkazem: "
 
-#: ../data/prefs.glade.h:45
+#: ../data/prefs.glade.h:46
 msgid "Please select a json file"
 msgstr "Vyberte soubor json"
 
-#: ../data/prefs.glade.h:46
+#: ../data/prefs.glade.h:47 ../src/guake/prefs.py:75
 msgid "General"
 msgstr "Obecné"
 
-#: ../data/prefs.glade.h:47
+#: ../data/prefs.glade.h:48
 msgid "Default interpreter:"
 msgstr "Výchozí interpret shellu:"
 
-#: ../data/prefs.glade.h:48
+#: ../data/prefs.glade.h:49
 msgid "_Run command as a login shell"
 msgstr "_Spustit příkaz jako přihlašovací shell"
 
-#: ../data/prefs.glade.h:49
+#: ../data/prefs.glade.h:50
 msgid "_Open new tab in current directory"
 msgstr "_Otevřít novou kartu v aktuálním adresáři"
 
-#: ../data/prefs.glade.h:50
+#: ../data/prefs.glade.h:51
 msgid "<b>Shell</b>"
 msgstr "<b>Shell</b>"
 
-#: ../data/prefs.glade.h:51
+#: ../data/prefs.glade.h:52
 msgid "Shell"
 msgstr "Shell"
 
-#: ../data/prefs.glade.h:52
+#: ../data/prefs.glade.h:53
 msgid "Show scrollbar"
 msgstr "Zobrazit posuvník"
 
-#: ../data/prefs.glade.h:53
+#: ../data/prefs.glade.h:54
 msgid "Scrollback lines:"
 msgstr "Omezit posuv na:"
 
-#: ../data/prefs.glade.h:54
+#: ../data/prefs.glade.h:55
 msgid "On output"
 msgstr "Při výstupu"
 
-#: ../data/prefs.glade.h:55
+#: ../data/prefs.glade.h:56
 msgid "On key stroke"
 msgstr "Při stisku klávesy"
 
-#: ../data/prefs.glade.h:56
+#: ../data/prefs.glade.h:57
 msgid "<b>Scroll</b>"
 msgstr "<b>Posun</b>"
 
-#: ../data/prefs.glade.h:57
+#: ../data/prefs.glade.h:58
 msgid "Scrolling"
 msgstr "Posouvání"
 
-#: ../data/prefs.glade.h:58
+#: ../data/prefs.glade.h:59
 msgid "Use the system fixed width font"
 msgstr "Používat systémové písmo s pevnou šířkou"
 
-#: ../data/prefs.glade.h:59
+#: ../data/prefs.glade.h:60
 msgid "Font:"
 msgstr "Písmo:"
 
-#: ../data/prefs.glade.h:60
+#: ../data/prefs.glade.h:61
 msgid "Choose some font"
 msgstr "Vyberte písmo terminálu"
 
-#: ../data/prefs.glade.h:61
+#: ../data/prefs.glade.h:62
 msgid "Text color:"
 msgstr "Barva textu:"
 
-#: ../data/prefs.glade.h:62
+#: ../data/prefs.glade.h:63
 msgid "Background color:"
 msgstr "Barva pozadí:"
 
-#: ../data/prefs.glade.h:63
+#: ../data/prefs.glade.h:64
 msgid "Cursor shape:"
 msgstr "Tvar kurzoru:"
 
-#: ../data/prefs.glade.h:64
+#: ../data/prefs.glade.h:65
 msgid ""
 "Block\n"
 "I-Beam\n"
@@ -402,7 +406,7 @@ msgstr ""
 "svislá čára\n"
 "podtrhávací čára"
 
-#: ../data/prefs.glade.h:67
+#: ../data/prefs.glade.h:68
 msgid ""
 "Follow GTK+ setting\n"
 "Blink on\n"
@@ -412,59 +416,59 @@ msgstr ""
 "blikat\n"
 "neblikat"
 
-#: ../data/prefs.glade.h:70
+#: ../data/prefs.glade.h:71
 msgid "Cursor blink mode:"
 msgstr "Blikání kurzoru:"
 
-#: ../data/prefs.glade.h:71
+#: ../data/prefs.glade.h:72
 msgid "Allow bold font"
 msgstr "Povolit tučný text"
 
-#: ../data/prefs.glade.h:72
+#: ../data/prefs.glade.h:73
 msgid "<b>Palette</b>"
 msgstr "<b>Paleta</b>"
 
-#: ../data/prefs.glade.h:73
+#: ../data/prefs.glade.h:74
 msgid "Built-in schemes:"
 msgstr "Zabudovaná schémata:"
 
-#: ../data/prefs.glade.h:74
+#: ../data/prefs.glade.h:75
 msgid "Color palette:"
 msgstr "Paleta barev:"
 
-#: ../data/prefs.glade.h:75
+#: ../data/prefs.glade.h:76
 msgid "Font color"
 msgstr "Barva textu"
 
-#: ../data/prefs.glade.h:76
+#: ../data/prefs.glade.h:77
 msgid "Background color"
 msgstr "Barva pozadí"
 
-#: ../data/prefs.glade.h:77
+#: ../data/prefs.glade.h:78
 msgid "Use font and background color from the palette"
 msgstr "Použít barvu písma a pozadí z palety"
 
-#: ../data/prefs.glade.h:78
+#: ../data/prefs.glade.h:79
 msgid "Demo:"
 msgstr "Náhled:"
 
-#: ../data/prefs.glade.h:79
+#: ../data/prefs.glade.h:80
 msgid "<b>Effects</b>"
 msgstr "<b>Efekty</b>"
 
-#: ../data/prefs.glade.h:80
+#: ../data/prefs.glade.h:81
 msgid "Transparency:"
 msgstr "Průhlednost:"
 
-#: ../data/prefs.glade.h:81
+#: ../data/prefs.glade.h:82
 msgid "Background image:"
 msgstr "Obrázek na pozadí:"
 
-#: ../data/prefs.glade.h:82
+#: ../data/prefs.glade.h:83 ../src/guake/prefs.py:130
 msgid "Appearance"
 msgstr "Vzhled"
 
-#: ../data/prefs.glade.h:83
+#: ../data/prefs.glade.h:84
 msgid ""
 "<small>Quick open is a feature allowing you to open a file directly into "
 "your favorite text editor by clicking on its filename when it appears in "
@@ -476,16 +480,16 @@ msgstr ""
 "podporovaných textových vzorů použitých pro zjištění názvu souboru naleznete "
 "níže.</small>"
 
-#: ../data/prefs.glade.h:84
+#: ../data/prefs.glade.h:85
 msgid "Enable Quick Open when Ctrl+clicking on a filename in the terminal"
 msgstr ""
 "Aktivovat Snadné otevření při Ctrl+kliknutí na název souboru v terminálu"
 
-#: ../data/prefs.glade.h:85
+#: ../data/prefs.glade.h:86
 msgid "Editor command line:"
 msgstr "Příkaz ke spuštění editoru"
 
-#: ../data/prefs.glade.h:87
+#: ../data/prefs.glade.h:88
 #, no-c-format
 msgid ""
 "<small><i>Use the following elements in the open editor command line:\n"
@@ -505,11 +509,11 @@ msgstr ""
 "b>\n"
 "</i></small>"
 
-#: ../data/prefs.glade.h:93
+#: ../data/prefs.glade.h:94
 msgid "Quick open in current terminal"
 msgstr "Otevírat v aktuálním terminálu"
 
-#: ../data/prefs.glade.h:94
+#: ../data/prefs.glade.h:95
 msgid ""
 "Here is the list of supported patterns: (to add your own, please contact the "
 "Guake's authors)"
@@ -517,15 +521,15 @@ msgstr ""
 "Zde je seznam podporovaných vzorů: (pro přidání vlastních, kontaktujte "
 "vývojáře Guake)"
 
-#: ../data/prefs.glade.h:95
+#: ../data/prefs.glade.h:96
 msgid "<b>Quick Open</b>"
 msgstr "<b>Snadné otevření</b>"
 
-#: ../data/prefs.glade.h:96
+#: ../data/prefs.glade.h:97
 msgid "Quick Open"
 msgstr "Snadné otevření"
 
-#: ../data/prefs.glade.h:97
+#: ../data/prefs.glade.h:98
 msgid ""
 "To change a shortcut simply click on its name.\n"
 "To disable a shortcut, press the \"Backspace\" key."
@@ -533,11 +537,11 @@ msgstr ""
 "Pro změnu klávesové zkratky klikněte na její název.\n"
 "Pro její deaktivaci stiskněte \"Backspace\"."
 
-#: ../data/prefs.glade.h:99
+#: ../data/prefs.glade.h:100
 msgid "Keyboard shortcuts"
 msgstr "Klávesové zkratky"
 
-#: ../data/prefs.glade.h:100
+#: ../data/prefs.glade.h:101
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -549,7 +553,7 @@ msgstr ""
 "skutečnost, že některé aplikace a operační systémy očekávají jiné chování "
 "terminálu.</i></small>"
 
-#: ../data/prefs.glade.h:101
+#: ../data/prefs.glade.h:102
 msgid ""
 "ASCII DEL\n"
 "Escape sequence\n"
@@ -559,37 +563,36 @@ msgstr ""
 "Escape sekvence\n"
 "Ctrl+H"
 
-#: ../data/prefs.glade.h:104
+#: ../data/prefs.glade.h:105
 msgid "_Backspace key generates:"
 msgstr "Klávesa _Backspace generuje:"
 
-#: ../data/prefs.glade.h:105
+#: ../data/prefs.glade.h:106
 msgid "_Delete key generates:"
 msgstr "Klávesa _Delete generuje:"
 
-#: ../data/prefs.glade.h:106
+#: ../data/prefs.glade.h:107
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "_Obnovit standardní nastavení pro kompatibilitu"
 
-#: ../data/prefs.glade.h:107
+#: ../data/prefs.glade.h:108
 msgid "<b>Keyboard compatibility</b>"
 msgstr "<b>Kompatibilita klávesnic</b>"
 
-#: ../data/prefs.glade.h:108
+#: ../data/prefs.glade.h:109
 msgid "Compatibility"
 msgstr "Kompatibilita"
 
-#: ../src/guake/about.py:47 ../src/guake/gconfhandler.py:427
-#: ../src/guake/guake_app.py:177 ../src/guake/guake_app.py:348
+#: ../src/guake/about.py:47 ../src/guake/gconfhandler.py:435
+#: ../src/guake/guake_app.py:181 ../src/guake/guake_app.py:376
 msgid "Guake Terminal"
 msgstr "Guake Terminal"
 
-#. Adding a new radio button to the tabbar
-#: ../src/guake/gconfhandler.py:365 ../src/guake/guake_app.py:1548
+#: ../src/guake/gconfhandler.py:368 ../src/guake/guake_app.py:1363
 msgid "Terminal"
 msgstr "Terminál %s"
 
-#: ../src/guake/gconfhandler.py:428
+#: ../src/guake/gconfhandler.py:436
 #, python-format
 msgid ""
 "A problem happened when binding <b>%s</b> key.\n"
@@ -599,49 +602,49 @@ msgstr ""
 "Pro výběr jiné zkratky použijte, prosím, okno Nastavení. (Ikona v oznamovací "
 "oblasti byla povolena.)"
 
-#: ../src/guake/guake_app.py:128
+#: ../src/guake/guake_app.py:132
 msgid "Do you want to close the tab?"
 msgstr "Opravdu chcete zavřít kartu?"
 
-#: ../src/guake/guake_app.py:131
+#: ../src/guake/guake_app.py:135
 msgid "Do you really want to quit Guake?"
 msgstr "Opravdu chcete ukončit Guake!?"
 
-#: ../src/guake/guake_app.py:133
+#: ../src/guake/guake_app.py:137
 msgid " and one tab open"
 msgstr " a jedna karta otevřena"
 
-#: ../src/guake/guake_app.py:135
+#: ../src/guake/guake_app.py:139
 #, python-brace-format
 msgid " and {0} tabs open"
 msgstr " a {0} karet otevřeno"
 
-#: ../src/guake/guake_app.py:138
+#: ../src/guake/guake_app.py:142
 msgid "There are no processes running"
 msgstr "Neběží žádné procesy"
 
-#: ../src/guake/guake_app.py:140
+#: ../src/guake/guake_app.py:144
 msgid "There is a process still running"
 msgstr "Stále běží jeden proces"
 
-#: ../src/guake/guake_app.py:142
+#: ../src/guake/guake_app.py:146
 #, python-brace-format
 msgid "There are {0} processes still running"
 msgstr "Stále běží {0} procesů"
 
-#: ../src/guake/guake_app.py:182
+#: ../src/guake/guake_app.py:186
 msgid "guake-indicator"
 msgstr "guake-indicator"
 
-#: ../src/guake/guake_app.py:182
+#: ../src/guake/guake_app.py:186
 msgid "guake-tray"
 msgstr "guake-tray"
 
-#: ../src/guake/guake_app.py:186
+#: ../src/guake/guake_app.py:190
 msgid "Show"
 msgstr "Zobrazit"
 
-#: ../src/guake/guake_app.py:349
+#: ../src/guake/guake_app.py:377
 #, python-format
 msgid ""
 "Guake is now running,\n"
@@ -650,130 +653,135 @@ msgstr ""
 "Guake je nyní spuštěno,\n"
 "pro zobrazení stiskněte <b>%s</b>."
 
-#: ../src/guake/guake_app.py:611
+#: ../src/guake/guake_app.py:665
 #, python-format
 msgid "Search on Web: '%s'"
 msgstr "Vyhledat na webu: '%s'"
 
-#: ../src/guake/guake_app.py:616
+#: ../src/guake/guake_app.py:670
 msgid "Search on Web (no selection)"
 msgstr "Vyhledat na webu (bez výběru)"
 
-#: ../src/guake/guake_app.py:622
+#: ../src/guake/guake_app.py:678
+#, fuzzy
+msgid "Open Link: '{}...'"
+msgstr "Otevřít odkaz: {}"
+
+#: ../src/guake/guake_app.py:680
 msgid "Open Link: {}"
 msgstr "Otevřít odkaz: {}"
 
-#: ../src/guake/guake_app.py:625
+#: ../src/guake/guake_app.py:683
 msgid "Open Link..."
 msgstr "Otevřít odkaz..."
 
-#: ../src/guake/guake_app.py:1300
+#: ../src/guake/guake_app.py:1402
 msgid "Rename tab"
 msgstr "Přejmenovat kartu"
 
-#: ../src/guake/guake_app.py:1591
+#: ../src/guake/guake_app.py:1716
 msgid "Save to..."
 msgstr "Uložit do..."
 
-#: ../src/guake/guake_app.py:1598 ../src/guake/prefs.py:930
+#: ../src/guake/guake_app.py:1723 ../src/guake/prefs.py:998
 msgid "All files"
 msgstr "Všechny soubory"
 
-#: ../src/guake/guake_app.py:1603
+#: ../src/guake/guake_app.py:1728
 msgid "Text and Logs"
 msgstr "Text a logy"
 
-#: ../src/guake/guake_app.py:1621
+#: ../src/guake/guake_app.py:1746
 msgid "Find"
 msgstr "Vyhledat"
 
-#: ../src/guake/guake_app.py:1623
+#: ../src/guake/guake_app.py:1748
 msgid "Forward"
 msgstr "Vpřed"
 
-#: ../src/guake/guake_app.py:1624
+#: ../src/guake/guake_app.py:1749
 msgid "Backward"
 msgstr "Zpět"
 
-#: ../src/guake/main.py:67
+#: ../src/guake/main.py:68
 msgid "Put Guake in fullscreen mode"
 msgstr "Přepnout Guake na celou obrazovku"
 
-#: ../src/guake/main.py:71
+#: ../src/guake/main.py:72
 msgid "Toggles the visibility of the terminal window"
 msgstr "Zobrazí / skryje okno terminálu"
 
-#: ../src/guake/main.py:75
+#: ../src/guake/main.py:76
 msgid "Shows Guake main window"
 msgstr "Zobrazí hlavní okno Guake"
 
-#: ../src/guake/main.py:79
+#: ../src/guake/main.py:80
 msgid "Hides Guake main window"
 msgstr "Skryje hlavní okno Guake"
 
-#: ../src/guake/main.py:83
+#: ../src/guake/main.py:84
 msgid "Shows Guake preference window"
 msgstr "Zobrazí okno nastavení Guake"
 
-#: ../src/guake/main.py:87
+#: ../src/guake/main.py:88
 msgid "Shows Guake's about info"
 msgstr "Zobrazí info o Guake"
 
-#: ../src/guake/main.py:91
+#: ../src/guake/main.py:92
 msgid "Add a new tab (with current directory set to NEW_TAB)"
 msgstr "Otevře novou kartu s cestou nastavenou na NEW_TAB"
 
-#: ../src/guake/main.py:95
+#: ../src/guake/main.py:96
 msgid "Select a tab (SELECT_TAB is the index of the tab)"
 msgstr "Vybere kartu podle indexu SELECT_TAB"
 
-#: ../src/guake/main.py:99
+#: ../src/guake/main.py:100
 msgid "Return the selected tab index."
 msgstr "Vypíše pořadí vybrané karty."
 
-#: ../src/guake/main.py:103
+#: ../src/guake/main.py:104
 msgid "Execute an arbitrary command in the selected tab."
 msgstr "Spustí ve vybrané kartě libovolný příkaz."
 
-#: ../src/guake/main.py:107
+#: ../src/guake/main.py:108
 msgid "Specify the tab to rename. Default is 0."
 msgstr "Vybere kartu k přejmenování. Výchozí je 0."
 
-#: ../src/guake/main.py:111
+#: ../src/guake/main.py:112
 msgid "Set the hexadecimal (#rrggbb) background color of the selected tab."
 msgstr "Nastaví hexadecimální (#rrggbb) barvu pozadí pro vybranou kartu."
 
-#: ../src/guake/main.py:116
+#: ../src/guake/main.py:117
 msgid "Set the hexadecimal (#rrggbb) foreground color of the selected tab."
 msgstr "Nastaví hexadecimální (#rrggbb) barvu popředí pro vybranou kartu."
 
-#: ../src/guake/main.py:122
+#: ../src/guake/main.py:123
 msgid ""
 "Rename the specified tab. Reset to default if TITLE is a single dash \"-\"."
 msgstr ""
 "Přejmenuje vybranou kartu. Dostane výchozí název, pokud bude TITLE "
 "jednoduchá pomlčka \"-\"."
 
-#: ../src/guake/main.py:128
+#: ../src/guake/main.py:129
 msgid ""
 "Rename the current tab. Reset to default if TITLE is a single dash \"-\"."
 msgstr ""
 "Přejmenuje aktuální kartu. Dostane výchozí název, pokud bude TITLE "
 "jednoduchá pomlčka \"-\"."
 
-#: ../src/guake/main.py:133
+#: ../src/guake/main.py:134
 msgid "Says to Guake go away =("
 msgstr "Řekne Guake, aby šlo pryč =("
 
-#: ../src/guake/main.py:137
+#: ../src/guake/main.py:138
 msgid "Do not execute the start up script"
 msgstr "Nespouštět skript po spuštění"
 
-#: ../src/guake/main.py:231
+#: ../src/guake/main.py:235
 msgid "Guake can not init!"
 msgstr "Guake nelze spustit!"
 
-#: ../src/guake/main.py:232
+#: ../src/guake/main.py:236
 msgid ""
 "Gconf Error.\n"
 "Have you installed <b>guake.schemas</b> properly?"
@@ -786,32 +794,191 @@ msgstr ""
 msgid "<user shell>"
 msgstr "<uživatelský shell>"
 
-#: ../src/guake/prefs.py:467
+#: ../src/guake/prefs.py:77
+msgid "Toggle Guake visibility"
+msgstr "Přepnout viditelnost Guake"
+
+#: ../src/guake/prefs.py:81
+#, fuzzy
+msgid "Toggle Hide on Lose Focus"
+msgstr "Skrýt při ztrátě aktivity okna"
+
+#: ../src/guake/prefs.py:88
+msgid "Tab management"
+msgstr "Správa karet"
+
+#: ../src/guake/prefs.py:90
+#, fuzzy
+msgid "New tab"
+msgstr "Nová karta"
+
+#: ../src/guake/prefs.py:92
+msgid "Close tab"
+msgstr "Zavřít kartu"
+
+#: ../src/guake/prefs.py:94
+msgid "Rename current tab"
+msgstr "Přejmenovat současnou kartu"
+
+#: ../src/guake/prefs.py:97
+msgid "Navigation"
+msgstr "Navigace"
+
+#: ../src/guake/prefs.py:99
+msgid "Go to previous tab"
+msgstr "Přejít na předchozí kartu"
+
+#: ../src/guake/prefs.py:101
+msgid "Go to next tab"
+msgstr "Přejít na následující kartu"
+
+#: ../src/guake/prefs.py:103
+#, fuzzy
+msgid "Move current tab left"
+msgstr "Přejmenovat současnou kartu"
+
+#: ../src/guake/prefs.py:105
+#, fuzzy
+msgid "Move current tab right"
+msgstr "Přejmenovat současnou kartu"
+
+#: ../src/guake/prefs.py:107
+#, fuzzy
+msgid "Go to first tab"
+msgstr "Přejít na následující kartu"
+
+#: ../src/guake/prefs.py:109
+#, fuzzy
+msgid "Go to second tab"
+msgstr "Přejít na následující kartu"
+
+#: ../src/guake/prefs.py:111
+#, fuzzy
+msgid "Go to third tab"
+msgstr "Přejít na následující kartu"
+
+#: ../src/guake/prefs.py:113
+#, fuzzy
+msgid "Go to fourth tab"
+msgstr "Přejít na následující kartu"
+
+#: ../src/guake/prefs.py:115
+#, fuzzy
+msgid "Go to fifth tab"
+msgstr "Přejít na následující kartu"
+
+#: ../src/guake/prefs.py:117
+#, fuzzy
+msgid "Go to sixth tab"
+msgstr "Přejít na následující kartu"
+
+#: ../src/guake/prefs.py:119
+#, fuzzy
+msgid "Go to seventh tab"
+msgstr "Přejít na následující kartu"
+
+#: ../src/guake/prefs.py:121
+#, fuzzy
+msgid "Go to eighth tab"
+msgstr "Přejít na následující kartu"
+
+#: ../src/guake/prefs.py:123
+#, fuzzy
+msgid "Go to ninth tab"
+msgstr "Přejít na následující kartu"
+
+#: ../src/guake/prefs.py:125
+#, fuzzy
+msgid "Go to tenth tab"
+msgstr "Přejít na následující kartu"
+
+#: ../src/guake/prefs.py:127
+#, fuzzy
+msgid "Go to last tab"
+msgstr "Přejít na následující kartu"
+
+#: ../src/guake/prefs.py:132
+msgid "Zoom out"
+msgstr ""
+
+#: ../src/guake/prefs.py:134
+msgid "Zoom in"
+msgstr ""
+
+#: ../src/guake/prefs.py:136
+msgid "Zoom in (alternative)"
+msgstr ""
+
+#: ../src/guake/prefs.py:138
+msgid "Increase height"
+msgstr ""
+
+#: ../src/guake/prefs.py:140
+msgid "Decrease height"
+msgstr ""
+
+#: ../src/guake/prefs.py:142
+#, fuzzy
+msgid "Increase transparency"
+msgstr "Průhlednost:"
+
+#: ../src/guake/prefs.py:144
+#, fuzzy
+msgid "Decrease transparency"
+msgstr "Průhlednost:"
+
+#: ../src/guake/prefs.py:146
+#, fuzzy
+msgid "Toggle transparency"
+msgstr "Průhlednost:"
+
+#: ../src/guake/prefs.py:149
+msgid "Clipboard"
+msgstr "Schránka"
+
+#: ../src/guake/prefs.py:151
+msgid "Copy text to clipboard"
+msgstr "Kopírovat text do schránky"
+
+#: ../src/guake/prefs.py:153
+msgid "Paste text from clipboard"
+msgstr "Vložit text ze schránky"
+
+#: ../src/guake/prefs.py:156
+msgid "Extra features"
+msgstr ""
+
+#: ../src/guake/prefs.py:159
+#, fuzzy
+msgid "Search select text on web"
+msgstr "Najít na webu"
+
+#: ../src/guake/prefs.py:519
 msgid "Action"
 msgstr "Akce"
 
-#: ../src/guake/prefs.py:477
+#: ../src/guake/prefs.py:529
 msgid "Shortcut"
 msgstr "Klávesová zkratka"
 
-#: ../src/guake/prefs.py:619 ../src/guake/prefs.py:665
+#: ../src/guake/prefs.py:678 ../src/guake/prefs.py:724
 msgid "Custom"
 msgstr "Vlastní"
 
-#: ../src/guake/prefs.py:926
+#: ../src/guake/prefs.py:994
 msgid "JSON files"
 msgstr "JSON soubory"
 
-#: ../src/guake/prefs.py:1019
+#: ../src/guake/prefs.py:1088
 #, python-format
 msgid "The shortcut \"%s\" is already in use."
 msgstr "Klávesová zkratka \"%s\" se již používá."
 
-#: ../src/guake/prefs.py:1020
+#: ../src/guake/prefs.py:1089
 msgid "Error setting keybinding."
 msgstr "Chyba při nastavování klávesové zkratky."
 
-#: ../src/guake/prefs.py:1032
+#: ../src/guake/prefs.py:1101
 #, python-format
 msgid ""
 "The shortcut \"%s\" cannot be used because it will become impossible to type "
@@ -851,33 +1018,3 @@ msgstr ""
 
 #~ msgid "Rename the selected tab."
 #~ msgstr "Přejmenovat vybranou kartu."
-
-#~ msgid "Toggle Guake visibility"
-#~ msgstr "Přepnout viditelnost Guake"
-
-#~ msgid "Tab management"
-#~ msgstr "Správa karet"
-
-#~ msgid "Close tab"
-#~ msgstr "Zavřít kartu"
-
-#~ msgid "Rename current tab"
-#~ msgstr "Přejmenovat současnou kartu"
-
-#~ msgid "Navigation"
-#~ msgstr "Navigace"
-
-#~ msgid "Go to previous tab"
-#~ msgstr "Přejít na předchozí kartu"
-
-#~ msgid "Go to next tab"
-#~ msgstr "Přejít na následující kartu"
-
-#~ msgid "Clipboard"
-#~ msgstr "Schránka"
-
-#~ msgid "Copy text to clipboard"
-#~ msgstr "Kopírovat text do schránky"
-
-#~ msgid "Paste text from clipboard"
-#~ msgstr "Vložit text ze schránky"

--- a/po/de.po
+++ b/po/de.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Guake 0.4.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-12-01 16:49+0100\n"
+"POT-Creation-Date: 2016-08-17 21:41+0000\n"
 "PO-Revision-Date: 2016-06-06 23:12+0200\n"
 "Last-Translator: Frank Dietrich <bits_n_bytes@gmx.de>\n"
 "Language-Team: guake@lists.guake.org\n"
@@ -99,7 +99,7 @@ msgstr "Kopieren"
 msgid "Paste"
 msgstr "Einfügen"
 
-#: ../data/guake.glade.h:3
+#: ../data/guake.glade.h:3 ../src/guake/prefs.py:79
 msgid "Toggle Fullscreen"
 msgstr "Vollbildmodus aktivieren"
 
@@ -107,7 +107,7 @@ msgstr "Vollbildmodus aktivieren"
 msgid "Save to File..."
 msgstr "Speichern unter..."
 
-#: ../data/guake.glade.h:5
+#: ../data/guake.glade.h:5 ../src/guake/prefs.py:85
 #, fuzzy
 msgid "Reset terminal"
 msgstr "Guake-Terminal"
@@ -136,7 +136,7 @@ msgstr "Link öffnen..."
 msgid "Search on Web"
 msgstr "Im Web suchen"
 
-#: ../data/guake.glade.h:12
+#: ../data/guake.glade.h:12 ../src/guake/prefs.py:83
 msgid "Quit"
 msgstr "Beenden"
 
@@ -186,8 +186,8 @@ msgid ""
 "guake -r \"main\" -e \"cd ~/projects/myproject/main\"\n"
 "guake -r \"prod\" -e \"cd ~/projects/myproject/prod\"\n"
 msgstr ""
-"Pfad zu einem Bash-Skript, das beim Start von Guake automatisch ausgeführt wird, "
-"außer man gibt --no-startup-script an.\n"
+"Pfad zu einem Bash-Skript, das beim Start von Guake automatisch ausgeführt "
+"wird, außer man gibt --no-startup-script an.\n"
 "\n"
 "Normalerweise benutzt dies die Konfiguration über die Kommandozeile:\n"
 "\n"
@@ -268,130 +268,134 @@ msgid "Use VTE titles for tab names"
 msgstr "VTE-Titel als Reiternamen benutzen"
 
 #: ../data/prefs.glade.h:33
+msgid "Abbreviate directories in tab names"
+msgstr ""
+
+#: ../data/prefs.glade.h:34
 msgid "Max tab name length:"
 msgstr "Max. Tab-Namen-Länge:"
 
-#: ../data/prefs.glade.h:34
+#: ../data/prefs.glade.h:35
 msgid "Hide on lose focus"
 msgstr "Verstecken, wenn der Fokus verloren geht"
 
-#: ../data/prefs.glade.h:35
+#: ../data/prefs.glade.h:36
 msgid "Show tab bar"
 msgstr "Reiterleiste anzeigen"
 
-#: ../data/prefs.glade.h:36
+#: ../data/prefs.glade.h:37
 msgid "Start fullscreen"
 msgstr "Vollbild starten"
 
-#: ../data/prefs.glade.h:37
+#: ../data/prefs.glade.h:38
 msgid "<b>Main Window</b>"
 msgstr "<b>Hauptfenster</b>"
 
-#: ../data/prefs.glade.h:38
+#: ../data/prefs.glade.h:39
 msgid "Left"
 msgstr "Links"
 
-#: ../data/prefs.glade.h:39
+#: ../data/prefs.glade.h:40
 msgid "Center"
 msgstr "Mittig"
 
-#: ../data/prefs.glade.h:40
+#: ../data/prefs.glade.h:41
 msgid "Right"
 msgstr "Rechts"
 
-#: ../data/prefs.glade.h:41
+#: ../data/prefs.glade.h:42
 msgid "<b>Main Window Horizontal Alignment</b>"
 msgstr "<b>Horizontale Ausrichtung des Hauptfensters</b>"
 
-#: ../data/prefs.glade.h:42
+#: ../data/prefs.glade.h:43
 msgid "<b>Main Window Height</b>"
 msgstr "<b>Höhe des Hauptfensters</b>"
 
-#: ../data/prefs.glade.h:43
+#: ../data/prefs.glade.h:44
 msgid "<b>Main Window Width</b>"
 msgstr "<b>Breite des Hauptfensters</b>"
 
-#: ../data/prefs.glade.h:44
+#: ../data/prefs.glade.h:45
 msgid "Custom command file path: "
 msgstr "Benutzerdefinierter Befehl"
 
-#: ../data/prefs.glade.h:45
+#: ../data/prefs.glade.h:46
 msgid "Please select a json file"
 msgstr "Bitte wählen Sie eine JSON-Datei aus"
 
-#: ../data/prefs.glade.h:46
+#: ../data/prefs.glade.h:47 ../src/guake/prefs.py:75
 msgid "General"
 msgstr "Allgemein"
 
-#: ../data/prefs.glade.h:47
+#: ../data/prefs.glade.h:48
 msgid "Default interpreter:"
 msgstr "Standard-Interpreter:"
 
-#: ../data/prefs.glade.h:48
+#: ../data/prefs.glade.h:49
 msgid "_Run command as a login shell"
 msgstr "Befehl als Loginshell ausführen"
 
-#: ../data/prefs.glade.h:49
+#: ../data/prefs.glade.h:50
 msgid "_Open new tab in current directory"
 msgstr "_Neuen Reiter in aktuellem Verzeichnis öffnen"
 
-#: ../data/prefs.glade.h:50
+#: ../data/prefs.glade.h:51
 msgid "<b>Shell</b>"
 msgstr "<b>Shell</b>"
 
-#: ../data/prefs.glade.h:51
+#: ../data/prefs.glade.h:52
 msgid "Shell"
 msgstr "Shell"
 
-#: ../data/prefs.glade.h:52
+#: ../data/prefs.glade.h:53
 msgid "Show scrollbar"
 msgstr "Scroll-Balken anzeigen"
 
-#: ../data/prefs.glade.h:53
+#: ../data/prefs.glade.h:54
 msgid "Scrollback lines:"
 msgstr "Zurückscrollbare Zeilen:"
 
-#: ../data/prefs.glade.h:54
+#: ../data/prefs.glade.h:55
 msgid "On output"
 msgstr "Bei Ausgabe"
 
-#: ../data/prefs.glade.h:55
+#: ../data/prefs.glade.h:56
 msgid "On key stroke"
 msgstr "Auf Tastendruck"
 
-#: ../data/prefs.glade.h:56
+#: ../data/prefs.glade.h:57
 msgid "<b>Scroll</b>"
 msgstr "<b>Bildlauf</b>"
 
-#: ../data/prefs.glade.h:57
+#: ../data/prefs.glade.h:58
 msgid "Scrolling"
 msgstr "Bildlauf"
 
-#: ../data/prefs.glade.h:58
+#: ../data/prefs.glade.h:59
 msgid "Use the system fixed width font"
 msgstr "Die dicktengleiche Systemschrift benutzen"
 
-#: ../data/prefs.glade.h:59
+#: ../data/prefs.glade.h:60
 msgid "Font:"
 msgstr "Schriftart:"
 
-#: ../data/prefs.glade.h:60
+#: ../data/prefs.glade.h:61
 msgid "Choose some font"
 msgstr "Schrift auswählen"
 
-#: ../data/prefs.glade.h:61
+#: ../data/prefs.glade.h:62
 msgid "Text color:"
 msgstr "Textfarbe:"
 
-#: ../data/prefs.glade.h:62
+#: ../data/prefs.glade.h:63
 msgid "Background color:"
 msgstr "Hintergrundfarbe:"
 
-#: ../data/prefs.glade.h:63
+#: ../data/prefs.glade.h:64
 msgid "Cursor shape:"
 msgstr "Form des Text-Cursors:"
 
-#: ../data/prefs.glade.h:64
+#: ../data/prefs.glade.h:65
 msgid ""
 "Block\n"
 "I-Beam\n"
@@ -401,7 +405,7 @@ msgstr ""
 "I-Strich\n"
 "Unterstreichen"
 
-#: ../data/prefs.glade.h:67
+#: ../data/prefs.glade.h:68
 msgid ""
 "Follow GTK+ setting\n"
 "Blink on\n"
@@ -411,60 +415,60 @@ msgstr ""
 "Blinken an\n"
 "Blinken aus"
 
-#: ../data/prefs.glade.h:70
+#: ../data/prefs.glade.h:71
 msgid "Cursor blink mode:"
 msgstr "Blinkmodus des Zeigers:"
 
-#: ../data/prefs.glade.h:71
+#: ../data/prefs.glade.h:72
 msgid "Allow bold font"
 msgstr "Schriftstärke fett erlauben"
 
-#: ../data/prefs.glade.h:72
+#: ../data/prefs.glade.h:73
 msgid "<b>Palette</b>"
 msgstr "<b>Farbpalette</b>"
 
-#: ../data/prefs.glade.h:73
+#: ../data/prefs.glade.h:74
 msgid "Built-in schemes:"
 msgstr "Eingebaute Schemata:"
 
 # changed according to translation as present in gnome-settings
-#: ../data/prefs.glade.h:74
+#: ../data/prefs.glade.h:75
 msgid "Color palette:"
 msgstr "Farbpalette:"
 
-#: ../data/prefs.glade.h:75
+#: ../data/prefs.glade.h:76
 msgid "Font color"
 msgstr "Schriftfarbe"
 
-#: ../data/prefs.glade.h:76
+#: ../data/prefs.glade.h:77
 msgid "Background color"
 msgstr "<b>Hintergrundfarbe</b>"
 
-#: ../data/prefs.glade.h:77
+#: ../data/prefs.glade.h:78
 msgid "Use font and background color from the palette"
 msgstr "Schriftart und Hintergrundfarbe der Farbpalette benutzen"
 
-#: ../data/prefs.glade.h:78
+#: ../data/prefs.glade.h:79
 msgid "Demo:"
 msgstr "Demo:"
 
-#: ../data/prefs.glade.h:79
+#: ../data/prefs.glade.h:80
 msgid "<b>Effects</b>"
 msgstr "<b>Effekte</b>"
 
-#: ../data/prefs.glade.h:80
+#: ../data/prefs.glade.h:81
 msgid "Transparency:"
 msgstr "Transparenz:"
 
-#: ../data/prefs.glade.h:81
+#: ../data/prefs.glade.h:82
 msgid "Background image:"
 msgstr "Hintergrundbild:"
 
-#: ../data/prefs.glade.h:82
+#: ../data/prefs.glade.h:83 ../src/guake/prefs.py:130
 msgid "Appearance"
 msgstr "Aussehen"
 
-#: ../data/prefs.glade.h:83
+#: ../data/prefs.glade.h:84
 msgid ""
 "<small>Quick open is a feature allowing you to open a file directly into "
 "your favorite text editor by clicking on its filename when it appears in "
@@ -472,20 +476,20 @@ msgid ""
 "extract filename below.</small>"
 msgstr ""
 "<small>Schnell-Öffnen bietet die Möglichkeit, eine Datei direkt in einem "
-"bevorzugten Text-Editor durch klicken auf den Dateinamen zu öffnen, wenn "
-"er im Terminal erscheint. In der Liste der verfügbaren Text-Muster finden "
-"sich Beispiele, wie der Dateiname aus dem Terminal extrahiert werden kann.</small>"
+"bevorzugten Text-Editor durch klicken auf den Dateinamen zu öffnen, wenn er "
+"im Terminal erscheint. In der Liste der verfügbaren Text-Muster finden sich "
+"Beispiele, wie der Dateiname aus dem Terminal extrahiert werden kann.</small>"
 
-#: ../data/prefs.glade.h:84
+#: ../data/prefs.glade.h:85
 msgid "Enable Quick Open when Ctrl+clicking on a filename in the terminal"
 msgstr ""
 "Schnell-Öffnen bei Strg+Klick auf einen Dateinamen im Terminal aktivieren"
 
-#: ../data/prefs.glade.h:85
+#: ../data/prefs.glade.h:86
 msgid "Editor command line:"
 msgstr "Kommandozeilen"
 
-#: ../data/prefs.glade.h:87
+#: ../data/prefs.glade.h:88
 #, no-c-format
 msgid ""
 "<small><i>Use the following elements in the open editor command line:\n"
@@ -506,11 +510,11 @@ msgstr ""
 "Zum Beispiel benutze sublime mit: <b>subl %(file_path)s:%(line_number)s</b>\n"
 "</i></small>"
 
-#: ../data/prefs.glade.h:93
+#: ../data/prefs.glade.h:94
 msgid "Quick open in current terminal"
 msgstr "Schnell-Öffnen im Terminal"
 
-#: ../data/prefs.glade.h:94
+#: ../data/prefs.glade.h:95
 msgid ""
 "Here is the list of supported patterns: (to add your own, please contact the "
 "Guake's authors)"
@@ -518,15 +522,15 @@ msgstr ""
 "Hier ist eine Liste der unterstützen Muster: (um Eigene hinzuzufügen, "
 "kontaktiere bitte die Autoren von Guake)"
 
-#: ../data/prefs.glade.h:95
+#: ../data/prefs.glade.h:96
 msgid "<b>Quick Open</b>"
 msgstr "<b>Schnell öffnen</b>"
 
-#: ../data/prefs.glade.h:96
+#: ../data/prefs.glade.h:97
 msgid "Quick Open"
 msgstr "Schnell öffnen"
 
-#: ../data/prefs.glade.h:97
+#: ../data/prefs.glade.h:98
 msgid ""
 "To change a shortcut simply click on its name.\n"
 "To disable a shortcut, press the \"Backspace\" key."
@@ -534,11 +538,11 @@ msgstr ""
 "Um eine Tastenkombination zu ändern, klicke auf dessen Namen.\n"
 "Um eine Tastenkombination abzuschalten, drücke die \"Rücktaste\"."
 
-#: ../data/prefs.glade.h:99
+#: ../data/prefs.glade.h:100
 msgid "Keyboard shortcuts"
 msgstr "Tastenkombination"
 
-#: ../data/prefs.glade.h:100
+#: ../data/prefs.glade.h:101
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -550,7 +554,7 @@ msgstr ""
 "dazu verschiedene Programme und Systeme zu unterstützen, die ein anderes "
 "Terminalverhalten besitzen\" </i></small>"
 
-#: ../data/prefs.glade.h:101
+#: ../data/prefs.glade.h:102
 msgid ""
 "ASCII DEL\n"
 "Escape sequence\n"
@@ -560,37 +564,36 @@ msgstr ""
 "Escape Sequenz\n"
 "Strg-H"
 
-#: ../data/prefs.glade.h:104
+#: ../data/prefs.glade.h:105
 msgid "_Backspace key generates:"
 msgstr "_Rückschritttaste bewirkt:"
 
-#: ../data/prefs.glade.h:105
+#: ../data/prefs.glade.h:106
 msgid "_Delete key generates:"
 msgstr "_Entfernen-Taste bewirkt:"
 
-#: ../data/prefs.glade.h:106
+#: ../data/prefs.glade.h:107
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "_Zurücksetzen der Kompatibilitätsoptionen "
 
-#: ../data/prefs.glade.h:107
+#: ../data/prefs.glade.h:108
 msgid "<b>Keyboard compatibility</b>"
 msgstr "<b>Tastatur Kompatibilität </b>"
 
-#: ../data/prefs.glade.h:108
+#: ../data/prefs.glade.h:109
 msgid "Compatibility"
 msgstr "Kompatibilität"
 
-#: ../src/guake/about.py:47 ../src/guake/gconfhandler.py:427
-#: ../src/guake/guake_app.py:177 ../src/guake/guake_app.py:348
+#: ../src/guake/about.py:47 ../src/guake/gconfhandler.py:435
+#: ../src/guake/guake_app.py:181 ../src/guake/guake_app.py:376
 msgid "Guake Terminal"
 msgstr "Guake-Terminal"
 
-#. Adding a new radio button to the tabbar
-#: ../src/guake/gconfhandler.py:365 ../src/guake/guake_app.py:1548
+#: ../src/guake/gconfhandler.py:368 ../src/guake/guake_app.py:1363
 msgid "Terminal"
 msgstr "Terminal"
 
-#: ../src/guake/gconfhandler.py:428
+#: ../src/guake/gconfhandler.py:436
 #, python-format
 msgid ""
 "A problem happened when binding <b>%s</b> key.\n"
@@ -600,49 +603,49 @@ msgstr ""
 "Bitte benutzen Sie die Einstellungen um eine andere Taste oder eine andere "
 "Tastenkombination zu wählen."
 
-#: ../src/guake/guake_app.py:128
+#: ../src/guake/guake_app.py:132
 msgid "Do you want to close the tab?"
 msgstr "Möchten sie den Reiter wirklich beenden?"
 
-#: ../src/guake/guake_app.py:131
+#: ../src/guake/guake_app.py:135
 msgid "Do you really want to quit Guake?"
 msgstr "Möchten sie Guake wirklich beenden?"
 
-#: ../src/guake/guake_app.py:133
+#: ../src/guake/guake_app.py:137
 msgid " and one tab open"
 msgstr "und ein offener Reiter"
 
-#: ../src/guake/guake_app.py:135
+#: ../src/guake/guake_app.py:139
 #, python-brace-format
 msgid " and {0} tabs open"
 msgstr "und {0} Reiter offen"
 
-#: ../src/guake/guake_app.py:138
+#: ../src/guake/guake_app.py:142
 msgid "There are no processes running"
 msgstr "<b>Es existiert kein laufender Prozess</b>"
 
-#: ../src/guake/guake_app.py:140
+#: ../src/guake/guake_app.py:144
 msgid "There is a process still running"
 msgstr "<b>Es existiert noch ein laufender Prozess</b>"
 
-#: ../src/guake/guake_app.py:142
+#: ../src/guake/guake_app.py:146
 #, python-brace-format
 msgid "There are {0} processes still running"
 msgstr "Es existieren noch {0} laufende Prozesse"
 
-#: ../src/guake/guake_app.py:182
+#: ../src/guake/guake_app.py:186
 msgid "guake-indicator"
 msgstr "guake-indicator"
 
-#: ../src/guake/guake_app.py:182
+#: ../src/guake/guake_app.py:186
 msgid "guake-tray"
 msgstr "guake-tray"
 
-#: ../src/guake/guake_app.py:186
+#: ../src/guake/guake_app.py:190
 msgid "Show"
 msgstr "Zeigen"
 
-#: ../src/guake/guake_app.py:349
+#: ../src/guake/guake_app.py:377
 #, python-format
 msgid ""
 "Guake is now running,\n"
@@ -651,132 +654,137 @@ msgstr ""
 "Guake läuft bereits,\n"
 "bitte drücken Sie <b>%s</b> um es zu benutzen."
 
-#: ../src/guake/guake_app.py:611
+#: ../src/guake/guake_app.py:665
 #, python-format
 msgid "Search on Web: '%s'"
 msgstr "Im Web suchen: '%s'"
 
-#: ../src/guake/guake_app.py:616
+#: ../src/guake/guake_app.py:670
 msgid "Search on Web (no selection)"
 msgstr "Im Web suchen (keine Auswahl)"
 
-#: ../src/guake/guake_app.py:622
+#: ../src/guake/guake_app.py:678
+#, fuzzy
+msgid "Open Link: '{}...'"
+msgstr "Link öffnen: {}"
+
+#: ../src/guake/guake_app.py:680
 msgid "Open Link: {}"
 msgstr "Link öffnen: {}"
 
-#: ../src/guake/guake_app.py:625
+#: ../src/guake/guake_app.py:683
 msgid "Open Link..."
 msgstr "Link öffnen..."
 
-#: ../src/guake/guake_app.py:1300
+#: ../src/guake/guake_app.py:1402
 msgid "Rename tab"
 msgstr "Reiter umbenennen"
 
-#: ../src/guake/guake_app.py:1591
+#: ../src/guake/guake_app.py:1716
 msgid "Save to..."
 msgstr "Speichern unter..."
 
-#: ../src/guake/guake_app.py:1598 ../src/guake/prefs.py:930
+#: ../src/guake/guake_app.py:1723 ../src/guake/prefs.py:998
 msgid "All files"
 msgstr "Alle Dateien"
 
-#: ../src/guake/guake_app.py:1603
+#: ../src/guake/guake_app.py:1728
 msgid "Text and Logs"
 msgstr "Text und Protokolle"
 
-#: ../src/guake/guake_app.py:1621
+#: ../src/guake/guake_app.py:1746
 msgid "Find"
 msgstr "Suche"
 
-#: ../src/guake/guake_app.py:1623
+#: ../src/guake/guake_app.py:1748
 msgid "Forward"
 msgstr "Vorwärts"
 
-#: ../src/guake/guake_app.py:1624
+#: ../src/guake/guake_app.py:1749
 msgid "Backward"
 msgstr "Zurück"
 
-#: ../src/guake/main.py:67
+#: ../src/guake/main.py:68
 msgid "Put Guake in fullscreen mode"
 msgstr "Guake in den Vollbildmodus setzen"
 
-#: ../src/guake/main.py:71
+#: ../src/guake/main.py:72
 msgid "Toggles the visibility of the terminal window"
 msgstr "Ändert die Sichtbarkeit des Terminal-Fensters."
 
-#: ../src/guake/main.py:75
+#: ../src/guake/main.py:76
 msgid "Shows Guake main window"
 msgstr "Zeigt das Hauptfenster von Guake"
 
-#: ../src/guake/main.py:79
+#: ../src/guake/main.py:80
 msgid "Hides Guake main window"
 msgstr "Versteckt das Hauptfenster von Guake"
 
-#: ../src/guake/main.py:83
+#: ../src/guake/main.py:84
 msgid "Shows Guake preference window"
 msgstr "Zeigt die Einstellungen von Guake"
 
-#: ../src/guake/main.py:87
+#: ../src/guake/main.py:88
 msgid "Shows Guake's about info"
 msgstr "Zeigt die Programminformationen von Guake"
 
-#: ../src/guake/main.py:91
+#: ../src/guake/main.py:92
 msgid "Add a new tab (with current directory set to NEW_TAB)"
 msgstr "Neuer Reiter (mit aktuellem Verzeichnis von NEW_TAB)"
 
-#: ../src/guake/main.py:95
+#: ../src/guake/main.py:96
 msgid "Select a tab (SELECT_TAB is the index of the tab)"
 msgstr "Wähle einen Reiter aus (SELECT_TAB ist der Index des Reiters)"
 
-#: ../src/guake/main.py:99
+#: ../src/guake/main.py:100
 msgid "Return the selected tab index."
 msgstr "Gib den Index des ausgewählten Reiters zurück."
 
-#: ../src/guake/main.py:103
+#: ../src/guake/main.py:104
 msgid "Execute an arbitrary command in the selected tab."
 msgstr "Eigenen Befehl im ausgewählten Reiter ausführen"
 
-#: ../src/guake/main.py:107
+#: ../src/guake/main.py:108
 msgid "Specify the tab to rename. Default is 0."
 msgstr "Benenne den Reiter zum Umbenennen. Standard ist 0."
 
-#: ../src/guake/main.py:111
+#: ../src/guake/main.py:112
 msgid "Set the hexadecimal (#rrggbb) background color of the selected tab."
 msgstr ""
 "Hexadezimale (#rrggbb) Hintergrundfarbe des ausgewählten Reiters setzen."
 
-#: ../src/guake/main.py:116
+#: ../src/guake/main.py:117
 msgid "Set the hexadecimal (#rrggbb) foreground color of the selected tab."
 msgstr ""
 "Hexadezimale (#rrggbb) Vordergrundfarbe des ausgewählten Reiters setzen."
 
-#: ../src/guake/main.py:122
+#: ../src/guake/main.py:123
 msgid ""
 "Rename the specified tab. Reset to default if TITLE is a single dash \"-\"."
 msgstr ""
 "Den angegebenen Reiter umbenennen. Auf die Voreinstellung zurücksetzen fall "
 "TITLE ein Minus \"-\" ist."
 
-#: ../src/guake/main.py:128
+#: ../src/guake/main.py:129
 msgid ""
 "Rename the current tab. Reset to default if TITLE is a single dash \"-\"."
 msgstr ""
 "Den aktuellen Reiter umbenennen. Auf die Voreinstellung zurücksetzen fall "
 "TITLE ein Minus \"-\" ist."
 
-#: ../src/guake/main.py:133
+#: ../src/guake/main.py:134
 msgid "Says to Guake go away =("
 msgstr "Sagt Guake, dass es verschwinden soll :o("
 
-#: ../src/guake/main.py:137
+#: ../src/guake/main.py:138
 msgid "Do not execute the start up script"
 msgstr "Das Startskript nicht ausführen"
 
-#: ../src/guake/main.py:231
+#: ../src/guake/main.py:235
 msgid "Guake can not init!"
 msgstr "Guake kann nicht starten!"
 
-#: ../src/guake/main.py:232
+#: ../src/guake/main.py:236
 msgid ""
 "Gconf Error.\n"
 "Have you installed <b>guake.schemas</b> properly?"
@@ -789,32 +797,191 @@ msgstr ""
 msgid "<user shell>"
 msgstr "<Benutzershell>"
 
-#: ../src/guake/prefs.py:467
+#: ../src/guake/prefs.py:77
+msgid "Toggle Guake visibility"
+msgstr "Guake Terimal Sichtbarkeit umschalten"
+
+#: ../src/guake/prefs.py:81
+#, fuzzy
+msgid "Toggle Hide on Lose Focus"
+msgstr "Verstecken, wenn der Fokus verloren geht"
+
+#: ../src/guake/prefs.py:88
+msgid "Tab management"
+msgstr "Tab Verwaltung"
+
+#: ../src/guake/prefs.py:90
+#, fuzzy
+msgid "New tab"
+msgstr "Neuer Reiter"
+
+#: ../src/guake/prefs.py:92
+msgid "Close tab"
+msgstr "Tab schließen"
+
+#: ../src/guake/prefs.py:94
+msgid "Rename current tab"
+msgstr "Aktuellen Tab umbenennen"
+
+#: ../src/guake/prefs.py:97
+msgid "Navigation"
+msgstr "Navigation"
+
+#: ../src/guake/prefs.py:99
+msgid "Go to previous tab"
+msgstr "Gehe zum vorigen Tab"
+
+#: ../src/guake/prefs.py:101
+msgid "Go to next tab"
+msgstr "Gehe zum nächsten Tab"
+
+#: ../src/guake/prefs.py:103
+#, fuzzy
+msgid "Move current tab left"
+msgstr "Aktuellen Tab umbenennen"
+
+#: ../src/guake/prefs.py:105
+#, fuzzy
+msgid "Move current tab right"
+msgstr "Aktuellen Tab umbenennen"
+
+#: ../src/guake/prefs.py:107
+#, fuzzy
+msgid "Go to first tab"
+msgstr "Gehe zum nächsten Tab"
+
+#: ../src/guake/prefs.py:109
+#, fuzzy
+msgid "Go to second tab"
+msgstr "Gehe zum nächsten Tab"
+
+#: ../src/guake/prefs.py:111
+#, fuzzy
+msgid "Go to third tab"
+msgstr "Gehe zum nächsten Tab"
+
+#: ../src/guake/prefs.py:113
+#, fuzzy
+msgid "Go to fourth tab"
+msgstr "Gehe zum nächsten Tab"
+
+#: ../src/guake/prefs.py:115
+#, fuzzy
+msgid "Go to fifth tab"
+msgstr "Gehe zum nächsten Tab"
+
+#: ../src/guake/prefs.py:117
+#, fuzzy
+msgid "Go to sixth tab"
+msgstr "Gehe zum nächsten Tab"
+
+#: ../src/guake/prefs.py:119
+#, fuzzy
+msgid "Go to seventh tab"
+msgstr "Gehe zum nächsten Tab"
+
+#: ../src/guake/prefs.py:121
+#, fuzzy
+msgid "Go to eighth tab"
+msgstr "Gehe zum nächsten Tab"
+
+#: ../src/guake/prefs.py:123
+#, fuzzy
+msgid "Go to ninth tab"
+msgstr "Gehe zum nächsten Tab"
+
+#: ../src/guake/prefs.py:125
+#, fuzzy
+msgid "Go to tenth tab"
+msgstr "Gehe zum nächsten Tab"
+
+#: ../src/guake/prefs.py:127
+#, fuzzy
+msgid "Go to last tab"
+msgstr "Gehe zum nächsten Tab"
+
+#: ../src/guake/prefs.py:132
+msgid "Zoom out"
+msgstr ""
+
+#: ../src/guake/prefs.py:134
+msgid "Zoom in"
+msgstr ""
+
+#: ../src/guake/prefs.py:136
+msgid "Zoom in (alternative)"
+msgstr ""
+
+#: ../src/guake/prefs.py:138
+msgid "Increase height"
+msgstr ""
+
+#: ../src/guake/prefs.py:140
+msgid "Decrease height"
+msgstr ""
+
+#: ../src/guake/prefs.py:142
+#, fuzzy
+msgid "Increase transparency"
+msgstr "Transparenz:"
+
+#: ../src/guake/prefs.py:144
+#, fuzzy
+msgid "Decrease transparency"
+msgstr "Transparenz:"
+
+#: ../src/guake/prefs.py:146
+#, fuzzy
+msgid "Toggle transparency"
+msgstr "Transparenz:"
+
+#: ../src/guake/prefs.py:149
+msgid "Clipboard"
+msgstr "Zwischenablage"
+
+#: ../src/guake/prefs.py:151
+msgid "Copy text to clipboard"
+msgstr "Kopiere Text zur Zwischenablage"
+
+#: ../src/guake/prefs.py:153
+msgid "Paste text from clipboard"
+msgstr "Füge Text aus der Zwischenablage ein"
+
+#: ../src/guake/prefs.py:156
+msgid "Extra features"
+msgstr ""
+
+#: ../src/guake/prefs.py:159
+#, fuzzy
+msgid "Search select text on web"
+msgstr "Im Web suchen"
+
+#: ../src/guake/prefs.py:519
 msgid "Action"
 msgstr "Aktion"
 
-#: ../src/guake/prefs.py:477
+#: ../src/guake/prefs.py:529
 msgid "Shortcut"
 msgstr "Kürzel"
 
-#: ../src/guake/prefs.py:619 ../src/guake/prefs.py:665
+#: ../src/guake/prefs.py:678 ../src/guake/prefs.py:724
 msgid "Custom"
 msgstr "Angepasst"
 
-#: ../src/guake/prefs.py:926
+#: ../src/guake/prefs.py:994
 msgid "JSON files"
 msgstr "JSON-Dateien"
 
-#: ../src/guake/prefs.py:1019
+#: ../src/guake/prefs.py:1088
 #, python-format
 msgid "The shortcut \"%s\" is already in use."
 msgstr "Die Tastenkombination \"%s\" ist bereits belegt."
 
-#: ../src/guake/prefs.py:1020
+#: ../src/guake/prefs.py:1089
 msgid "Error setting keybinding."
 msgstr "Fehler beim Setzen der Tastenkombination"
 
-#: ../src/guake/prefs.py:1032
+#: ../src/guake/prefs.py:1101
 #, python-format
 msgid ""
 "The shortcut \"%s\" cannot be used because it will become impossible to type "
@@ -847,36 +1014,6 @@ msgstr ""
 
 #~ msgid "Use system defaults"
 #~ msgstr "Systemeinstellungen benutzen"
-
-#~ msgid "Toggle Guake visibility"
-#~ msgstr "Guake Terimal Sichtbarkeit umschalten"
-
-#~ msgid "Tab management"
-#~ msgstr "Tab Verwaltung"
-
-#~ msgid "Close tab"
-#~ msgstr "Tab schließen"
-
-#~ msgid "Rename current tab"
-#~ msgstr "Aktuellen Tab umbenennen"
-
-#~ msgid "Navigation"
-#~ msgstr "Navigation"
-
-#~ msgid "Go to previous tab"
-#~ msgstr "Gehe zum vorigen Tab"
-
-#~ msgid "Go to next tab"
-#~ msgstr "Gehe zum nächsten Tab"
-
-#~ msgid "Clipboard"
-#~ msgstr "Zwischenablage"
-
-#~ msgid "Copy text to clipboard"
-#~ msgstr "Kopiere Text zur Zwischenablage"
-
-#~ msgid "Paste text from clipboard"
-#~ msgstr "Füge Text aus der Zwischenablage ein"
 
 #~ msgid "Select a tab"
 #~ msgstr "Tab auswählen"

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Guake 0.4.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-12-01 16:49+0100\n"
+"POT-Creation-Date: 2016-08-17 21:41+0000\n"
 "PO-Revision-Date: 2009-08-25 18:58+0300\n"
 "Last-Translator: Μαριμπής Αβραάμ <makism@venus.cs.teicrete.gr>\n"
 "Language-Team: guake@lists.guake.org\n"
@@ -107,7 +107,7 @@ msgstr "Αντιγραφή"
 msgid "Paste"
 msgstr "Επικόλληση"
 
-#: ../data/guake.glade.h:3
+#: ../data/guake.glade.h:3 ../src/guake/prefs.py:79
 msgid "Toggle Fullscreen"
 msgstr "Εναλλαγή πλήρους οθόνης"
 
@@ -115,7 +115,7 @@ msgstr "Εναλλαγή πλήρους οθόνης"
 msgid "Save to File..."
 msgstr ""
 
-#: ../data/guake.glade.h:5
+#: ../data/guake.glade.h:5 ../src/guake/prefs.py:85
 #, fuzzy
 msgid "Reset terminal"
 msgstr "Guake-Terminal"
@@ -146,7 +146,7 @@ msgstr ""
 msgid "Search on Web"
 msgstr ""
 
-#: ../data/guake.glade.h:12
+#: ../data/guake.glade.h:12 ../src/guake/prefs.py:83
 msgid "Quit"
 msgstr "Έξοδος"
 
@@ -269,204 +269,208 @@ msgid "Use VTE titles for tab names"
 msgstr ""
 
 #: ../data/prefs.glade.h:33
-msgid "Max tab name length:"
+msgid "Abbreviate directories in tab names"
 msgstr ""
 
 #: ../data/prefs.glade.h:34
+msgid "Max tab name length:"
+msgstr ""
+
+#: ../data/prefs.glade.h:35
 msgid "Hide on lose focus"
 msgstr "Απόκρυψη όταν χάνει εστίαση"
 
-#: ../data/prefs.glade.h:35
+#: ../data/prefs.glade.h:36
 msgid "Show tab bar"
 msgstr "Εμφάνισε την γραμμή καρτελών"
 
-#: ../data/prefs.glade.h:36
+#: ../data/prefs.glade.h:37
 #, fuzzy
 msgid "Start fullscreen"
 msgstr "Εναλλαγή πλήρους οθόνης"
 
-#: ../data/prefs.glade.h:37
+#: ../data/prefs.glade.h:38
 msgid "<b>Main Window</b>"
 msgstr "<b>Κεντρικό Παράθυρο</b>"
 
-#: ../data/prefs.glade.h:38
+#: ../data/prefs.glade.h:39
 msgid "Left"
 msgstr ""
 
-#: ../data/prefs.glade.h:39
+#: ../data/prefs.glade.h:40
 msgid "Center"
 msgstr ""
 
-#: ../data/prefs.glade.h:40
+#: ../data/prefs.glade.h:41
 msgid "Right"
 msgstr ""
 
-#: ../data/prefs.glade.h:41
+#: ../data/prefs.glade.h:42
 #, fuzzy
 msgid "<b>Main Window Horizontal Alignment</b>"
 msgstr "<b>Μέγεθος κεντρικού παραθύρου</b>"
 
-#: ../data/prefs.glade.h:42
+#: ../data/prefs.glade.h:43
 #, fuzzy
 msgid "<b>Main Window Height</b>"
 msgstr "<b>Κεντρικό Παράθυρο</b>"
 
-#: ../data/prefs.glade.h:43
+#: ../data/prefs.glade.h:44
 #, fuzzy
 msgid "<b>Main Window Width</b>"
 msgstr "<b>Κεντρικό Παράθυρο</b>"
 
-#: ../data/prefs.glade.h:44
+#: ../data/prefs.glade.h:45
 msgid "Custom command file path: "
 msgstr ""
 
-#: ../data/prefs.glade.h:45
+#: ../data/prefs.glade.h:46
 msgid "Please select a json file"
 msgstr ""
 
-#: ../data/prefs.glade.h:46
+#: ../data/prefs.glade.h:47 ../src/guake/prefs.py:75
 msgid "General"
 msgstr "Γενικά"
 
-#: ../data/prefs.glade.h:47
+#: ../data/prefs.glade.h:48
 msgid "Default interpreter:"
 msgstr "Προκαθορισμένος μεταγλωττιστής:"
 
-#: ../data/prefs.glade.h:48
+#: ../data/prefs.glade.h:49
 msgid "_Run command as a login shell"
 msgstr "_Εκτέλεση εντολής ως κέλυφος σύνδεσης"
 
-#: ../data/prefs.glade.h:49
+#: ../data/prefs.glade.h:50
 msgid "_Open new tab in current directory"
 msgstr ""
 
-#: ../data/prefs.glade.h:50
+#: ../data/prefs.glade.h:51
 msgid "<b>Shell</b>"
 msgstr "<b>Κελύφος</b>"
 
-#: ../data/prefs.glade.h:51
+#: ../data/prefs.glade.h:52
 msgid "Shell"
 msgstr ""
 
-#: ../data/prefs.glade.h:52
+#: ../data/prefs.glade.h:53
 msgid "Show scrollbar"
 msgstr "Εμφάνιση γραμμή κύλισης"
 
-#: ../data/prefs.glade.h:53
+#: ../data/prefs.glade.h:54
 msgid "Scrollback lines:"
 msgstr "Γραμμές κύλισης προς τα πίσω:"
 
-#: ../data/prefs.glade.h:54
+#: ../data/prefs.glade.h:55
 msgid "On output"
 msgstr "Όταν υπάρχει έξοδος"
 
-#: ../data/prefs.glade.h:55
+#: ../data/prefs.glade.h:56
 msgid "On key stroke"
 msgstr "Στο πάτημα ενός πλήκτρου"
 
-#: ../data/prefs.glade.h:56
+#: ../data/prefs.glade.h:57
 msgid "<b>Scroll</b>"
 msgstr "<b>Κύλιση</b>"
 
-#: ../data/prefs.glade.h:57
+#: ../data/prefs.glade.h:58
 msgid "Scrolling"
 msgstr "Κύλιση"
 
-#: ../data/prefs.glade.h:58
+#: ../data/prefs.glade.h:59
 msgid "Use the system fixed width font"
 msgstr ""
 
-#: ../data/prefs.glade.h:59
+#: ../data/prefs.glade.h:60
 msgid "Font:"
 msgstr ""
 
-#: ../data/prefs.glade.h:60
+#: ../data/prefs.glade.h:61
 msgid "Choose some font"
 msgstr "Επιλογή γραμματοσειράς"
 
-#: ../data/prefs.glade.h:61
+#: ../data/prefs.glade.h:62
 msgid "Text color:"
 msgstr ""
 
-#: ../data/prefs.glade.h:62
+#: ../data/prefs.glade.h:63
 msgid "Background color:"
 msgstr ""
 
-#: ../data/prefs.glade.h:63
+#: ../data/prefs.glade.h:64
 msgid "Cursor shape:"
 msgstr ""
 
-#: ../data/prefs.glade.h:64
+#: ../data/prefs.glade.h:65
 msgid ""
 "Block\n"
 "I-Beam\n"
 "Underline"
 msgstr ""
 
-#: ../data/prefs.glade.h:67
+#: ../data/prefs.glade.h:68
 msgid ""
 "Follow GTK+ setting\n"
 "Blink on\n"
 "Blink off"
 msgstr ""
 
-#: ../data/prefs.glade.h:70
+#: ../data/prefs.glade.h:71
 msgid "Cursor blink mode:"
 msgstr ""
 
-#: ../data/prefs.glade.h:71
+#: ../data/prefs.glade.h:72
 msgid "Allow bold font"
 msgstr ""
 
-#: ../data/prefs.glade.h:72
+#: ../data/prefs.glade.h:73
 #, fuzzy
 msgid "<b>Palette</b>"
 msgstr "<b>Γενικά</b>"
 
-#: ../data/prefs.glade.h:73
+#: ../data/prefs.glade.h:74
 msgid "Built-in schemes:"
 msgstr ""
 
-#: ../data/prefs.glade.h:74
+#: ../data/prefs.glade.h:75
 #, fuzzy
 msgid "Color palette:"
 msgstr "Χρώμα:"
 
-#: ../data/prefs.glade.h:75
+#: ../data/prefs.glade.h:76
 msgid "Font color"
 msgstr ""
 
-#: ../data/prefs.glade.h:76
+#: ../data/prefs.glade.h:77
 #, fuzzy
 msgid "Background color"
 msgstr "<b>Φόντο</b>"
 
-#: ../data/prefs.glade.h:77
+#: ../data/prefs.glade.h:78
 msgid "Use font and background color from the palette"
 msgstr ""
 
-#: ../data/prefs.glade.h:78
+#: ../data/prefs.glade.h:79
 msgid "Demo:"
 msgstr ""
 
-#: ../data/prefs.glade.h:79
+#: ../data/prefs.glade.h:80
 #, fuzzy
 msgid "<b>Effects</b>"
 msgstr "<b>Γραμματοσειρές</b>"
 
-#: ../data/prefs.glade.h:80
+#: ../data/prefs.glade.h:81
 msgid "Transparency:"
 msgstr "Διαφάνεια:"
 
-#: ../data/prefs.glade.h:81
+#: ../data/prefs.glade.h:82
 msgid "Background image:"
 msgstr ""
 
-#: ../data/prefs.glade.h:82
+#: ../data/prefs.glade.h:83 ../src/guake/prefs.py:130
 msgid "Appearance"
 msgstr "Εμφάνιση"
 
-#: ../data/prefs.glade.h:83
+#: ../data/prefs.glade.h:84
 msgid ""
 "<small>Quick open is a feature allowing you to open a file directly into "
 "your favorite text editor by clicking on its filename when it appears in "
@@ -474,15 +478,15 @@ msgid ""
 "extract filename below.</small>"
 msgstr ""
 
-#: ../data/prefs.glade.h:84
+#: ../data/prefs.glade.h:85
 msgid "Enable Quick Open when Ctrl+clicking on a filename in the terminal"
 msgstr ""
 
-#: ../data/prefs.glade.h:85
+#: ../data/prefs.glade.h:86
 msgid "Editor command line:"
 msgstr ""
 
-#: ../data/prefs.glade.h:87
+#: ../data/prefs.glade.h:88
 #, no-c-format
 msgid ""
 "<small><i>Use the following elements in the open editor command line:\n"
@@ -494,36 +498,36 @@ msgid ""
 "</i></small>"
 msgstr ""
 
-#: ../data/prefs.glade.h:93
+#: ../data/prefs.glade.h:94
 msgid "Quick open in current terminal"
 msgstr ""
 
-#: ../data/prefs.glade.h:94
+#: ../data/prefs.glade.h:95
 msgid ""
 "Here is the list of supported patterns: (to add your own, please contact the "
 "Guake's authors)"
 msgstr ""
 
-#: ../data/prefs.glade.h:95
+#: ../data/prefs.glade.h:96
 #, fuzzy
 msgid "<b>Quick Open</b>"
 msgstr "<b>Γραμματοσειρές</b>"
 
-#: ../data/prefs.glade.h:96
+#: ../data/prefs.glade.h:97
 msgid "Quick Open"
 msgstr ""
 
-#: ../data/prefs.glade.h:97
+#: ../data/prefs.glade.h:98
 msgid ""
 "To change a shortcut simply click on its name.\n"
 "To disable a shortcut, press the \"Backspace\" key."
 msgstr ""
 
-#: ../data/prefs.glade.h:99
+#: ../data/prefs.glade.h:100
 msgid "Keyboard shortcuts"
 msgstr "Συντομεύσεις πληκτρολογίου"
 
-#: ../data/prefs.glade.h:100
+#: ../data/prefs.glade.h:101
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -535,7 +539,7 @@ msgstr ""
 "να δουλέψετε με συγκεκριμένες εφαρμογές και λειτουργικά συστήματα τα οποία "
 "απαιτούν διαφορετική συμπεριφορά από το τερματικό.</i></small>"
 
-#: ../data/prefs.glade.h:101
+#: ../data/prefs.glade.h:102
 msgid ""
 "ASCII DEL\n"
 "Escape sequence\n"
@@ -545,39 +549,38 @@ msgstr ""
 "Escape sequence\n"
 "Control-H"
 
-#: ../data/prefs.glade.h:104
+#: ../data/prefs.glade.h:105
 msgid "_Backspace key generates:"
 msgstr "Το πλήκτρο _Backspace παράγει:"
 
-#: ../data/prefs.glade.h:105
+#: ../data/prefs.glade.h:106
 msgid "_Delete key generates:"
 msgstr "Το πλήκτρο _Delete παράγει:"
 
-#: ../data/prefs.glade.h:106
+#: ../data/prefs.glade.h:107
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "_Επαναφορά των Προκαθορισμένων Ρυθμίσεων Συμβατότητας"
 
-#: ../data/prefs.glade.h:107
+#: ../data/prefs.glade.h:108
 msgid "<b>Keyboard compatibility</b>"
 msgstr "<b>Συμβατότητα πληκτρολογίου</b>"
 
-#: ../data/prefs.glade.h:108
+#: ../data/prefs.glade.h:109
 msgid "Compatibility"
 msgstr "Συμβατότητα"
 
-#: ../src/guake/about.py:47 ../src/guake/gconfhandler.py:427
-#: ../src/guake/guake_app.py:177 ../src/guake/guake_app.py:348
+#: ../src/guake/about.py:47 ../src/guake/gconfhandler.py:435
+#: ../src/guake/guake_app.py:181 ../src/guake/guake_app.py:376
 #, fuzzy
 msgid "Guake Terminal"
 msgstr "Guake-Terminal"
 
-#. Adding a new radio button to the tabbar
-#: ../src/guake/gconfhandler.py:365 ../src/guake/guake_app.py:1548
+#: ../src/guake/gconfhandler.py:368 ../src/guake/guake_app.py:1363
 #, fuzzy
 msgid "Terminal"
 msgstr "Τερματικό %s"
 
-#: ../src/guake/gconfhandler.py:428
+#: ../src/guake/gconfhandler.py:436
 #, fuzzy, python-format
 msgid ""
 "A problem happened when binding <b>%s</b> key.\n"
@@ -587,50 +590,50 @@ msgstr ""
 "Παρακαλώ χρησιμοποιήστε την φόρμα Ρυθμίσεων του Guake και επιλέξτε ένα "
 "διαφορετικό πλήκτρο (Το εικονίδιο συστήματος ήταν ενεργοποιημένο)"
 
-#: ../src/guake/guake_app.py:128
+#: ../src/guake/guake_app.py:132
 msgid "Do you want to close the tab?"
 msgstr ""
 
-#: ../src/guake/guake_app.py:131
+#: ../src/guake/guake_app.py:135
 msgid "Do you really want to quit Guake?"
 msgstr ""
 
-#: ../src/guake/guake_app.py:133
+#: ../src/guake/guake_app.py:137
 #, fuzzy
 msgid " and one tab open"
 msgstr "Προσθήκη νέας καρτέλας"
 
-#: ../src/guake/guake_app.py:135
+#: ../src/guake/guake_app.py:139
 #, python-brace-format
 msgid " and {0} tabs open"
 msgstr ""
 
-#: ../src/guake/guake_app.py:138
+#: ../src/guake/guake_app.py:142
 msgid "There are no processes running"
 msgstr ""
 
-#: ../src/guake/guake_app.py:140
+#: ../src/guake/guake_app.py:144
 msgid "There is a process still running"
 msgstr ""
 
-#: ../src/guake/guake_app.py:142
+#: ../src/guake/guake_app.py:146
 #, python-brace-format
 msgid "There are {0} processes still running"
 msgstr ""
 
-#: ../src/guake/guake_app.py:182
+#: ../src/guake/guake_app.py:186
 msgid "guake-indicator"
 msgstr ""
 
-#: ../src/guake/guake_app.py:182
+#: ../src/guake/guake_app.py:186
 msgid "guake-tray"
 msgstr ""
 
-#: ../src/guake/guake_app.py:186
+#: ../src/guake/guake_app.py:190
 msgid "Show"
 msgstr ""
 
-#: ../src/guake/guake_app.py:349
+#: ../src/guake/guake_app.py:377
 #, fuzzy, python-format
 msgid ""
 "Guake is now running,\n"
@@ -639,128 +642,132 @@ msgstr ""
 "Το Guake εκτελείται ήδη,\n"
 "πατήστε <b>%s</b> για να το χρησιμοποιήσετε."
 
-#: ../src/guake/guake_app.py:611
+#: ../src/guake/guake_app.py:665
 #, python-format
 msgid "Search on Web: '%s'"
 msgstr ""
 
-#: ../src/guake/guake_app.py:616
+#: ../src/guake/guake_app.py:670
 msgid "Search on Web (no selection)"
 msgstr ""
 
-#: ../src/guake/guake_app.py:622
+#: ../src/guake/guake_app.py:678
+msgid "Open Link: '{}...'"
+msgstr ""
+
+#: ../src/guake/guake_app.py:680
 msgid "Open Link: {}"
 msgstr ""
 
-#: ../src/guake/guake_app.py:625
+#: ../src/guake/guake_app.py:683
 msgid "Open Link..."
 msgstr ""
 
-#: ../src/guake/guake_app.py:1300
+#: ../src/guake/guake_app.py:1402
 msgid "Rename tab"
 msgstr "Μετονομασία καρτέλας"
 
-#: ../src/guake/guake_app.py:1591
+#: ../src/guake/guake_app.py:1716
 msgid "Save to..."
 msgstr ""
 
-#: ../src/guake/guake_app.py:1598 ../src/guake/prefs.py:930
+#: ../src/guake/guake_app.py:1723 ../src/guake/prefs.py:998
 msgid "All files"
 msgstr ""
 
-#: ../src/guake/guake_app.py:1603
+#: ../src/guake/guake_app.py:1728
 msgid "Text and Logs"
 msgstr ""
 
-#: ../src/guake/guake_app.py:1621
+#: ../src/guake/guake_app.py:1746
 msgid "Find"
 msgstr ""
 
-#: ../src/guake/guake_app.py:1623
+#: ../src/guake/guake_app.py:1748
 msgid "Forward"
 msgstr ""
 
-#: ../src/guake/guake_app.py:1624
+#: ../src/guake/guake_app.py:1749
 msgid "Backward"
 msgstr ""
 
-#: ../src/guake/main.py:67
+#: ../src/guake/main.py:68
 msgid "Put Guake in fullscreen mode"
 msgstr ""
 
-#: ../src/guake/main.py:71
+#: ../src/guake/main.py:72
 msgid "Toggles the visibility of the terminal window"
 msgstr "Εναλλάσει την ορατότητα του τερματικού παραθύρου"
 
-#: ../src/guake/main.py:75
+#: ../src/guake/main.py:76
 #, fuzzy
 msgid "Shows Guake main window"
 msgstr "Εμφανίζει το παράθυρο προτιμήσεων του Guake"
 
-#: ../src/guake/main.py:79
+#: ../src/guake/main.py:80
 #, fuzzy
 msgid "Hides Guake main window"
 msgstr "Εμφανίζει το παράθυρο προτιμήσεων του Guake"
 
-#: ../src/guake/main.py:83
+#: ../src/guake/main.py:84
 msgid "Shows Guake preference window"
 msgstr "Εμφανίζει το παράθυρο προτιμήσεων του Guake"
 
-#: ../src/guake/main.py:87
+#: ../src/guake/main.py:88
 msgid "Shows Guake's about info"
 msgstr "Εμφανίζει πληροφορίες περί του Guake"
 
-#: ../src/guake/main.py:91
+#: ../src/guake/main.py:92
 msgid "Add a new tab (with current directory set to NEW_TAB)"
 msgstr ""
 
-#: ../src/guake/main.py:95
+#: ../src/guake/main.py:96
 msgid "Select a tab (SELECT_TAB is the index of the tab)"
 msgstr ""
 
-#: ../src/guake/main.py:99
+#: ../src/guake/main.py:100
 msgid "Return the selected tab index."
 msgstr "Restituisce l'indice della scheda selezionata."
 
-#: ../src/guake/main.py:103
+#: ../src/guake/main.py:104
 msgid "Execute an arbitrary command in the selected tab."
 msgstr "Εκτέλεσε μία εντολή στην επιλεγμένη καρτέλα"
 
-#: ../src/guake/main.py:107
+#: ../src/guake/main.py:108
 msgid "Specify the tab to rename. Default is 0."
 msgstr ""
 
-#: ../src/guake/main.py:111
+#: ../src/guake/main.py:112
 msgid "Set the hexadecimal (#rrggbb) background color of the selected tab."
 msgstr ""
 
-#: ../src/guake/main.py:116
+#: ../src/guake/main.py:117
 msgid "Set the hexadecimal (#rrggbb) foreground color of the selected tab."
 msgstr ""
 
-#: ../src/guake/main.py:122
+#: ../src/guake/main.py:123
 msgid ""
 "Rename the specified tab. Reset to default if TITLE is a single dash \"-\"."
 msgstr ""
 
-#: ../src/guake/main.py:128
+#: ../src/guake/main.py:129
 msgid ""
 "Rename the current tab. Reset to default if TITLE is a single dash \"-\"."
 msgstr ""
 
-#: ../src/guake/main.py:133
+#: ../src/guake/main.py:134
 msgid "Says to Guake go away =("
 msgstr "Λέει στο Guake να φύγει =("
 
-#: ../src/guake/main.py:137
+#: ../src/guake/main.py:138
 msgid "Do not execute the start up script"
 msgstr ""
 
-#: ../src/guake/main.py:231
+#: ../src/guake/main.py:235
 msgid "Guake can not init!"
 msgstr "Το Guake δεν μπορεί να ξεκινήσει!"
 
-#: ../src/guake/main.py:232
+#: ../src/guake/main.py:236
 #, fuzzy
 msgid ""
 "Gconf Error.\n"
@@ -774,32 +781,190 @@ msgstr ""
 msgid "<user shell>"
 msgstr "<κέλυφος χρήστη>"
 
-#: ../src/guake/prefs.py:467
+#: ../src/guake/prefs.py:77
+msgid "Toggle Guake visibility"
+msgstr "Εναλλαγή ορατότητας του Guake"
+
+#: ../src/guake/prefs.py:81
+#, fuzzy
+msgid "Toggle Hide on Lose Focus"
+msgstr "Απόκρυψη όταν χάνει εστίαση"
+
+#: ../src/guake/prefs.py:88
+msgid "Tab management"
+msgstr "Διαχείρηση καρτελών"
+
+#: ../src/guake/prefs.py:90
+#, fuzzy
+msgid "New tab"
+msgstr "Νέα καρτέλα"
+
+#: ../src/guake/prefs.py:92
+msgid "Close tab"
+msgstr "Κλείσμο καρτέλας"
+
+#: ../src/guake/prefs.py:94
+msgid "Rename current tab"
+msgstr "Μετονομασία τρέχουσας καρτέλας"
+
+#: ../src/guake/prefs.py:97
+msgid "Navigation"
+msgstr "Πλοήγηση"
+
+#: ../src/guake/prefs.py:99
+msgid "Go to previous tab"
+msgstr "Μετάβαση στην προηγούμενη καρτέλα"
+
+#: ../src/guake/prefs.py:101
+msgid "Go to next tab"
+msgstr "Μετάβαση στην επόμενη καρτέλα"
+
+#: ../src/guake/prefs.py:103
+#, fuzzy
+msgid "Move current tab left"
+msgstr "Μετονομασία τρέχουσας καρτέλας"
+
+#: ../src/guake/prefs.py:105
+#, fuzzy
+msgid "Move current tab right"
+msgstr "Μετονομασία τρέχουσας καρτέλας"
+
+#: ../src/guake/prefs.py:107
+#, fuzzy
+msgid "Go to first tab"
+msgstr "Μετάβαση στην επόμενη καρτέλα"
+
+#: ../src/guake/prefs.py:109
+#, fuzzy
+msgid "Go to second tab"
+msgstr "Μετάβαση στην επόμενη καρτέλα"
+
+#: ../src/guake/prefs.py:111
+#, fuzzy
+msgid "Go to third tab"
+msgstr "Μετάβαση στην επόμενη καρτέλα"
+
+#: ../src/guake/prefs.py:113
+#, fuzzy
+msgid "Go to fourth tab"
+msgstr "Μετάβαση στην επόμενη καρτέλα"
+
+#: ../src/guake/prefs.py:115
+#, fuzzy
+msgid "Go to fifth tab"
+msgstr "Μετάβαση στην επόμενη καρτέλα"
+
+#: ../src/guake/prefs.py:117
+#, fuzzy
+msgid "Go to sixth tab"
+msgstr "Μετάβαση στην επόμενη καρτέλα"
+
+#: ../src/guake/prefs.py:119
+#, fuzzy
+msgid "Go to seventh tab"
+msgstr "Μετάβαση στην επόμενη καρτέλα"
+
+#: ../src/guake/prefs.py:121
+#, fuzzy
+msgid "Go to eighth tab"
+msgstr "Μετάβαση στην επόμενη καρτέλα"
+
+#: ../src/guake/prefs.py:123
+#, fuzzy
+msgid "Go to ninth tab"
+msgstr "Μετάβαση στην επόμενη καρτέλα"
+
+#: ../src/guake/prefs.py:125
+#, fuzzy
+msgid "Go to tenth tab"
+msgstr "Μετάβαση στην επόμενη καρτέλα"
+
+#: ../src/guake/prefs.py:127
+#, fuzzy
+msgid "Go to last tab"
+msgstr "Μετάβαση στην επόμενη καρτέλα"
+
+#: ../src/guake/prefs.py:132
+msgid "Zoom out"
+msgstr ""
+
+#: ../src/guake/prefs.py:134
+msgid "Zoom in"
+msgstr ""
+
+#: ../src/guake/prefs.py:136
+msgid "Zoom in (alternative)"
+msgstr ""
+
+#: ../src/guake/prefs.py:138
+msgid "Increase height"
+msgstr ""
+
+#: ../src/guake/prefs.py:140
+msgid "Decrease height"
+msgstr ""
+
+#: ../src/guake/prefs.py:142
+#, fuzzy
+msgid "Increase transparency"
+msgstr "Διαφάνεια:"
+
+#: ../src/guake/prefs.py:144
+#, fuzzy
+msgid "Decrease transparency"
+msgstr "Διαφάνεια:"
+
+#: ../src/guake/prefs.py:146
+#, fuzzy
+msgid "Toggle transparency"
+msgstr "Διαφάνεια:"
+
+#: ../src/guake/prefs.py:149
+msgid "Clipboard"
+msgstr "Πρόχειρο"
+
+#: ../src/guake/prefs.py:151
+msgid "Copy text to clipboard"
+msgstr "Αντιγραφή κειμένου στο πρόχειρο"
+
+#: ../src/guake/prefs.py:153
+msgid "Paste text from clipboard"
+msgstr "Επικόλληση κειμένου από το πρόχειρο"
+
+#: ../src/guake/prefs.py:156
+msgid "Extra features"
+msgstr ""
+
+#: ../src/guake/prefs.py:159
+msgid "Search select text on web"
+msgstr ""
+
+#: ../src/guake/prefs.py:519
 msgid "Action"
 msgstr "Ενέργεια"
 
-#: ../src/guake/prefs.py:477
+#: ../src/guake/prefs.py:529
 msgid "Shortcut"
 msgstr "Συντόμευση"
 
-#: ../src/guake/prefs.py:619 ../src/guake/prefs.py:665
+#: ../src/guake/prefs.py:678 ../src/guake/prefs.py:724
 msgid "Custom"
 msgstr ""
 
-#: ../src/guake/prefs.py:926
+#: ../src/guake/prefs.py:994
 msgid "JSON files"
 msgstr ""
 
-#: ../src/guake/prefs.py:1019
+#: ../src/guake/prefs.py:1088
 #, python-format
 msgid "The shortcut \"%s\" is already in use."
 msgstr "Η συντόμευση \"%s\" είναι σε χρήση."
 
-#: ../src/guake/prefs.py:1020
+#: ../src/guake/prefs.py:1089
 msgid "Error setting keybinding."
 msgstr "Σφάλμα κατά τη ρύθμιση συντομεύσεων πληκτρολογίου"
 
-#: ../src/guake/prefs.py:1032
+#: ../src/guake/prefs.py:1101
 #, python-format
 msgid ""
 "The shortcut \"%s\" cannot be used because it will become impossible to type "
@@ -840,33 +1005,3 @@ msgstr ""
 
 #~ msgid "Rename the selected tab."
 #~ msgstr "Μετονομασία της επιλεγμένης καρτέλας"
-
-#~ msgid "Toggle Guake visibility"
-#~ msgstr "Εναλλαγή ορατότητας του Guake"
-
-#~ msgid "Tab management"
-#~ msgstr "Διαχείρηση καρτελών"
-
-#~ msgid "Close tab"
-#~ msgstr "Κλείσμο καρτέλας"
-
-#~ msgid "Rename current tab"
-#~ msgstr "Μετονομασία τρέχουσας καρτέλας"
-
-#~ msgid "Navigation"
-#~ msgstr "Πλοήγηση"
-
-#~ msgid "Go to previous tab"
-#~ msgstr "Μετάβαση στην προηγούμενη καρτέλα"
-
-#~ msgid "Go to next tab"
-#~ msgstr "Μετάβαση στην επόμενη καρτέλα"
-
-#~ msgid "Clipboard"
-#~ msgstr "Πρόχειρο"
-
-#~ msgid "Copy text to clipboard"
-#~ msgstr "Αντιγραφή κειμένου στο πρόχειρο"
-
-#~ msgid "Paste text from clipboard"
-#~ msgstr "Επικόλληση κειμένου από το πρόχειρο"

--- a/po/es.po
+++ b/po/es.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Guake 0.4.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-12-01 16:49+0100\n"
+"POT-Creation-Date: 2016-08-17 21:41+0000\n"
 "PO-Revision-Date: 2015-10-14 20:58+0100\n"
 "Last-Translator: Dante Bravo <dbravo.iessabadell@gmail.com>\n"
 "Language-Team: Spanish (http://www.transifex.com/projects/p/guake/language/"
@@ -105,7 +105,7 @@ msgstr "Copiar"
 msgid "Paste"
 msgstr "Pegar"
 
-#: ../data/guake.glade.h:3
+#: ../data/guake.glade.h:3 ../src/guake/prefs.py:79
 msgid "Toggle Fullscreen"
 msgstr "Conmutar pantalla completa"
 
@@ -113,7 +113,7 @@ msgstr "Conmutar pantalla completa"
 msgid "Save to File..."
 msgstr "Guardar en fichero..."
 
-#: ../data/guake.glade.h:5
+#: ../data/guake.glade.h:5 ../src/guake/prefs.py:85
 msgid "Reset terminal"
 msgstr "Reiniciar terminal"
 
@@ -141,7 +141,7 @@ msgstr "Abrir vínculo..."
 msgid "Search on Web"
 msgstr "Buscar en la Web"
 
-#: ../data/guake.glade.h:12
+#: ../data/guake.glade.h:12 ../src/guake/prefs.py:83
 msgid "Quit"
 msgstr "Salir"
 
@@ -277,130 +277,134 @@ msgid "Use VTE titles for tab names"
 msgstr "Usar nombres estilo VTE para las pestañas"
 
 #: ../data/prefs.glade.h:33
-msgid "Max tab name length:"
+msgid "Abbreviate directories in tab names"
 msgstr ""
 
 #: ../data/prefs.glade.h:34
+msgid "Max tab name length:"
+msgstr ""
+
+#: ../data/prefs.glade.h:35
 msgid "Hide on lose focus"
 msgstr "Esconder al perder el foco"
 
-#: ../data/prefs.glade.h:35
+#: ../data/prefs.glade.h:36
 msgid "Show tab bar"
 msgstr "Mostrar barra de pestañas"
 
-#: ../data/prefs.glade.h:36
+#: ../data/prefs.glade.h:37
 msgid "Start fullscreen"
 msgstr "Iniciar en pantalla completa"
 
-#: ../data/prefs.glade.h:37
+#: ../data/prefs.glade.h:38
 msgid "<b>Main Window</b>"
 msgstr "<b>Ventana principal</b>"
 
-#: ../data/prefs.glade.h:38
+#: ../data/prefs.glade.h:39
 msgid "Left"
 msgstr "Izquierda"
 
-#: ../data/prefs.glade.h:39
+#: ../data/prefs.glade.h:40
 msgid "Center"
 msgstr "Centro"
 
-#: ../data/prefs.glade.h:40
+#: ../data/prefs.glade.h:41
 msgid "Right"
 msgstr "Derecha"
 
-#: ../data/prefs.glade.h:41
+#: ../data/prefs.glade.h:42
 msgid "<b>Main Window Horizontal Alignment</b>"
 msgstr "<b>Alineación horizontal de la ventana principal</b>"
 
-#: ../data/prefs.glade.h:42
+#: ../data/prefs.glade.h:43
 msgid "<b>Main Window Height</b>"
 msgstr "<b>Altura de la ventana principal</b>"
 
-#: ../data/prefs.glade.h:43
+#: ../data/prefs.glade.h:44
 msgid "<b>Main Window Width</b>"
 msgstr "<b>Anchura de la ventana principal</b>"
 
-#: ../data/prefs.glade.h:44
+#: ../data/prefs.glade.h:45
 msgid "Custom command file path: "
 msgstr "Ruta del fichero de comandos personalizados:"
 
-#: ../data/prefs.glade.h:45
+#: ../data/prefs.glade.h:46
 msgid "Please select a json file"
 msgstr "Seleccione un fichero JSON"
 
-#: ../data/prefs.glade.h:46
+#: ../data/prefs.glade.h:47 ../src/guake/prefs.py:75
 msgid "General"
 msgstr "General"
 
-#: ../data/prefs.glade.h:47
+#: ../data/prefs.glade.h:48
 msgid "Default interpreter:"
 msgstr "Intérprete predeterminado:"
 
-#: ../data/prefs.glade.h:48
+#: ../data/prefs.glade.h:49
 msgid "_Run command as a login shell"
 msgstr "_Ejecutar comando como un usuario de shell"
 
-#: ../data/prefs.glade.h:49
+#: ../data/prefs.glade.h:50
 msgid "_Open new tab in current directory"
 msgstr "_Abrir nueva pestaña en el directorio actual"
 
-#: ../data/prefs.glade.h:50
+#: ../data/prefs.glade.h:51
 msgid "<b>Shell</b>"
 msgstr "<b>Shell</b>"
 
-#: ../data/prefs.glade.h:51
+#: ../data/prefs.glade.h:52
 msgid "Shell"
 msgstr "Shell"
 
-#: ../data/prefs.glade.h:52
+#: ../data/prefs.glade.h:53
 msgid "Show scrollbar"
 msgstr "Mostrar barra de desplazamiento"
 
-#: ../data/prefs.glade.h:53
+#: ../data/prefs.glade.h:54
 msgid "Scrollback lines:"
 msgstr "Desplazamiento hacia atrás (líneas):"
 
-#: ../data/prefs.glade.h:54
+#: ../data/prefs.glade.h:55
 msgid "On output"
 msgstr "En la salida"
 
-#: ../data/prefs.glade.h:55
+#: ../data/prefs.glade.h:56
 msgid "On key stroke"
 msgstr "Al presionar una tecla"
 
-#: ../data/prefs.glade.h:56
+#: ../data/prefs.glade.h:57
 msgid "<b>Scroll</b>"
 msgstr "<b>Desplazar</b>"
 
-#: ../data/prefs.glade.h:57
+#: ../data/prefs.glade.h:58
 msgid "Scrolling"
 msgstr "Desplazamiento hacia atrás (líneas):"
 
-#: ../data/prefs.glade.h:58
+#: ../data/prefs.glade.h:59
 msgid "Use the system fixed width font"
 msgstr "Usar tamaño de letra del sistema"
 
-#: ../data/prefs.glade.h:59
+#: ../data/prefs.glade.h:60
 msgid "Font:"
 msgstr "Fuente:"
 
-#: ../data/prefs.glade.h:60
+#: ../data/prefs.glade.h:61
 msgid "Choose some font"
 msgstr "Elija una tipografía"
 
-#: ../data/prefs.glade.h:61
+#: ../data/prefs.glade.h:62
 msgid "Text color:"
 msgstr "Color del texto:"
 
-#: ../data/prefs.glade.h:62
+#: ../data/prefs.glade.h:63
 msgid "Background color:"
 msgstr "Color de fondo:"
 
-#: ../data/prefs.glade.h:63
+#: ../data/prefs.glade.h:64
 msgid "Cursor shape:"
 msgstr "Forma del cursor:"
 
-#: ../data/prefs.glade.h:64
+#: ../data/prefs.glade.h:65
 msgid ""
 "Block\n"
 "I-Beam\n"
@@ -410,7 +414,7 @@ msgstr ""
 "Forma de viga\n"
 "Guión bajo"
 
-#: ../data/prefs.glade.h:67
+#: ../data/prefs.glade.h:68
 msgid ""
 "Follow GTK+ setting\n"
 "Blink on\n"
@@ -420,59 +424,59 @@ msgstr ""
 "Parpadeo activado\n"
 "Parpadeo desactivado"
 
-#: ../data/prefs.glade.h:70
+#: ../data/prefs.glade.h:71
 msgid "Cursor blink mode:"
 msgstr "Modo de parpadeo del cursor:"
 
-#: ../data/prefs.glade.h:71
+#: ../data/prefs.glade.h:72
 msgid "Allow bold font"
 msgstr "Permitir negrita"
 
-#: ../data/prefs.glade.h:72
+#: ../data/prefs.glade.h:73
 msgid "<b>Palette</b>"
 msgstr "<b>Paleta</b>"
 
-#: ../data/prefs.glade.h:73
+#: ../data/prefs.glade.h:74
 msgid "Built-in schemes:"
 msgstr "Esquemas incorporados:"
 
-#: ../data/prefs.glade.h:74
+#: ../data/prefs.glade.h:75
 msgid "Color palette:"
 msgstr "Paleta de colores:"
 
-#: ../data/prefs.glade.h:75
+#: ../data/prefs.glade.h:76
 msgid "Font color"
 msgstr "Color del texto"
 
-#: ../data/prefs.glade.h:76
+#: ../data/prefs.glade.h:77
 msgid "Background color"
 msgstr "Color de fondo"
 
-#: ../data/prefs.glade.h:77
+#: ../data/prefs.glade.h:78
 msgid "Use font and background color from the palette"
 msgstr "Utilizar color de texto y de fondo de la paleta de colores"
 
-#: ../data/prefs.glade.h:78
+#: ../data/prefs.glade.h:79
 msgid "Demo:"
 msgstr "Demo:"
 
-#: ../data/prefs.glade.h:79
+#: ../data/prefs.glade.h:80
 msgid "<b>Effects</b>"
 msgstr "<b>Efectos</b>"
 
-#: ../data/prefs.glade.h:80
+#: ../data/prefs.glade.h:81
 msgid "Transparency:"
 msgstr "Fondo transparente:"
 
-#: ../data/prefs.glade.h:81
+#: ../data/prefs.glade.h:82
 msgid "Background image:"
 msgstr "Imagen de fondo:"
 
-#: ../data/prefs.glade.h:82
+#: ../data/prefs.glade.h:83 ../src/guake/prefs.py:130
 msgid "Appearance"
 msgstr "Apariencia"
 
-#: ../data/prefs.glade.h:83
+#: ../data/prefs.glade.h:84
 msgid ""
 "<small>Quick open is a feature allowing you to open a file directly into "
 "your favorite text editor by clicking on its filename when it appears in "
@@ -484,17 +488,17 @@ msgstr ""
 "dispone de una lista de los patrones de texto utilizados para mostrar el "
 "nombre del fichero.</small>"
 
-#: ../data/prefs.glade.h:84
+#: ../data/prefs.glade.h:85
 msgid "Enable Quick Open when Ctrl+clicking on a filename in the terminal"
 msgstr ""
 "Habilitar Abrir rápido cuando abra un fichero de la terminal pulsando Ctrl"
 "+Clic"
 
-#: ../data/prefs.glade.h:85
+#: ../data/prefs.glade.h:86
 msgid "Editor command line:"
 msgstr "Editor de línea de comandos:"
 
-#: ../data/prefs.glade.h:87
+#: ../data/prefs.glade.h:88
 #, no-c-format
 msgid ""
 "<small><i>Use the following elements in the open editor command line:\n"
@@ -515,11 +519,11 @@ msgstr ""
 "b>\n"
 "</i></small>"
 
-#: ../data/prefs.glade.h:93
+#: ../data/prefs.glade.h:94
 msgid "Quick open in current terminal"
 msgstr "Abrir rápido en el terminal actual"
 
-#: ../data/prefs.glade.h:94
+#: ../data/prefs.glade.h:95
 msgid ""
 "Here is the list of supported patterns: (to add your own, please contact the "
 "Guake's authors)"
@@ -527,15 +531,15 @@ msgstr ""
 "Aquí encontrará una lista de patrones soportados: (Si desea añadir uno "
 "propio, contacte con los autores de Guake)"
 
-#: ../data/prefs.glade.h:95
+#: ../data/prefs.glade.h:96
 msgid "<b>Quick Open</b>"
 msgstr "<b>Abrir rápido</b>"
 
-#: ../data/prefs.glade.h:96
+#: ../data/prefs.glade.h:97
 msgid "Quick Open"
 msgstr "Abrir rápido"
 
-#: ../data/prefs.glade.h:97
+#: ../data/prefs.glade.h:98
 msgid ""
 "To change a shortcut simply click on its name.\n"
 "To disable a shortcut, press the \"Backspace\" key."
@@ -543,11 +547,11 @@ msgstr ""
 "Para cambiar un atajo del teclado haga clic encima de su nombre.\n"
 "Para desactivar un atajo del teclado, presione la tecla \"Backspace\"."
 
-#: ../data/prefs.glade.h:99
+#: ../data/prefs.glade.h:100
 msgid "Keyboard shortcuts"
 msgstr "Atajos de teclado"
 
-#: ../data/prefs.glade.h:100
+#: ../data/prefs.glade.h:101
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -559,7 +563,7 @@ msgstr ""
 "alternativa a ciertas aplicaciones o sistemas operativos que esperan un "
 "comportamiento del terminal distinto.</i></small>"
 
-#: ../data/prefs.glade.h:101
+#: ../data/prefs.glade.h:102
 msgid ""
 "ASCII DEL\n"
 "Escape sequence\n"
@@ -569,37 +573,36 @@ msgstr ""
 "Secuencia de Escape \n"
 "Control-H"
 
-#: ../data/prefs.glade.h:104
+#: ../data/prefs.glade.h:105
 msgid "_Backspace key generates:"
 msgstr "Tecla _Backspace genera:"
 
-#: ../data/prefs.glade.h:105
+#: ../data/prefs.glade.h:106
 msgid "_Delete key generates:"
 msgstr "Tecla _Delete genera:"
 
-#: ../data/prefs.glade.h:106
+#: ../data/prefs.glade.h:107
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "_Reiniciar "
 
-#: ../data/prefs.glade.h:107
+#: ../data/prefs.glade.h:108
 msgid "<b>Keyboard compatibility</b>"
 msgstr "<b>Compatibilidad del teclado</b>"
 
-#: ../data/prefs.glade.h:108
+#: ../data/prefs.glade.h:109
 msgid "Compatibility"
 msgstr "Compatibilidad"
 
-#: ../src/guake/about.py:47 ../src/guake/gconfhandler.py:427
-#: ../src/guake/guake_app.py:177 ../src/guake/guake_app.py:348
+#: ../src/guake/about.py:47 ../src/guake/gconfhandler.py:435
+#: ../src/guake/guake_app.py:181 ../src/guake/guake_app.py:376
 msgid "Guake Terminal"
 msgstr "Guake Terminal"
 
-#. Adding a new radio button to the tabbar
-#: ../src/guake/gconfhandler.py:365 ../src/guake/guake_app.py:1548
+#: ../src/guake/gconfhandler.py:368 ../src/guake/guake_app.py:1363
 msgid "Terminal"
 msgstr "Terminal"
 
-#: ../src/guake/gconfhandler.py:428
+#: ../src/guake/gconfhandler.py:436
 #, python-format
 msgid ""
 "A problem happened when binding <b>%s</b> key.\n"
@@ -608,49 +611,49 @@ msgstr ""
 "Ocurrió un problema asignando la tecla <b>%s</b>.\n"
 "Por favor, use las preferencias de Guake para asignar otra tecla."
 
-#: ../src/guake/guake_app.py:128
+#: ../src/guake/guake_app.py:132
 msgid "Do you want to close the tab?"
 msgstr "¿Realmente quiere cerrar la pestaña?"
 
-#: ../src/guake/guake_app.py:131
+#: ../src/guake/guake_app.py:135
 msgid "Do you really want to quit Guake?"
 msgstr "¿Realmente quiere salir de Guake?"
 
-#: ../src/guake/guake_app.py:133
+#: ../src/guake/guake_app.py:137
 msgid " and one tab open"
 msgstr "y una pestaña abierta"
 
-#: ../src/guake/guake_app.py:135
+#: ../src/guake/guake_app.py:139
 #, python-brace-format
 msgid " and {0} tabs open"
 msgstr "y {0} pestañas abiertas"
 
-#: ../src/guake/guake_app.py:138
+#: ../src/guake/guake_app.py:142
 msgid "There are no processes running"
 msgstr "No hay procesos ejecutándose actualmente"
 
-#: ../src/guake/guake_app.py:140
+#: ../src/guake/guake_app.py:144
 msgid "There is a process still running"
 msgstr "Hay un proceso ejecutándose actualmente"
 
-#: ../src/guake/guake_app.py:142
+#: ../src/guake/guake_app.py:146
 #, python-brace-format
 msgid "There are {0} processes still running"
 msgstr "Hay {0} procesos ejecutándose actualmente"
 
-#: ../src/guake/guake_app.py:182
+#: ../src/guake/guake_app.py:186
 msgid "guake-indicator"
 msgstr ""
 
-#: ../src/guake/guake_app.py:182
+#: ../src/guake/guake_app.py:186
 msgid "guake-tray"
 msgstr ""
 
-#: ../src/guake/guake_app.py:186
+#: ../src/guake/guake_app.py:190
 msgid "Show"
 msgstr "Mostrar"
 
-#: ../src/guake/guake_app.py:349
+#: ../src/guake/guake_app.py:377
 #, python-format
 msgid ""
 "Guake is now running,\n"
@@ -659,134 +662,139 @@ msgstr ""
 "Guake se está ejecutando,\n"
 "pulse <b>%s</b> para usarlo."
 
-#: ../src/guake/guake_app.py:611
+#: ../src/guake/guake_app.py:665
 #, python-format
 msgid "Search on Web: '%s'"
 msgstr "Buscar en la Web: '%s'"
 
-#: ../src/guake/guake_app.py:616
+#: ../src/guake/guake_app.py:670
 msgid "Search on Web (no selection)"
 msgstr "Buscar en la Web (nada seleccionado)"
 
-#: ../src/guake/guake_app.py:622
+#: ../src/guake/guake_app.py:678
+#, fuzzy
+msgid "Open Link: '{}...'"
+msgstr "Abrir vínculo: {}"
+
+#: ../src/guake/guake_app.py:680
 msgid "Open Link: {}"
 msgstr "Abrir vínculo: {}"
 
-#: ../src/guake/guake_app.py:625
+#: ../src/guake/guake_app.py:683
 msgid "Open Link..."
 msgstr "Abrir vínculo..."
 
-#: ../src/guake/guake_app.py:1300
+#: ../src/guake/guake_app.py:1402
 msgid "Rename tab"
 msgstr "Renombrar pestaña"
 
-#: ../src/guake/guake_app.py:1591
+#: ../src/guake/guake_app.py:1716
 msgid "Save to..."
 msgstr "Guardar como..."
 
-#: ../src/guake/guake_app.py:1598 ../src/guake/prefs.py:930
+#: ../src/guake/guake_app.py:1723 ../src/guake/prefs.py:998
 msgid "All files"
 msgstr "Todos los ficheros"
 
-#: ../src/guake/guake_app.py:1603
+#: ../src/guake/guake_app.py:1728
 msgid "Text and Logs"
 msgstr ""
 
-#: ../src/guake/guake_app.py:1621
+#: ../src/guake/guake_app.py:1746
 msgid "Find"
 msgstr "Buscar"
 
-#: ../src/guake/guake_app.py:1623
+#: ../src/guake/guake_app.py:1748
 msgid "Forward"
 msgstr "Adelante"
 
-#: ../src/guake/guake_app.py:1624
+#: ../src/guake/guake_app.py:1749
 msgid "Backward"
 msgstr "Atrás"
 
-#: ../src/guake/main.py:67
+#: ../src/guake/main.py:68
 msgid "Put Guake in fullscreen mode"
 msgstr "Guake en modo pantalla completa"
 
-#: ../src/guake/main.py:71
+#: ../src/guake/main.py:72
 msgid "Toggles the visibility of the terminal window"
 msgstr "Conmuta la visibilidad de la ventana del terminal"
 
-#: ../src/guake/main.py:75
+#: ../src/guake/main.py:76
 msgid "Shows Guake main window"
 msgstr "Muestra la ventana principal de Guake"
 
-#: ../src/guake/main.py:79
+#: ../src/guake/main.py:80
 msgid "Hides Guake main window"
 msgstr "Oculta la ventana principal de Guake"
 
-#: ../src/guake/main.py:83
+#: ../src/guake/main.py:84
 msgid "Shows Guake preference window"
 msgstr "Muestra las preferencias de Guake"
 
-#: ../src/guake/main.py:87
+#: ../src/guake/main.py:88
 msgid "Shows Guake's about info"
 msgstr "Muestra el diálogo de información de Guake"
 
-#: ../src/guake/main.py:91
+#: ../src/guake/main.py:92
 msgid "Add a new tab (with current directory set to NEW_TAB)"
 msgstr "Añadir nueva pestaña (directorio actual establecido en NEW_TAB)"
 
-#: ../src/guake/main.py:95
+#: ../src/guake/main.py:96
 msgid "Select a tab (SELECT_TAB is the index of the tab)"
 msgstr "Seleccionar una pestaña (SELECT_TAB es el índice de la pestaña)"
 
-#: ../src/guake/main.py:99
+#: ../src/guake/main.py:100
 msgid "Return the selected tab index."
 msgstr "Devolver el índice de la pestaña seleccionada"
 
-#: ../src/guake/main.py:103
+#: ../src/guake/main.py:104
 msgid "Execute an arbitrary command in the selected tab."
 msgstr "Ejecutar un comando arbitrario en la pestaña seleccionada."
 
-#: ../src/guake/main.py:107
+#: ../src/guake/main.py:108
 msgid "Specify the tab to rename. Default is 0."
 msgstr "Especifique la pestaña a renombrar. Por defecto es 0."
 
-#: ../src/guake/main.py:111
+#: ../src/guake/main.py:112
 msgid "Set the hexadecimal (#rrggbb) background color of the selected tab."
 msgstr ""
 "Establecer un color de fondo hexadecimal (#rrggbb) para la pestaña "
 "seleccionada."
 
-#: ../src/guake/main.py:116
+#: ../src/guake/main.py:117
 msgid "Set the hexadecimal (#rrggbb) foreground color of the selected tab."
 msgstr ""
 "Establecer un color de fuente hexadecimal (#rrggbb) para la pestaña "
 "seleccionada."
 
-#: ../src/guake/main.py:122
+#: ../src/guake/main.py:123
 msgid ""
 "Rename the specified tab. Reset to default if TITLE is a single dash \"-\"."
 msgstr ""
 "Renombrar la pestaña especificada. Retomará el valor por defecto si TITLE es "
 "solo un \"-\"."
 
-#: ../src/guake/main.py:128
+#: ../src/guake/main.py:129
 msgid ""
 "Rename the current tab. Reset to default if TITLE is a single dash \"-\"."
 msgstr ""
 "Renombrar la pestaña actual. Retomará el valor por defecto si TITLE es solo "
 "un \"-\"."
 
-#: ../src/guake/main.py:133
+#: ../src/guake/main.py:134
 msgid "Says to Guake go away =("
 msgstr "Le dice a Guake que desaparezca =("
 
-#: ../src/guake/main.py:137
+#: ../src/guake/main.py:138
 msgid "Do not execute the start up script"
 msgstr "No ejecutar el script de inicio"
 
-#: ../src/guake/main.py:231
+#: ../src/guake/main.py:235
 msgid "Guake can not init!"
 msgstr "¡Guake no se puede iniciar!"
 
-#: ../src/guake/main.py:232
+#: ../src/guake/main.py:236
 msgid ""
 "Gconf Error.\n"
 "Have you installed <b>guake.schemas</b> properly?"
@@ -799,32 +807,191 @@ msgstr ""
 msgid "<user shell>"
 msgstr "<usuario shell>"
 
-#: ../src/guake/prefs.py:467
+#: ../src/guake/prefs.py:77
+msgid "Toggle Guake visibility"
+msgstr "Conmuta la visibilidad del terminal"
+
+#: ../src/guake/prefs.py:81
+#, fuzzy
+msgid "Toggle Hide on Lose Focus"
+msgstr "Esconder al perder el foco"
+
+#: ../src/guake/prefs.py:88
+msgid "Tab management"
+msgstr "Administrar pestañas"
+
+#: ../src/guake/prefs.py:90
+#, fuzzy
+msgid "New tab"
+msgstr "Nueva pestaña"
+
+#: ../src/guake/prefs.py:92
+msgid "Close tab"
+msgstr "Cerrar pestaña"
+
+#: ../src/guake/prefs.py:94
+msgid "Rename current tab"
+msgstr "Renombrar la pestaña actual"
+
+#: ../src/guake/prefs.py:97
+msgid "Navigation"
+msgstr "Navegación"
+
+#: ../src/guake/prefs.py:99
+msgid "Go to previous tab"
+msgstr "Ir a la pestaña anterior"
+
+#: ../src/guake/prefs.py:101
+msgid "Go to next tab"
+msgstr "Ir a la pestaña siguiente"
+
+#: ../src/guake/prefs.py:103
+#, fuzzy
+msgid "Move current tab left"
+msgstr "Renombrar la pestaña actual"
+
+#: ../src/guake/prefs.py:105
+#, fuzzy
+msgid "Move current tab right"
+msgstr "Renombrar la pestaña actual"
+
+#: ../src/guake/prefs.py:107
+#, fuzzy
+msgid "Go to first tab"
+msgstr "Ir a la pestaña siguiente"
+
+#: ../src/guake/prefs.py:109
+#, fuzzy
+msgid "Go to second tab"
+msgstr "Ir a la pestaña siguiente"
+
+#: ../src/guake/prefs.py:111
+#, fuzzy
+msgid "Go to third tab"
+msgstr "Ir a la pestaña siguiente"
+
+#: ../src/guake/prefs.py:113
+#, fuzzy
+msgid "Go to fourth tab"
+msgstr "Ir a la pestaña siguiente"
+
+#: ../src/guake/prefs.py:115
+#, fuzzy
+msgid "Go to fifth tab"
+msgstr "Ir a la pestaña siguiente"
+
+#: ../src/guake/prefs.py:117
+#, fuzzy
+msgid "Go to sixth tab"
+msgstr "Ir a la pestaña siguiente"
+
+#: ../src/guake/prefs.py:119
+#, fuzzy
+msgid "Go to seventh tab"
+msgstr "Ir a la pestaña siguiente"
+
+#: ../src/guake/prefs.py:121
+#, fuzzy
+msgid "Go to eighth tab"
+msgstr "Ir a la pestaña siguiente"
+
+#: ../src/guake/prefs.py:123
+#, fuzzy
+msgid "Go to ninth tab"
+msgstr "Ir a la pestaña siguiente"
+
+#: ../src/guake/prefs.py:125
+#, fuzzy
+msgid "Go to tenth tab"
+msgstr "Ir a la pestaña siguiente"
+
+#: ../src/guake/prefs.py:127
+#, fuzzy
+msgid "Go to last tab"
+msgstr "Ir a la pestaña siguiente"
+
+#: ../src/guake/prefs.py:132
+msgid "Zoom out"
+msgstr ""
+
+#: ../src/guake/prefs.py:134
+msgid "Zoom in"
+msgstr ""
+
+#: ../src/guake/prefs.py:136
+msgid "Zoom in (alternative)"
+msgstr ""
+
+#: ../src/guake/prefs.py:138
+msgid "Increase height"
+msgstr ""
+
+#: ../src/guake/prefs.py:140
+msgid "Decrease height"
+msgstr ""
+
+#: ../src/guake/prefs.py:142
+#, fuzzy
+msgid "Increase transparency"
+msgstr "Fondo transparente:"
+
+#: ../src/guake/prefs.py:144
+#, fuzzy
+msgid "Decrease transparency"
+msgstr "Fondo transparente:"
+
+#: ../src/guake/prefs.py:146
+#, fuzzy
+msgid "Toggle transparency"
+msgstr "Fondo transparente:"
+
+#: ../src/guake/prefs.py:149
+msgid "Clipboard"
+msgstr "Portapapeles"
+
+#: ../src/guake/prefs.py:151
+msgid "Copy text to clipboard"
+msgstr "Copiar texto al portapapeles"
+
+#: ../src/guake/prefs.py:153
+msgid "Paste text from clipboard"
+msgstr "Pegar texto del portapapeles"
+
+#: ../src/guake/prefs.py:156
+msgid "Extra features"
+msgstr ""
+
+#: ../src/guake/prefs.py:159
+#, fuzzy
+msgid "Search select text on web"
+msgstr "Buscar en la Web"
+
+#: ../src/guake/prefs.py:519
 msgid "Action"
 msgstr "Acción"
 
-#: ../src/guake/prefs.py:477
+#: ../src/guake/prefs.py:529
 msgid "Shortcut"
 msgstr "Atajo"
 
-#: ../src/guake/prefs.py:619 ../src/guake/prefs.py:665
+#: ../src/guake/prefs.py:678 ../src/guake/prefs.py:724
 msgid "Custom"
 msgstr "Personalizado"
 
-#: ../src/guake/prefs.py:926
+#: ../src/guake/prefs.py:994
 msgid "JSON files"
 msgstr "Ficheros JSON"
 
-#: ../src/guake/prefs.py:1019
+#: ../src/guake/prefs.py:1088
 #, python-format
 msgid "The shortcut \"%s\" is already in use."
 msgstr "El atajo de teclado \"%s\" esta en uso actualmente."
 
-#: ../src/guake/prefs.py:1020
+#: ../src/guake/prefs.py:1089
 msgid "Error setting keybinding."
 msgstr "Error asignando teclas."
 
-#: ../src/guake/prefs.py:1032
+#: ../src/guake/prefs.py:1101
 #, python-format
 msgid ""
 "The shortcut \"%s\" cannot be used because it will become impossible to type "
@@ -864,33 +1031,3 @@ msgstr ""
 
 #~ msgid "Rename the selected tab."
 #~ msgstr "Renombrar la pestaña seleccionada"
-
-#~ msgid "Toggle Guake visibility"
-#~ msgstr "Conmuta la visibilidad del terminal"
-
-#~ msgid "Tab management"
-#~ msgstr "Administrar pestañas"
-
-#~ msgid "Close tab"
-#~ msgstr "Cerrar pestaña"
-
-#~ msgid "Rename current tab"
-#~ msgstr "Renombrar la pestaña actual"
-
-#~ msgid "Navigation"
-#~ msgstr "Navegación"
-
-#~ msgid "Go to previous tab"
-#~ msgstr "Ir a la pestaña anterior"
-
-#~ msgid "Go to next tab"
-#~ msgstr "Ir a la pestaña siguiente"
-
-#~ msgid "Clipboard"
-#~ msgstr "Portapapeles"
-
-#~ msgid "Copy text to clipboard"
-#~ msgstr "Copiar texto al portapapeles"
-
-#~ msgid "Paste text from clipboard"
-#~ msgstr "Pegar texto del portapapeles"

--- a/po/fa.po
+++ b/po/fa.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Guake 0.4.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-12-01 16:49+0100\n"
+"POT-Creation-Date: 2016-08-17 21:41+0000\n"
 "PO-Revision-Date: 2010-04-17 17:45+0430\n"
 "Last-Translator: Kasra Keshavarz <kasra545@gmail.com>\n"
 "Language-Team: guake@lists.guake.org <>\n"
@@ -101,7 +101,7 @@ msgstr "رونوشت کردن"
 msgid "Paste"
 msgstr "چسباندن"
 
-#: ../data/guake.glade.h:3
+#: ../data/guake.glade.h:3 ../src/guake/prefs.py:79
 msgid "Toggle Fullscreen"
 msgstr "‌تغییر به تمام‌صفحه"
 
@@ -109,7 +109,7 @@ msgstr "‌تغییر به تمام‌صفحه"
 msgid "Save to File..."
 msgstr ""
 
-#: ../data/guake.glade.h:5
+#: ../data/guake.glade.h:5 ../src/guake/prefs.py:85
 #, fuzzy
 msgid "Reset terminal"
 msgstr "Guake Terminal"
@@ -139,7 +139,7 @@ msgstr ""
 msgid "Search on Web"
 msgstr ""
 
-#: ../data/guake.glade.h:12
+#: ../data/guake.glade.h:12 ../src/guake/prefs.py:83
 msgid "Quit"
 msgstr "خروج"
 
@@ -262,202 +262,206 @@ msgid "Use VTE titles for tab names"
 msgstr ""
 
 #: ../data/prefs.glade.h:33
-msgid "Max tab name length:"
+msgid "Abbreviate directories in tab names"
 msgstr ""
 
 #: ../data/prefs.glade.h:34
+msgid "Max tab name length:"
+msgstr ""
+
+#: ../data/prefs.glade.h:35
 msgid "Hide on lose focus"
 msgstr "در صورت توجه کم پنهان شو"
 
-#: ../data/prefs.glade.h:35
+#: ../data/prefs.glade.h:36
 msgid "Show tab bar"
 msgstr "نمایش دادن نوار حاوی زبانه"
 
-#: ../data/prefs.glade.h:36
+#: ../data/prefs.glade.h:37
 #, fuzzy
 msgid "Start fullscreen"
 msgstr "‌تغییر به تمام‌صفحه"
 
-#: ../data/prefs.glade.h:37
+#: ../data/prefs.glade.h:38
 msgid "<b>Main Window</b>"
 msgstr "<b>پنجره اصلی</b>"
 
-#: ../data/prefs.glade.h:38
+#: ../data/prefs.glade.h:39
 msgid "Left"
 msgstr ""
 
-#: ../data/prefs.glade.h:39
+#: ../data/prefs.glade.h:40
 msgid "Center"
 msgstr ""
 
-#: ../data/prefs.glade.h:40
+#: ../data/prefs.glade.h:41
 msgid "Right"
 msgstr ""
 
-#: ../data/prefs.glade.h:41
+#: ../data/prefs.glade.h:42
 #, fuzzy
 msgid "<b>Main Window Horizontal Alignment</b>"
 msgstr "<b>سایز پنجره اصلی</b>"
 
-#: ../data/prefs.glade.h:42
+#: ../data/prefs.glade.h:43
 #, fuzzy
 msgid "<b>Main Window Height</b>"
 msgstr "<b>سایز پنجره اصلی</b>"
 
-#: ../data/prefs.glade.h:43
+#: ../data/prefs.glade.h:44
 #, fuzzy
 msgid "<b>Main Window Width</b>"
 msgstr "<b>سایز پنجره اصلی</b>"
 
-#: ../data/prefs.glade.h:44
+#: ../data/prefs.glade.h:45
 msgid "Custom command file path: "
 msgstr ""
 
-#: ../data/prefs.glade.h:45
+#: ../data/prefs.glade.h:46
 msgid "Please select a json file"
 msgstr ""
 
-#: ../data/prefs.glade.h:46
+#: ../data/prefs.glade.h:47 ../src/guake/prefs.py:75
 msgid "General"
 msgstr "عمومی"
 
-#: ../data/prefs.glade.h:47
+#: ../data/prefs.glade.h:48
 msgid "Default interpreter:"
 msgstr "خط فرمان پیشفرض:"
 
-#: ../data/prefs.glade.h:48
+#: ../data/prefs.glade.h:49
 msgid "_Run command as a login shell"
 msgstr "_اجرا دستور به عنوان خط فرمان ورود به سیستم"
 
-#: ../data/prefs.glade.h:49
+#: ../data/prefs.glade.h:50
 msgid "_Open new tab in current directory"
 msgstr "_زبانه‌ای جدید در مسیر کنونی باز کن"
 
-#: ../data/prefs.glade.h:50
+#: ../data/prefs.glade.h:51
 msgid "<b>Shell</b>"
 msgstr "<b>خط فرمان</b>"
 
-#: ../data/prefs.glade.h:51
+#: ../data/prefs.glade.h:52
 msgid "Shell"
 msgstr ""
 
-#: ../data/prefs.glade.h:52
+#: ../data/prefs.glade.h:53
 msgid "Show scrollbar"
 msgstr "نمایش دادن نوار لغزش"
 
-#: ../data/prefs.glade.h:53
+#: ../data/prefs.glade.h:54
 msgid "Scrollback lines:"
 msgstr "پیمایش خط‌های قبلی:"
 
-#: ../data/prefs.glade.h:54
+#: ../data/prefs.glade.h:55
 msgid "On output"
 msgstr "در خروجی"
 
-#: ../data/prefs.glade.h:55
+#: ../data/prefs.glade.h:56
 msgid "On key stroke"
 msgstr "با زدن کلید"
 
-#: ../data/prefs.glade.h:56
+#: ../data/prefs.glade.h:57
 msgid "<b>Scroll</b>"
 msgstr "<b>پیمایش</b>"
 
-#: ../data/prefs.glade.h:57
+#: ../data/prefs.glade.h:58
 msgid "Scrolling"
 msgstr "پیمایش"
 
-#: ../data/prefs.glade.h:58
+#: ../data/prefs.glade.h:59
 msgid "Use the system fixed width font"
 msgstr "استفاده از قلم عریض ساخته‌شده‌ی سیستم"
 
-#: ../data/prefs.glade.h:59
+#: ../data/prefs.glade.h:60
 msgid "Font:"
 msgstr "قلم:"
 
-#: ../data/prefs.glade.h:60
+#: ../data/prefs.glade.h:61
 msgid "Choose some font"
 msgstr "تعدادی قلم انتخاب کنید"
 
-#: ../data/prefs.glade.h:61
+#: ../data/prefs.glade.h:62
 msgid "Text color:"
 msgstr "رنگ متن:"
 
-#: ../data/prefs.glade.h:62
+#: ../data/prefs.glade.h:63
 msgid "Background color:"
 msgstr "رنگ پس‌زمینه:"
 
-#: ../data/prefs.glade.h:63
+#: ../data/prefs.glade.h:64
 msgid "Cursor shape:"
 msgstr ""
 
-#: ../data/prefs.glade.h:64
+#: ../data/prefs.glade.h:65
 msgid ""
 "Block\n"
 "I-Beam\n"
 "Underline"
 msgstr ""
 
-#: ../data/prefs.glade.h:67
+#: ../data/prefs.glade.h:68
 msgid ""
 "Follow GTK+ setting\n"
 "Blink on\n"
 "Blink off"
 msgstr ""
 
-#: ../data/prefs.glade.h:70
+#: ../data/prefs.glade.h:71
 msgid "Cursor blink mode:"
 msgstr ""
 
-#: ../data/prefs.glade.h:71
+#: ../data/prefs.glade.h:72
 msgid "Allow bold font"
 msgstr ""
 
-#: ../data/prefs.glade.h:72
+#: ../data/prefs.glade.h:73
 msgid "<b>Palette</b>"
 msgstr "<b>پَلت</b>"
 
-#: ../data/prefs.glade.h:73
+#: ../data/prefs.glade.h:74
 msgid "Built-in schemes:"
 msgstr "طرح‌های داخلی:"
 
-#: ../data/prefs.glade.h:74
+#: ../data/prefs.glade.h:75
 msgid "Color palette:"
 msgstr "پَلت رنگ:"
 
-#: ../data/prefs.glade.h:75
+#: ../data/prefs.glade.h:76
 #, fuzzy
 msgid "Font color"
 msgstr "رنگ متن:"
 
-#: ../data/prefs.glade.h:76
+#: ../data/prefs.glade.h:77
 #, fuzzy
 msgid "Background color"
 msgstr "رنگ پس‌زمینه:"
 
-#: ../data/prefs.glade.h:77
+#: ../data/prefs.glade.h:78
 msgid "Use font and background color from the palette"
 msgstr ""
 
-#: ../data/prefs.glade.h:78
+#: ../data/prefs.glade.h:79
 msgid "Demo:"
 msgstr ""
 
-#: ../data/prefs.glade.h:79
+#: ../data/prefs.glade.h:80
 msgid "<b>Effects</b>"
 msgstr "<b>اثرات</b>"
 
-#: ../data/prefs.glade.h:80
+#: ../data/prefs.glade.h:81
 msgid "Transparency:"
 msgstr "شفافیت:"
 
-#: ../data/prefs.glade.h:81
+#: ../data/prefs.glade.h:82
 msgid "Background image:"
 msgstr "عکس پس‌زمینه:"
 
-#: ../data/prefs.glade.h:82
+#: ../data/prefs.glade.h:83 ../src/guake/prefs.py:130
 msgid "Appearance"
 msgstr "ظاهر"
 
-#: ../data/prefs.glade.h:83
+#: ../data/prefs.glade.h:84
 msgid ""
 "<small>Quick open is a feature allowing you to open a file directly into "
 "your favorite text editor by clicking on its filename when it appears in "
@@ -465,15 +469,15 @@ msgid ""
 "extract filename below.</small>"
 msgstr ""
 
-#: ../data/prefs.glade.h:84
+#: ../data/prefs.glade.h:85
 msgid "Enable Quick Open when Ctrl+clicking on a filename in the terminal"
 msgstr ""
 
-#: ../data/prefs.glade.h:85
+#: ../data/prefs.glade.h:86
 msgid "Editor command line:"
 msgstr ""
 
-#: ../data/prefs.glade.h:87
+#: ../data/prefs.glade.h:88
 #, no-c-format
 msgid ""
 "<small><i>Use the following elements in the open editor command line:\n"
@@ -485,36 +489,36 @@ msgid ""
 "</i></small>"
 msgstr ""
 
-#: ../data/prefs.glade.h:93
+#: ../data/prefs.glade.h:94
 msgid "Quick open in current terminal"
 msgstr ""
 
-#: ../data/prefs.glade.h:94
+#: ../data/prefs.glade.h:95
 msgid ""
 "Here is the list of supported patterns: (to add your own, please contact the "
 "Guake's authors)"
 msgstr ""
 
-#: ../data/prefs.glade.h:95
+#: ../data/prefs.glade.h:96
 #, fuzzy
 msgid "<b>Quick Open</b>"
 msgstr "<b>Posición de las pestañas</b>"
 
-#: ../data/prefs.glade.h:96
+#: ../data/prefs.glade.h:97
 msgid "Quick Open"
 msgstr ""
 
-#: ../data/prefs.glade.h:97
+#: ../data/prefs.glade.h:98
 msgid ""
 "To change a shortcut simply click on its name.\n"
 "To disable a shortcut, press the \"Backspace\" key."
 msgstr ""
 
-#: ../data/prefs.glade.h:99
+#: ../data/prefs.glade.h:100
 msgid "Keyboard shortcuts"
 msgstr "میانبر‌های صفحه‌کلید"
 
-#: ../data/prefs.glade.h:100
+#: ../data/prefs.glade.h:101
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -525,7 +529,7 @@ msgstr ""
 "کار نکنند.  این‌ها فقط اینجا هستند برای احازه دادن شما برای کارکردن در بعضی "
 "برنامه‌ها و سیستم عامل‌ها که انتظار رفتار پایانه‌های متفاوتی دارند. </i></small>"
 
-#: ../data/prefs.glade.h:101
+#: ../data/prefs.glade.h:102
 msgid ""
 "ASCII DEL\n"
 "Escape sequence\n"
@@ -535,38 +539,37 @@ msgstr ""
 "Escape sequence\n"
 "Control-H"
 
-#: ../data/prefs.glade.h:104
+#: ../data/prefs.glade.h:105
 msgid "_Backspace key generates:"
 msgstr "_تولید کردن کلید پسبردن"
 
-#: ../data/prefs.glade.h:105
+#: ../data/prefs.glade.h:106
 msgid "_Delete key generates:"
 msgstr "تولید کردن کلید پاک کردن"
 
-#: ../data/prefs.glade.h:106
+#: ../data/prefs.glade.h:107
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "_تنظیم مجدد ترجیحات سازگاری به پیشفرض"
 
-#: ../data/prefs.glade.h:107
+#: ../data/prefs.glade.h:108
 msgid "<b>Keyboard compatibility</b>"
 msgstr "<b>سازگاری با صفحه‌کلید</b>"
 
-#: ../data/prefs.glade.h:108
+#: ../data/prefs.glade.h:109
 msgid "Compatibility"
 msgstr "سازگاری"
 
-#: ../src/guake/about.py:47 ../src/guake/gconfhandler.py:427
-#: ../src/guake/guake_app.py:177 ../src/guake/guake_app.py:348
+#: ../src/guake/about.py:47 ../src/guake/gconfhandler.py:435
+#: ../src/guake/guake_app.py:181 ../src/guake/guake_app.py:376
 msgid "Guake Terminal"
 msgstr "Guake Terminal"
 
-#. Adding a new radio button to the tabbar
-#: ../src/guake/gconfhandler.py:365 ../src/guake/guake_app.py:1548
+#: ../src/guake/gconfhandler.py:368 ../src/guake/guake_app.py:1363
 #, fuzzy
 msgid "Terminal"
 msgstr "ترمینال %s"
 
-#: ../src/guake/gconfhandler.py:428
+#: ../src/guake/gconfhandler.py:436
 #, fuzzy, python-format
 msgid ""
 "A problem happened when binding <b>%s</b> key.\n"
@@ -576,54 +579,54 @@ msgstr ""
 "لطفا از برگه‌ی تنظیمات Guake برای انتخاب کلید دیگر استفاده کنید(آیکون مخفی "
 "فعال شده بود)"
 
-#: ../src/guake/guake_app.py:128
+#: ../src/guake/guake_app.py:132
 #, fuzzy
 msgid "Do you want to close the tab?"
 msgstr "واقعا مایل به خارج شدن از Guake هستید!؟"
 
-#: ../src/guake/guake_app.py:131
+#: ../src/guake/guake_app.py:135
 #, fuzzy
 msgid "Do you really want to quit Guake?"
 msgstr "واقعا مایل به خارج شدن از Guake هستید!؟"
 
-#: ../src/guake/guake_app.py:133
+#: ../src/guake/guake_app.py:137
 #, fuzzy
 msgid " and one tab open"
 msgstr "افزودن زبانه‌ی جدید"
 
-#: ../src/guake/guake_app.py:135
+#: ../src/guake/guake_app.py:139
 #, python-brace-format
 msgid " and {0} tabs open"
 msgstr ""
 
-#: ../src/guake/guake_app.py:138
+#: ../src/guake/guake_app.py:142
 #, fuzzy
 msgid "There are no processes running"
 msgstr "<b>روند دیگری هنوز در حال اجراست</b>"
 
-#: ../src/guake/guake_app.py:140
+#: ../src/guake/guake_app.py:144
 #, fuzzy
 msgid "There is a process still running"
 msgstr "<b>روند دیگری هنوز در حال اجراست</b>"
 
-#: ../src/guake/guake_app.py:142
+#: ../src/guake/guake_app.py:146
 #, fuzzy, python-brace-format
 msgid "There are {0} processes still running"
 msgstr "<b>روندهای %d در حال اجرا هستند.</b>"
 
-#: ../src/guake/guake_app.py:182
+#: ../src/guake/guake_app.py:186
 msgid "guake-indicator"
 msgstr ""
 
-#: ../src/guake/guake_app.py:182
+#: ../src/guake/guake_app.py:186
 msgid "guake-tray"
 msgstr ""
 
-#: ../src/guake/guake_app.py:186
+#: ../src/guake/guake_app.py:190
 msgid "Show"
 msgstr ""
 
-#: ../src/guake/guake_app.py:349
+#: ../src/guake/guake_app.py:377
 #, python-format
 msgid ""
 "Guake is now running,\n"
@@ -632,129 +635,133 @@ msgstr ""
 "هم‌اکنون Guake در حال اجرا می‌باشد،\n"
 "برای استفاده کلید <b>%s</b> را فشار دهید."
 
-#: ../src/guake/guake_app.py:611
+#: ../src/guake/guake_app.py:665
 #, python-format
 msgid "Search on Web: '%s'"
 msgstr ""
 
-#: ../src/guake/guake_app.py:616
+#: ../src/guake/guake_app.py:670
 msgid "Search on Web (no selection)"
 msgstr ""
 
-#: ../src/guake/guake_app.py:622
+#: ../src/guake/guake_app.py:678
+msgid "Open Link: '{}...'"
+msgstr ""
+
+#: ../src/guake/guake_app.py:680
 msgid "Open Link: {}"
 msgstr ""
 
-#: ../src/guake/guake_app.py:625
+#: ../src/guake/guake_app.py:683
 msgid "Open Link..."
 msgstr ""
 
-#: ../src/guake/guake_app.py:1300
+#: ../src/guake/guake_app.py:1402
 msgid "Rename tab"
 msgstr "نام زبانه را تغییر بده"
 
-#: ../src/guake/guake_app.py:1591
+#: ../src/guake/guake_app.py:1716
 msgid "Save to..."
 msgstr ""
 
-#: ../src/guake/guake_app.py:1598 ../src/guake/prefs.py:930
+#: ../src/guake/guake_app.py:1723 ../src/guake/prefs.py:998
 msgid "All files"
 msgstr ""
 
-#: ../src/guake/guake_app.py:1603
+#: ../src/guake/guake_app.py:1728
 msgid "Text and Logs"
 msgstr ""
 
-#: ../src/guake/guake_app.py:1621
+#: ../src/guake/guake_app.py:1746
 msgid "Find"
 msgstr ""
 
-#: ../src/guake/guake_app.py:1623
+#: ../src/guake/guake_app.py:1748
 msgid "Forward"
 msgstr ""
 
-#: ../src/guake/guake_app.py:1624
+#: ../src/guake/guake_app.py:1749
 msgid "Backward"
 msgstr ""
 
-#: ../src/guake/main.py:67
+#: ../src/guake/main.py:68
 msgid "Put Guake in fullscreen mode"
 msgstr ""
 
-#: ../src/guake/main.py:71
+#: ../src/guake/main.py:72
 msgid "Toggles the visibility of the terminal window"
 msgstr "Toggles the visibility of the terminal window"
 
-#: ../src/guake/main.py:75
+#: ../src/guake/main.py:76
 #, fuzzy
 msgid "Shows Guake main window"
 msgstr "Shows Guake preference window"
 
-#: ../src/guake/main.py:79
+#: ../src/guake/main.py:80
 #, fuzzy
 msgid "Hides Guake main window"
 msgstr "Shows Guake preference window"
 
-#: ../src/guake/main.py:83
+#: ../src/guake/main.py:84
 msgid "Shows Guake preference window"
 msgstr "Shows Guake preference window"
 
-#: ../src/guake/main.py:87
+#: ../src/guake/main.py:88
 msgid "Shows Guake's about info"
 msgstr "Shows Guake's about info"
 
-#: ../src/guake/main.py:91
+#: ../src/guake/main.py:92
 #, fuzzy
 msgid "Add a new tab (with current directory set to NEW_TAB)"
 msgstr "_زبانه‌ای جدید در مسیر کنونی باز کن"
 
-#: ../src/guake/main.py:95
+#: ../src/guake/main.py:96
 msgid "Select a tab (SELECT_TAB is the index of the tab)"
 msgstr ""
 
-#: ../src/guake/main.py:99
+#: ../src/guake/main.py:100
 msgid "Return the selected tab index."
 msgstr "Return the selected tab index."
 
-#: ../src/guake/main.py:103
+#: ../src/guake/main.py:104
 msgid "Execute an arbitrary command in the selected tab."
 msgstr "Execute an arbitrary command in the selected tab."
 
-#: ../src/guake/main.py:107
+#: ../src/guake/main.py:108
 msgid "Specify the tab to rename. Default is 0."
 msgstr ""
 
-#: ../src/guake/main.py:111
+#: ../src/guake/main.py:112
 msgid "Set the hexadecimal (#rrggbb) background color of the selected tab."
 msgstr ""
 
-#: ../src/guake/main.py:116
+#: ../src/guake/main.py:117
 msgid "Set the hexadecimal (#rrggbb) foreground color of the selected tab."
 msgstr ""
 
-#: ../src/guake/main.py:122
+#: ../src/guake/main.py:123
 msgid ""
 "Rename the specified tab. Reset to default if TITLE is a single dash \"-\"."
 msgstr ""
 
-#: ../src/guake/main.py:128
+#: ../src/guake/main.py:129
 msgid ""
 "Rename the current tab. Reset to default if TITLE is a single dash \"-\"."
 msgstr ""
 
-#: ../src/guake/main.py:133
+#: ../src/guake/main.py:134
 msgid "Says to Guake go away =("
 msgstr "Says to Guake go away =("
 
-#: ../src/guake/main.py:137
+#: ../src/guake/main.py:138
 msgid "Do not execute the start up script"
 msgstr ""
 
-#: ../src/guake/main.py:231
+#: ../src/guake/main.py:235
 msgid "Guake can not init!"
 msgstr "برنامه‌ی Guake قابل بارگزاری نیست!"
 
-#: ../src/guake/main.py:232
+#: ../src/guake/main.py:236
 #, fuzzy
 msgid ""
 "Gconf Error.\n"
@@ -768,32 +775,190 @@ msgstr ""
 msgid "<user shell>"
 msgstr "<user shell>"
 
-#: ../src/guake/prefs.py:467
+#: ../src/guake/prefs.py:77
+msgid "Toggle Guake visibility"
+msgstr "تغییر پدیداری Guake"
+
+#: ../src/guake/prefs.py:81
+#, fuzzy
+msgid "Toggle Hide on Lose Focus"
+msgstr "در صورت توجه کم پنهان شو"
+
+#: ../src/guake/prefs.py:88
+msgid "Tab management"
+msgstr "مدیریت زبانه"
+
+#: ../src/guake/prefs.py:90
+#, fuzzy
+msgid "New tab"
+msgstr "Nueva pestaña"
+
+#: ../src/guake/prefs.py:92
+msgid "Close tab"
+msgstr "بستن زبانه"
+
+#: ../src/guake/prefs.py:94
+msgid "Rename current tab"
+msgstr "نام زبانه‌ی فعلی را تغییر بده"
+
+#: ../src/guake/prefs.py:97
+msgid "Navigation"
+msgstr "Navigation"
+
+#: ../src/guake/prefs.py:99
+msgid "Go to previous tab"
+msgstr "رفتن به زبانه‌ی قبلی"
+
+#: ../src/guake/prefs.py:101
+msgid "Go to next tab"
+msgstr "رفتن به زبانه‌ی بعدی"
+
+#: ../src/guake/prefs.py:103
+#, fuzzy
+msgid "Move current tab left"
+msgstr "نام زبانه‌ی فعلی را تغییر بده"
+
+#: ../src/guake/prefs.py:105
+#, fuzzy
+msgid "Move current tab right"
+msgstr "نام زبانه‌ی فعلی را تغییر بده"
+
+#: ../src/guake/prefs.py:107
+#, fuzzy
+msgid "Go to first tab"
+msgstr "رفتن به زبانه‌ی بعدی"
+
+#: ../src/guake/prefs.py:109
+#, fuzzy
+msgid "Go to second tab"
+msgstr "رفتن به زبانه‌ی بعدی"
+
+#: ../src/guake/prefs.py:111
+#, fuzzy
+msgid "Go to third tab"
+msgstr "رفتن به زبانه‌ی بعدی"
+
+#: ../src/guake/prefs.py:113
+#, fuzzy
+msgid "Go to fourth tab"
+msgstr "رفتن به زبانه‌ی بعدی"
+
+#: ../src/guake/prefs.py:115
+#, fuzzy
+msgid "Go to fifth tab"
+msgstr "رفتن به زبانه‌ی بعدی"
+
+#: ../src/guake/prefs.py:117
+#, fuzzy
+msgid "Go to sixth tab"
+msgstr "رفتن به زبانه‌ی بعدی"
+
+#: ../src/guake/prefs.py:119
+#, fuzzy
+msgid "Go to seventh tab"
+msgstr "رفتن به زبانه‌ی بعدی"
+
+#: ../src/guake/prefs.py:121
+#, fuzzy
+msgid "Go to eighth tab"
+msgstr "رفتن به زبانه‌ی بعدی"
+
+#: ../src/guake/prefs.py:123
+#, fuzzy
+msgid "Go to ninth tab"
+msgstr "رفتن به زبانه‌ی بعدی"
+
+#: ../src/guake/prefs.py:125
+#, fuzzy
+msgid "Go to tenth tab"
+msgstr "رفتن به زبانه‌ی بعدی"
+
+#: ../src/guake/prefs.py:127
+#, fuzzy
+msgid "Go to last tab"
+msgstr "رفتن به زبانه‌ی بعدی"
+
+#: ../src/guake/prefs.py:132
+msgid "Zoom out"
+msgstr ""
+
+#: ../src/guake/prefs.py:134
+msgid "Zoom in"
+msgstr ""
+
+#: ../src/guake/prefs.py:136
+msgid "Zoom in (alternative)"
+msgstr ""
+
+#: ../src/guake/prefs.py:138
+msgid "Increase height"
+msgstr ""
+
+#: ../src/guake/prefs.py:140
+msgid "Decrease height"
+msgstr ""
+
+#: ../src/guake/prefs.py:142
+#, fuzzy
+msgid "Increase transparency"
+msgstr "شفافیت:"
+
+#: ../src/guake/prefs.py:144
+#, fuzzy
+msgid "Decrease transparency"
+msgstr "شفافیت:"
+
+#: ../src/guake/prefs.py:146
+#, fuzzy
+msgid "Toggle transparency"
+msgstr "شفافیت:"
+
+#: ../src/guake/prefs.py:149
+msgid "Clipboard"
+msgstr "حافظه‌ی موقت"
+
+#: ../src/guake/prefs.py:151
+msgid "Copy text to clipboard"
+msgstr "کپی متن به حافظه‌ی موقت"
+
+#: ../src/guake/prefs.py:153
+msgid "Paste text from clipboard"
+msgstr "چشباندن متن از حافظه‌ی موقت"
+
+#: ../src/guake/prefs.py:156
+msgid "Extra features"
+msgstr ""
+
+#: ../src/guake/prefs.py:159
+msgid "Search select text on web"
+msgstr ""
+
+#: ../src/guake/prefs.py:519
 msgid "Action"
 msgstr "حرکت"
 
-#: ../src/guake/prefs.py:477
+#: ../src/guake/prefs.py:529
 msgid "Shortcut"
 msgstr "میانبر"
 
-#: ../src/guake/prefs.py:619 ../src/guake/prefs.py:665
+#: ../src/guake/prefs.py:678 ../src/guake/prefs.py:724
 msgid "Custom"
 msgstr ""
 
-#: ../src/guake/prefs.py:926
+#: ../src/guake/prefs.py:994
 msgid "JSON files"
 msgstr ""
 
-#: ../src/guake/prefs.py:1019
+#: ../src/guake/prefs.py:1088
 #, python-format
 msgid "The shortcut \"%s\" is already in use."
 msgstr "میانبر \"%s\" هم‌اکنون در حال استفاده می‌باشد."
 
-#: ../src/guake/prefs.py:1020
+#: ../src/guake/prefs.py:1089
 msgid "Error setting keybinding."
 msgstr "خطا در بارگزاری کلید."
 
-#: ../src/guake/prefs.py:1032
+#: ../src/guake/prefs.py:1101
 #, python-format
 msgid ""
 "The shortcut \"%s\" cannot be used because it will become impossible to type "
@@ -833,36 +998,6 @@ msgstr ""
 
 #~ msgid "Rename the selected tab."
 #~ msgstr "Rename the selected tab."
-
-#~ msgid "Toggle Guake visibility"
-#~ msgstr "تغییر پدیداری Guake"
-
-#~ msgid "Tab management"
-#~ msgstr "مدیریت زبانه"
-
-#~ msgid "Close tab"
-#~ msgstr "بستن زبانه"
-
-#~ msgid "Rename current tab"
-#~ msgstr "نام زبانه‌ی فعلی را تغییر بده"
-
-#~ msgid "Navigation"
-#~ msgstr "Navigation"
-
-#~ msgid "Go to previous tab"
-#~ msgstr "رفتن به زبانه‌ی قبلی"
-
-#~ msgid "Go to next tab"
-#~ msgstr "رفتن به زبانه‌ی بعدی"
-
-#~ msgid "Clipboard"
-#~ msgstr "حافظه‌ی موقت"
-
-#~ msgid "Copy text to clipboard"
-#~ msgstr "کپی متن به حافظه‌ی موقت"
-
-#~ msgid "Paste text from clipboard"
-#~ msgstr "چشباندن متن از حافظه‌ی موقت"
 
 #~ msgid "<b>Background</b>"
 #~ msgstr "<b>پس زمینه</b>"

--- a/po/fr.po
+++ b/po/fr.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Guake 0.4.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-12-01 16:49+0100\n"
+"POT-Creation-Date: 2016-08-17 21:41+0000\n"
 "PO-Revision-Date: 2015-08-27 13:42+0100\n"
 "Last-Translator: Benjamin Danon <benjamin@sphax3d.org>\n"
 "Language-Team: French (http://www.transifex.com/projects/p/guake/language/"
@@ -106,7 +106,7 @@ msgstr "Copier"
 msgid "Paste"
 msgstr "Coller"
 
-#: ../data/guake.glade.h:3
+#: ../data/guake.glade.h:3 ../src/guake/prefs.py:79
 msgid "Toggle Fullscreen"
 msgstr "Active/Désactive le plein écran"
 
@@ -114,7 +114,7 @@ msgstr "Active/Désactive le plein écran"
 msgid "Save to File..."
 msgstr "Enregister..."
 
-#: ../data/guake.glade.h:5
+#: ../data/guake.glade.h:5 ../src/guake/prefs.py:85
 #, fuzzy
 msgid "Reset terminal"
 msgstr "Terminal Guake"
@@ -143,7 +143,7 @@ msgstr "Ouvrir le lien..."
 msgid "Search on Web"
 msgstr "Rechercher sur le Web"
 
-#: ../data/guake.glade.h:12
+#: ../data/guake.glade.h:12 ../src/guake/prefs.py:83
 msgid "Quit"
 msgstr "Quitter"
 
@@ -277,130 +277,134 @@ msgid "Use VTE titles for tab names"
 msgstr "Utiliser les titres VTE pour le nom des tabs"
 
 #: ../data/prefs.glade.h:33
-msgid "Max tab name length:"
+msgid "Abbreviate directories in tab names"
 msgstr ""
 
 #: ../data/prefs.glade.h:34
+msgid "Max tab name length:"
+msgstr ""
+
+#: ../data/prefs.glade.h:35
 msgid "Hide on lose focus"
 msgstr "Cacher lors de la perte du focus"
 
-#: ../data/prefs.glade.h:35
+#: ../data/prefs.glade.h:36
 msgid "Show tab bar"
 msgstr "Afficher la barre d'onglets"
 
-#: ../data/prefs.glade.h:36
+#: ../data/prefs.glade.h:37
 msgid "Start fullscreen"
 msgstr "Active/Désactive le plein écran"
 
-#: ../data/prefs.glade.h:37
+#: ../data/prefs.glade.h:38
 msgid "<b>Main Window</b>"
 msgstr "<b>Fenêtre principale</b>"
 
-#: ../data/prefs.glade.h:38
+#: ../data/prefs.glade.h:39
 msgid "Left"
 msgstr "Gauche"
 
-#: ../data/prefs.glade.h:39
+#: ../data/prefs.glade.h:40
 msgid "Center"
 msgstr "Centre"
 
-#: ../data/prefs.glade.h:40
+#: ../data/prefs.glade.h:41
 msgid "Right"
 msgstr "Droit"
 
-#: ../data/prefs.glade.h:41
+#: ../data/prefs.glade.h:42
 msgid "<b>Main Window Horizontal Alignment</b>"
 msgstr "<b>Alignement horizontal de la fenêtre principale</b>"
 
-#: ../data/prefs.glade.h:42
+#: ../data/prefs.glade.h:43
 msgid "<b>Main Window Height</b>"
 msgstr "<b>Hauteur de la fenêtre principale</b>"
 
-#: ../data/prefs.glade.h:43
+#: ../data/prefs.glade.h:44
 msgid "<b>Main Window Width</b>"
 msgstr "<b>Largeur de la fenêtre principale</b>"
 
-#: ../data/prefs.glade.h:44
+#: ../data/prefs.glade.h:45
 msgid "Custom command file path: "
 msgstr "Fichier de commandes personnalisées:"
 
-#: ../data/prefs.glade.h:45
+#: ../data/prefs.glade.h:46
 msgid "Please select a json file"
 msgstr "Veuillez sélectionnez un fichier JSON"
 
-#: ../data/prefs.glade.h:46
+#: ../data/prefs.glade.h:47 ../src/guake/prefs.py:75
 msgid "General"
 msgstr "Général"
 
-#: ../data/prefs.glade.h:47
+#: ../data/prefs.glade.h:48
 msgid "Default interpreter:"
 msgstr "Interpréteur par défaut :"
 
-#: ../data/prefs.glade.h:48
+#: ../data/prefs.glade.h:49
 msgid "_Run command as a login shell"
 msgstr "_Exécuter les commandes comme shell de connexion"
 
-#: ../data/prefs.glade.h:49
+#: ../data/prefs.glade.h:50
 msgid "_Open new tab in current directory"
 msgstr "_Ouvrir un nouvel onglet dans le dossier courant"
 
-#: ../data/prefs.glade.h:50
+#: ../data/prefs.glade.h:51
 msgid "<b>Shell</b>"
 msgstr "<b>Shell</b>"
 
-#: ../data/prefs.glade.h:51
+#: ../data/prefs.glade.h:52
 msgid "Shell"
 msgstr "Shell"
 
-#: ../data/prefs.glade.h:52
+#: ../data/prefs.glade.h:53
 msgid "Show scrollbar"
 msgstr "Afficher la barre de défilement"
 
-#: ../data/prefs.glade.h:53
+#: ../data/prefs.glade.h:54
 msgid "Scrollback lines:"
 msgstr "Nombres de lignes en mémoire :"
 
-#: ../data/prefs.glade.h:54
+#: ../data/prefs.glade.h:55
 msgid "On output"
 msgstr "En sortie"
 
-#: ../data/prefs.glade.h:55
+#: ../data/prefs.glade.h:56
 msgid "On key stroke"
 msgstr "Par raccourcis clavier"
 
-#: ../data/prefs.glade.h:56
+#: ../data/prefs.glade.h:57
 msgid "<b>Scroll</b>"
 msgstr "<b>Défilement</b>"
 
-#: ../data/prefs.glade.h:57
+#: ../data/prefs.glade.h:58
 msgid "Scrolling"
 msgstr "Défilement"
 
-#: ../data/prefs.glade.h:58
+#: ../data/prefs.glade.h:59
 msgid "Use the system fixed width font"
 msgstr "Utiliser la taille de police définie par le système"
 
-#: ../data/prefs.glade.h:59
+#: ../data/prefs.glade.h:60
 msgid "Font:"
 msgstr "Police de caractères :"
 
-#: ../data/prefs.glade.h:60
+#: ../data/prefs.glade.h:61
 msgid "Choose some font"
 msgstr "Choisissez une police"
 
-#: ../data/prefs.glade.h:61
+#: ../data/prefs.glade.h:62
 msgid "Text color:"
 msgstr "Couleur du texte :"
 
-#: ../data/prefs.glade.h:62
+#: ../data/prefs.glade.h:63
 msgid "Background color:"
 msgstr "Couleur d'arrière-plan "
 
-#: ../data/prefs.glade.h:63
+#: ../data/prefs.glade.h:64
 msgid "Cursor shape:"
 msgstr "Forme du curseur"
 
-#: ../data/prefs.glade.h:64
+#: ../data/prefs.glade.h:65
 msgid ""
 "Block\n"
 "I-Beam\n"
@@ -410,7 +414,7 @@ msgstr ""
 "Faisceau en forme de I\n"
 "Souligner"
 
-#: ../data/prefs.glade.h:67
+#: ../data/prefs.glade.h:68
 msgid ""
 "Follow GTK+ setting\n"
 "Blink on\n"
@@ -420,59 +424,59 @@ msgstr ""
 "Activé\n"
 "Désactivé"
 
-#: ../data/prefs.glade.h:70
+#: ../data/prefs.glade.h:71
 msgid "Cursor blink mode:"
 msgstr "Mode de clignotement du curseur:"
 
-#: ../data/prefs.glade.h:71
+#: ../data/prefs.glade.h:72
 msgid "Allow bold font"
 msgstr "Autoriser les polices grasses"
 
-#: ../data/prefs.glade.h:72
+#: ../data/prefs.glade.h:73
 msgid "<b>Palette</b>"
 msgstr "<b>Palette</b>"
 
-#: ../data/prefs.glade.h:73
+#: ../data/prefs.glade.h:74
 msgid "Built-in schemes:"
 msgstr "Arrangements pré-définis :"
 
-#: ../data/prefs.glade.h:74
+#: ../data/prefs.glade.h:75
 msgid "Color palette:"
 msgstr "Palette de couleurs :"
 
-#: ../data/prefs.glade.h:75
+#: ../data/prefs.glade.h:76
 msgid "Font color"
 msgstr "Couleur du texte"
 
-#: ../data/prefs.glade.h:76
+#: ../data/prefs.glade.h:77
 msgid "Background color"
 msgstr "Couleur d'arrière-plan"
 
-#: ../data/prefs.glade.h:77
+#: ../data/prefs.glade.h:78
 msgid "Use font and background color from the palette"
 msgstr "Utiliser les couleurs de la palette pour la police et le fond"
 
-#: ../data/prefs.glade.h:78
+#: ../data/prefs.glade.h:79
 msgid "Demo:"
 msgstr "Demo:"
 
-#: ../data/prefs.glade.h:79
+#: ../data/prefs.glade.h:80
 msgid "<b>Effects</b>"
 msgstr "<b>Effets</b>"
 
-#: ../data/prefs.glade.h:80
+#: ../data/prefs.glade.h:81
 msgid "Transparency:"
 msgstr "Transparence :"
 
-#: ../data/prefs.glade.h:81
+#: ../data/prefs.glade.h:82
 msgid "Background image:"
 msgstr "Image d'arrière-plan :"
 
-#: ../data/prefs.glade.h:82
+#: ../data/prefs.glade.h:83 ../src/guake/prefs.py:130
 msgid "Appearance"
 msgstr "Apparence"
 
-#: ../data/prefs.glade.h:83
+#: ../data/prefs.glade.h:84
 msgid ""
 "<small>Quick open is a feature allowing you to open a file directly into "
 "your favorite text editor by clicking on its filename when it appears in "
@@ -484,17 +488,17 @@ msgstr ""
 "terminal. Veuillez consulter ci-dessous la liste des motifs de texte utilisé "
 "pour extraire les noms de fichiers.</small>"
 
-#: ../data/prefs.glade.h:84
+#: ../data/prefs.glade.h:85
 msgid "Enable Quick Open when Ctrl+clicking on a filename in the terminal"
 msgstr ""
 "Activer l'Ouverture Rapide lors d'un Ctrl+clic sur un nom de fichier dans le "
 "terminal"
 
-#: ../data/prefs.glade.h:85
+#: ../data/prefs.glade.h:86
 msgid "Editor command line:"
 msgstr "Ligne de commande de l'éditeur:"
 
-#: ../data/prefs.glade.h:87
+#: ../data/prefs.glade.h:88
 #, no-c-format
 msgid ""
 "<small><i>Use the following elements in the open editor command line:\n"
@@ -515,11 +519,11 @@ msgstr ""
 "%(file_path)s:%(line_number)s</b>\n"
 "</i></small>"
 
-#: ../data/prefs.glade.h:93
+#: ../data/prefs.glade.h:94
 msgid "Quick open in current terminal"
 msgstr "Ouverture Rapide dans le terminal courant"
 
-#: ../data/prefs.glade.h:94
+#: ../data/prefs.glade.h:95
 msgid ""
 "Here is the list of supported patterns: (to add your own, please contact the "
 "Guake's authors)"
@@ -527,15 +531,15 @@ msgstr ""
 "Voici la liste des motifs supportés (pour ajouter votre propre motif, "
 "contacter l'équipe de dévelopment)"
 
-#: ../data/prefs.glade.h:95
+#: ../data/prefs.glade.h:96
 msgid "<b>Quick Open</b>"
 msgstr "Ouverture Rapide"
 
-#: ../data/prefs.glade.h:96
+#: ../data/prefs.glade.h:97
 msgid "Quick Open"
 msgstr "Ouverture Rapide"
 
-#: ../data/prefs.glade.h:97
+#: ../data/prefs.glade.h:98
 msgid ""
 "To change a shortcut simply click on its name.\n"
 "To disable a shortcut, press the \"Backspace\" key."
@@ -543,11 +547,11 @@ msgstr ""
 "Pour changer un raccourcis, cliquer sur son nom.\n"
 "Pour désactiver un raccourcis, appuyer sur la touche \"Retour Arrière\"."
 
-#: ../data/prefs.glade.h:99
+#: ../data/prefs.glade.h:100
 msgid "Keyboard shortcuts"
 msgstr "Raccourcis clavier"
 
-#: ../data/prefs.glade.h:100
+#: ../data/prefs.glade.h:101
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -559,7 +563,7 @@ msgstr ""
 "certains logiciels ou système d'exploitation attendent un comportement "
 "différent du terminal.</i></small>"
 
-#: ../data/prefs.glade.h:101
+#: ../data/prefs.glade.h:102
 msgid ""
 "ASCII DEL\n"
 "Escape sequence\n"
@@ -569,37 +573,36 @@ msgstr ""
 "Séquence d'échap.\n"
 "Control-H"
 
-#: ../data/prefs.glade.h:104
+#: ../data/prefs.glade.h:105
 msgid "_Backspace key generates:"
 msgstr "La touche _Retour correspond à :"
 
-#: ../data/prefs.glade.h:105
+#: ../data/prefs.glade.h:106
 msgid "_Delete key generates:"
 msgstr "La touche _Suppr correspond  à :"
 
-#: ../data/prefs.glade.h:106
+#: ../data/prefs.glade.h:107
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "_Rétablir la configuration par défaut"
 
-#: ../data/prefs.glade.h:107
+#: ../data/prefs.glade.h:108
 msgid "<b>Keyboard compatibility</b>"
 msgstr "<b>Configuration clavier</b>"
 
-#: ../data/prefs.glade.h:108
+#: ../data/prefs.glade.h:109
 msgid "Compatibility"
 msgstr "Compatibilité"
 
-#: ../src/guake/about.py:47 ../src/guake/gconfhandler.py:427
-#: ../src/guake/guake_app.py:177 ../src/guake/guake_app.py:348
+#: ../src/guake/about.py:47 ../src/guake/gconfhandler.py:435
+#: ../src/guake/guake_app.py:181 ../src/guake/guake_app.py:376
 msgid "Guake Terminal"
 msgstr "Terminal Guake"
 
-#. Adding a new radio button to the tabbar
-#: ../src/guake/gconfhandler.py:365 ../src/guake/guake_app.py:1548
+#: ../src/guake/gconfhandler.py:368 ../src/guake/guake_app.py:1363
 msgid "Terminal"
 msgstr "Terminal %s"
 
-#: ../src/guake/gconfhandler.py:428
+#: ../src/guake/gconfhandler.py:436
 #, python-format
 msgid ""
 "A problem happened when binding <b>%s</b> key.\n"
@@ -609,182 +612,187 @@ msgstr ""
 "Merci d'utiliser la fenêtre de préférences de Guake pour choisir une autre "
 "touche (icône de notification activée)"
 
-#: ../src/guake/guake_app.py:128
+#: ../src/guake/guake_app.py:132
 msgid "Do you want to close the tab?"
 msgstr "Voulez-vous vraiment fermer l'onglet?"
 
-#: ../src/guake/guake_app.py:131
+#: ../src/guake/guake_app.py:135
 msgid "Do you really want to quit Guake?"
 msgstr "Voulez-vous vraiment quitter Guake ?"
 
-#: ../src/guake/guake_app.py:133
+#: ../src/guake/guake_app.py:137
 msgid " and one tab open"
 msgstr "et un tab ouvert"
 
-#: ../src/guake/guake_app.py:135
+#: ../src/guake/guake_app.py:139
 #, python-brace-format
 msgid " and {0} tabs open"
 msgstr "et {0} onglets ouverts"
 
-#: ../src/guake/guake_app.py:138
+#: ../src/guake/guake_app.py:142
 msgid "There are no processes running"
 msgstr "Il y n'a pas de processus actif."
 
-#: ../src/guake/guake_app.py:140
+#: ../src/guake/guake_app.py:144
 msgid "There is a process still running"
 msgstr "Il y a encore un processus en cours."
 
-#: ../src/guake/guake_app.py:142
+#: ../src/guake/guake_app.py:146
 #, python-brace-format
 msgid "There are {0} processes still running"
 msgstr "Il y a {0} processus encore actifs."
 
-#: ../src/guake/guake_app.py:182
+#: ../src/guake/guake_app.py:186
 msgid "guake-indicator"
 msgstr "guake-indicator"
 
-#: ../src/guake/guake_app.py:182
+#: ../src/guake/guake_app.py:186
 msgid "guake-tray"
 msgstr "guake-tray"
 
-#: ../src/guake/guake_app.py:186
+#: ../src/guake/guake_app.py:190
 msgid "Show"
 msgstr "Afficher"
 
-#: ../src/guake/guake_app.py:349
+#: ../src/guake/guake_app.py:377
 #, python-format
 msgid ""
 "Guake is now running,\n"
 "press <b>%s</b> to use it."
 msgstr "Appuyer sur <b>%s</b> pour afficher Guake."
 
-#: ../src/guake/guake_app.py:611
+#: ../src/guake/guake_app.py:665
 #, python-format
 msgid "Search on Web: '%s'"
 msgstr "Rechercher sur le Web: '%s'"
 
-#: ../src/guake/guake_app.py:616
+#: ../src/guake/guake_app.py:670
 msgid "Search on Web (no selection)"
 msgstr "Rechercher sur le Web (pas de sélection)"
 
-#: ../src/guake/guake_app.py:622
+#: ../src/guake/guake_app.py:678
+#, fuzzy
+msgid "Open Link: '{}...'"
+msgstr "Ouvrir le lien: {}"
+
+#: ../src/guake/guake_app.py:680
 msgid "Open Link: {}"
 msgstr "Ouvrir le lien: {}"
 
-#: ../src/guake/guake_app.py:625
+#: ../src/guake/guake_app.py:683
 msgid "Open Link..."
 msgstr "Ouvrir le lien..."
 
-#: ../src/guake/guake_app.py:1300
+#: ../src/guake/guake_app.py:1402
 msgid "Rename tab"
 msgstr "Renomme l'onglet"
 
-#: ../src/guake/guake_app.py:1591
+#: ../src/guake/guake_app.py:1716
 msgid "Save to..."
 msgstr "Enregistrer sous..."
 
-#: ../src/guake/guake_app.py:1598 ../src/guake/prefs.py:930
+#: ../src/guake/guake_app.py:1723 ../src/guake/prefs.py:998
 msgid "All files"
 msgstr "Tous les fichiers"
 
-#: ../src/guake/guake_app.py:1603
+#: ../src/guake/guake_app.py:1728
 msgid "Text and Logs"
 msgstr "Textes et logs"
 
-#: ../src/guake/guake_app.py:1621
+#: ../src/guake/guake_app.py:1746
 msgid "Find"
 msgstr "Rechercher"
 
-#: ../src/guake/guake_app.py:1623
+#: ../src/guake/guake_app.py:1748
 msgid "Forward"
 msgstr "Suivant"
 
-#: ../src/guake/guake_app.py:1624
+#: ../src/guake/guake_app.py:1749
 msgid "Backward"
 msgstr "Précédent"
 
-#: ../src/guake/main.py:67
+#: ../src/guake/main.py:68
 msgid "Put Guake in fullscreen mode"
 msgstr "Placer Guake en mode plein écran"
 
-#: ../src/guake/main.py:71
+#: ../src/guake/main.py:72
 msgid "Toggles the visibility of the terminal window"
 msgstr "Active/Désactive la visibilité de la fenêtre principale"
 
-#: ../src/guake/main.py:75
+#: ../src/guake/main.py:76
 msgid "Shows Guake main window"
 msgstr "Afficher la fenêtre principale de Guake"
 
-#: ../src/guake/main.py:79
+#: ../src/guake/main.py:80
 msgid "Hides Guake main window"
 msgstr "Afficher la fenêtre principale de Guake"
 
-#: ../src/guake/main.py:83
+#: ../src/guake/main.py:84
 msgid "Shows Guake preference window"
 msgstr "Afficher la fenêtre de préférences de Guake"
 
-#: ../src/guake/main.py:87
+#: ../src/guake/main.py:88
 msgid "Shows Guake's about info"
 msgstr "Afficher les informations à propos de Guake"
 
-#: ../src/guake/main.py:91
+#: ../src/guake/main.py:92
 msgid "Add a new tab (with current directory set to NEW_TAB)"
 msgstr "_Ouvrir un nouvel onglet (le dossier courant est spécifié par NEW_TAB)"
 
-#: ../src/guake/main.py:95
+#: ../src/guake/main.py:96
 msgid "Select a tab (SELECT_TAB is the index of the tab)"
 msgstr "Selectionner un onglet (SELECT_TAB est l'index du tab)"
 
-#: ../src/guake/main.py:99
+#: ../src/guake/main.py:100
 msgid "Return the selected tab index."
 msgstr "Retourne l'index de l'onglet sélectionné."
 
-#: ../src/guake/main.py:103
+#: ../src/guake/main.py:104
 msgid "Execute an arbitrary command in the selected tab."
 msgstr "Exécute une commande dans un onglet sélectionné"
 
-#: ../src/guake/main.py:107
+#: ../src/guake/main.py:108
 msgid "Specify the tab to rename. Default is 0."
 msgstr "Spécifier un onglet à renommer. Defaut: 0"
 
-#: ../src/guake/main.py:111
+#: ../src/guake/main.py:112
 msgid "Set the hexadecimal (#rrggbb) background color of the selected tab."
 msgstr ""
 "Choisir la couleur hexadécimale (#rrggbb) du fond pour l'onglet sectionné"
 
-#: ../src/guake/main.py:116
+#: ../src/guake/main.py:117
 msgid "Set the hexadecimal (#rrggbb) foreground color of the selected tab."
 msgstr ""
 "Choisir la couleur hexadécimale (#rrggbb) de la police pour l'onglet "
 "sectionné"
 
-#: ../src/guake/main.py:122
+#: ../src/guake/main.py:123
 msgid ""
 "Rename the specified tab. Reset to default if TITLE is a single dash \"-\"."
 msgstr ""
 "Renommer l'onglet spécifié. Pour remettre à la valeur par defaut, mettre "
 "TITRE à \"-\"."
 
-#: ../src/guake/main.py:128
+#: ../src/guake/main.py:129
 msgid ""
 "Rename the current tab. Reset to default if TITLE is a single dash \"-\"."
 msgstr ""
 "Renommer  the tab actuel. Pour remettre à la valeur par défaut, utiliser \"-"
 "\"."
 
-#: ../src/guake/main.py:133
+#: ../src/guake/main.py:134
 msgid "Says to Guake go away =("
 msgstr "Dis au-revoir à Guake =("
 
-#: ../src/guake/main.py:137
+#: ../src/guake/main.py:138
 msgid "Do not execute the start up script"
 msgstr "Ne pas executer le script de démarrage"
 
-#: ../src/guake/main.py:231
+#: ../src/guake/main.py:235
 msgid "Guake can not init!"
 msgstr "Guake ne peux démarrer"
 
-#: ../src/guake/main.py:232
+#: ../src/guake/main.py:236
 msgid ""
 "Gconf Error.\n"
 "Have you installed <b>guake.schemas</b> properly?"
@@ -797,32 +805,191 @@ msgstr ""
 msgid "<user shell>"
 msgstr "<shell utilisateur>"
 
-#: ../src/guake/prefs.py:467
+#: ../src/guake/prefs.py:77
+msgid "Toggle Guake visibility"
+msgstr "Affiche/Cache Guake"
+
+#: ../src/guake/prefs.py:81
+#, fuzzy
+msgid "Toggle Hide on Lose Focus"
+msgstr "Cacher lors de la perte du focus"
+
+#: ../src/guake/prefs.py:88
+msgid "Tab management"
+msgstr "Gestion des onglets"
+
+#: ../src/guake/prefs.py:90
+#, fuzzy
+msgid "New tab"
+msgstr "Nouvel onglet"
+
+#: ../src/guake/prefs.py:92
+msgid "Close tab"
+msgstr "Fermer un onglet"
+
+#: ../src/guake/prefs.py:94
+msgid "Rename current tab"
+msgstr "Renommer l'onglet actuel"
+
+#: ../src/guake/prefs.py:97
+msgid "Navigation"
+msgstr "Navigation"
+
+#: ../src/guake/prefs.py:99
+msgid "Go to previous tab"
+msgstr "Aller à l'onglet précédent"
+
+#: ../src/guake/prefs.py:101
+msgid "Go to next tab"
+msgstr "Aller à l'onglet suivant"
+
+#: ../src/guake/prefs.py:103
+#, fuzzy
+msgid "Move current tab left"
+msgstr "Renommer l'onglet actuel"
+
+#: ../src/guake/prefs.py:105
+#, fuzzy
+msgid "Move current tab right"
+msgstr "Renommer l'onglet actuel"
+
+#: ../src/guake/prefs.py:107
+#, fuzzy
+msgid "Go to first tab"
+msgstr "Aller à l'onglet suivant"
+
+#: ../src/guake/prefs.py:109
+#, fuzzy
+msgid "Go to second tab"
+msgstr "Aller à l'onglet suivant"
+
+#: ../src/guake/prefs.py:111
+#, fuzzy
+msgid "Go to third tab"
+msgstr "Aller à l'onglet suivant"
+
+#: ../src/guake/prefs.py:113
+#, fuzzy
+msgid "Go to fourth tab"
+msgstr "Aller à l'onglet suivant"
+
+#: ../src/guake/prefs.py:115
+#, fuzzy
+msgid "Go to fifth tab"
+msgstr "Aller à l'onglet suivant"
+
+#: ../src/guake/prefs.py:117
+#, fuzzy
+msgid "Go to sixth tab"
+msgstr "Aller à l'onglet suivant"
+
+#: ../src/guake/prefs.py:119
+#, fuzzy
+msgid "Go to seventh tab"
+msgstr "Aller à l'onglet suivant"
+
+#: ../src/guake/prefs.py:121
+#, fuzzy
+msgid "Go to eighth tab"
+msgstr "Aller à l'onglet suivant"
+
+#: ../src/guake/prefs.py:123
+#, fuzzy
+msgid "Go to ninth tab"
+msgstr "Aller à l'onglet suivant"
+
+#: ../src/guake/prefs.py:125
+#, fuzzy
+msgid "Go to tenth tab"
+msgstr "Aller à l'onglet suivant"
+
+#: ../src/guake/prefs.py:127
+#, fuzzy
+msgid "Go to last tab"
+msgstr "Aller à l'onglet suivant"
+
+#: ../src/guake/prefs.py:132
+msgid "Zoom out"
+msgstr ""
+
+#: ../src/guake/prefs.py:134
+msgid "Zoom in"
+msgstr ""
+
+#: ../src/guake/prefs.py:136
+msgid "Zoom in (alternative)"
+msgstr ""
+
+#: ../src/guake/prefs.py:138
+msgid "Increase height"
+msgstr ""
+
+#: ../src/guake/prefs.py:140
+msgid "Decrease height"
+msgstr ""
+
+#: ../src/guake/prefs.py:142
+#, fuzzy
+msgid "Increase transparency"
+msgstr "Transparence :"
+
+#: ../src/guake/prefs.py:144
+#, fuzzy
+msgid "Decrease transparency"
+msgstr "Transparence :"
+
+#: ../src/guake/prefs.py:146
+#, fuzzy
+msgid "Toggle transparency"
+msgstr "Transparence :"
+
+#: ../src/guake/prefs.py:149
+msgid "Clipboard"
+msgstr "Presse-papiers"
+
+#: ../src/guake/prefs.py:151
+msgid "Copy text to clipboard"
+msgstr "Copie dans le presse-papiers"
+
+#: ../src/guake/prefs.py:153
+msgid "Paste text from clipboard"
+msgstr "Colle à partir du presse-papiers"
+
+#: ../src/guake/prefs.py:156
+msgid "Extra features"
+msgstr ""
+
+#: ../src/guake/prefs.py:159
+#, fuzzy
+msgid "Search select text on web"
+msgstr "Rechercher sur le Web"
+
+#: ../src/guake/prefs.py:519
 msgid "Action"
 msgstr "Action"
 
-#: ../src/guake/prefs.py:477
+#: ../src/guake/prefs.py:529
 msgid "Shortcut"
 msgstr "Raccourcis"
 
-#: ../src/guake/prefs.py:619 ../src/guake/prefs.py:665
+#: ../src/guake/prefs.py:678 ../src/guake/prefs.py:724
 msgid "Custom"
 msgstr "Personnalisé"
 
-#: ../src/guake/prefs.py:926
+#: ../src/guake/prefs.py:994
 msgid "JSON files"
 msgstr "Fichiers JSON"
 
-#: ../src/guake/prefs.py:1019
+#: ../src/guake/prefs.py:1088
 #, python-format
 msgid "The shortcut \"%s\" is already in use."
 msgstr "Le raccourcis « %s » est déjà utilisé."
 
-#: ../src/guake/prefs.py:1020
+#: ../src/guake/prefs.py:1089
 msgid "Error setting keybinding."
 msgstr "Erreur d'attribution des raccourcis."
 
-#: ../src/guake/prefs.py:1032
+#: ../src/guake/prefs.py:1101
 #, python-format
 msgid ""
 "The shortcut \"%s\" cannot be used because it will become impossible to type "
@@ -869,33 +1036,3 @@ msgstr ""
 
 #~ msgid "Rename the selected tab."
 #~ msgstr "Renommer l'onglet sélectionné."
-
-#~ msgid "Toggle Guake visibility"
-#~ msgstr "Affiche/Cache Guake"
-
-#~ msgid "Tab management"
-#~ msgstr "Gestion des onglets"
-
-#~ msgid "Close tab"
-#~ msgstr "Fermer un onglet"
-
-#~ msgid "Rename current tab"
-#~ msgstr "Renommer l'onglet actuel"
-
-#~ msgid "Navigation"
-#~ msgstr "Navigation"
-
-#~ msgid "Go to previous tab"
-#~ msgstr "Aller à l'onglet précédent"
-
-#~ msgid "Go to next tab"
-#~ msgstr "Aller à l'onglet suivant"
-
-#~ msgid "Clipboard"
-#~ msgstr "Presse-papiers"
-
-#~ msgid "Copy text to clipboard"
-#~ msgstr "Copie dans le presse-papiers"
-
-#~ msgid "Paste text from clipboard"
-#~ msgstr "Colle à partir du presse-papiers"

--- a/po/gl.po
+++ b/po/gl.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Guake 0.4.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-12-01 16:49+0100\n"
+"POT-Creation-Date: 2016-08-17 21:41+0000\n"
 "PO-Revision-Date: 2012-11-12 20:06+0000\n"
 "Last-Translator: Antón Méixome <meixome@certima.net>\n"
 "Language-Team: Galician (http://www.transifex.com/projects/p/guake/language/"
@@ -103,7 +103,7 @@ msgstr "Copiar"
 msgid "Paste"
 msgstr "Pegar"
 
-#: ../data/guake.glade.h:3
+#: ../data/guake.glade.h:3 ../src/guake/prefs.py:79
 msgid "Toggle Fullscreen"
 msgstr "Alternar a pantalla completa"
 
@@ -111,7 +111,7 @@ msgstr "Alternar a pantalla completa"
 msgid "Save to File..."
 msgstr ""
 
-#: ../data/guake.glade.h:5
+#: ../data/guake.glade.h:5 ../src/guake/prefs.py:85
 #, fuzzy
 msgid "Reset terminal"
 msgstr "Terminal Guake"
@@ -142,7 +142,7 @@ msgstr ""
 msgid "Search on Web"
 msgstr ""
 
-#: ../data/guake.glade.h:12
+#: ../data/guake.glade.h:12 ../src/guake/prefs.py:83
 msgid "Quit"
 msgstr "Saír"
 
@@ -267,202 +267,206 @@ msgid "Use VTE titles for tab names"
 msgstr ""
 
 #: ../data/prefs.glade.h:33
-msgid "Max tab name length:"
+msgid "Abbreviate directories in tab names"
 msgstr ""
 
 #: ../data/prefs.glade.h:34
+msgid "Max tab name length:"
+msgstr ""
+
+#: ../data/prefs.glade.h:35
 msgid "Hide on lose focus"
 msgstr "Agochar ao perder o foco"
 
-#: ../data/prefs.glade.h:35
+#: ../data/prefs.glade.h:36
 msgid "Show tab bar"
 msgstr "Amosar barra de lapelas"
 
-#: ../data/prefs.glade.h:36
+#: ../data/prefs.glade.h:37
 #, fuzzy
 msgid "Start fullscreen"
 msgstr "Alternar a pantalla completa"
 
-#: ../data/prefs.glade.h:37
+#: ../data/prefs.glade.h:38
 msgid "<b>Main Window</b>"
 msgstr "<b>Xanela principal</b>"
 
-#: ../data/prefs.glade.h:38
+#: ../data/prefs.glade.h:39
 msgid "Left"
 msgstr ""
 
-#: ../data/prefs.glade.h:39
+#: ../data/prefs.glade.h:40
 msgid "Center"
 msgstr ""
 
-#: ../data/prefs.glade.h:40
+#: ../data/prefs.glade.h:41
 msgid "Right"
 msgstr ""
 
-#: ../data/prefs.glade.h:41
+#: ../data/prefs.glade.h:42
 #, fuzzy
 msgid "<b>Main Window Horizontal Alignment</b>"
 msgstr "<b>Altura da xanela principal</b>"
 
-#: ../data/prefs.glade.h:42
+#: ../data/prefs.glade.h:43
 #, fuzzy
 msgid "<b>Main Window Height</b>"
 msgstr "<b>Altura da xanela principal</b>"
 
-#: ../data/prefs.glade.h:43
+#: ../data/prefs.glade.h:44
 #, fuzzy
 msgid "<b>Main Window Width</b>"
 msgstr "<b>Altura da xanela principal</b>"
 
-#: ../data/prefs.glade.h:44
+#: ../data/prefs.glade.h:45
 msgid "Custom command file path: "
 msgstr ""
 
-#: ../data/prefs.glade.h:45
+#: ../data/prefs.glade.h:46
 msgid "Please select a json file"
 msgstr ""
 
-#: ../data/prefs.glade.h:46
+#: ../data/prefs.glade.h:47 ../src/guake/prefs.py:75
 msgid "General"
 msgstr "Xeral"
 
-#: ../data/prefs.glade.h:47
+#: ../data/prefs.glade.h:48
 msgid "Default interpreter:"
 msgstr "Intérprete predeter.:"
 
-#: ../data/prefs.glade.h:48
+#: ../data/prefs.glade.h:49
 msgid "_Run command as a login shell"
 msgstr "_Executar a orde como intérprete de ordes de inicio de sesión "
 
-#: ../data/prefs.glade.h:49
+#: ../data/prefs.glade.h:50
 msgid "_Open new tab in current directory"
 msgstr "_Abrir unha nova lapela no cartafol actual"
 
-#: ../data/prefs.glade.h:50
+#: ../data/prefs.glade.h:51
 msgid "<b>Shell</b>"
 msgstr "<b>Shell</b>"
 
-#: ../data/prefs.glade.h:51
+#: ../data/prefs.glade.h:52
 msgid "Shell"
 msgstr ""
 
-#: ../data/prefs.glade.h:52
+#: ../data/prefs.glade.h:53
 msgid "Show scrollbar"
 msgstr "Amosar barra de desprazamento"
 
-#: ../data/prefs.glade.h:53
+#: ../data/prefs.glade.h:54
 msgid "Scrollback lines:"
 msgstr "Liñas de historial:"
 
-#: ../data/prefs.glade.h:54
+#: ../data/prefs.glade.h:55
 msgid "On output"
 msgstr "Na saída"
 
-#: ../data/prefs.glade.h:55
+#: ../data/prefs.glade.h:56
 msgid "On key stroke"
 msgstr "Pulsacións de teclado"
 
-#: ../data/prefs.glade.h:56
+#: ../data/prefs.glade.h:57
 msgid "<b>Scroll</b>"
 msgstr "<b>Desprazamento</b>"
 
-#: ../data/prefs.glade.h:57
+#: ../data/prefs.glade.h:58
 msgid "Scrolling"
 msgstr "Desprazamento"
 
-#: ../data/prefs.glade.h:58
+#: ../data/prefs.glade.h:59
 msgid "Use the system fixed width font"
 msgstr "Usar o tamaño da letra definida no sistema"
 
-#: ../data/prefs.glade.h:59
+#: ../data/prefs.glade.h:60
 msgid "Font:"
 msgstr "Tipo de letra:"
 
-#: ../data/prefs.glade.h:60
+#: ../data/prefs.glade.h:61
 msgid "Choose some font"
 msgstr "Escoller un tipo de letra"
 
-#: ../data/prefs.glade.h:61
+#: ../data/prefs.glade.h:62
 msgid "Text color:"
 msgstr "Cor de texto:"
 
-#: ../data/prefs.glade.h:62
+#: ../data/prefs.glade.h:63
 msgid "Background color:"
 msgstr "Cor de fondo:"
 
-#: ../data/prefs.glade.h:63
+#: ../data/prefs.glade.h:64
 msgid "Cursor shape:"
 msgstr ""
 
-#: ../data/prefs.glade.h:64
+#: ../data/prefs.glade.h:65
 msgid ""
 "Block\n"
 "I-Beam\n"
 "Underline"
 msgstr ""
 
-#: ../data/prefs.glade.h:67
+#: ../data/prefs.glade.h:68
 msgid ""
 "Follow GTK+ setting\n"
 "Blink on\n"
 "Blink off"
 msgstr ""
 
-#: ../data/prefs.glade.h:70
+#: ../data/prefs.glade.h:71
 msgid "Cursor blink mode:"
 msgstr ""
 
-#: ../data/prefs.glade.h:71
+#: ../data/prefs.glade.h:72
 msgid "Allow bold font"
 msgstr ""
 
-#: ../data/prefs.glade.h:72
+#: ../data/prefs.glade.h:73
 msgid "<b>Palette</b>"
 msgstr "<b>Paleta</b>"
 
-#: ../data/prefs.glade.h:73
+#: ../data/prefs.glade.h:74
 msgid "Built-in schemes:"
 msgstr "Esquemas predefinidos:"
 
-#: ../data/prefs.glade.h:74
+#: ../data/prefs.glade.h:75
 msgid "Color palette:"
 msgstr "Paleta de cores:"
 
-#: ../data/prefs.glade.h:75
+#: ../data/prefs.glade.h:76
 #, fuzzy
 msgid "Font color"
 msgstr "Cor de texto:"
 
-#: ../data/prefs.glade.h:76
+#: ../data/prefs.glade.h:77
 #, fuzzy
 msgid "Background color"
 msgstr "Cor de fondo:"
 
-#: ../data/prefs.glade.h:77
+#: ../data/prefs.glade.h:78
 msgid "Use font and background color from the palette"
 msgstr ""
 
-#: ../data/prefs.glade.h:78
+#: ../data/prefs.glade.h:79
 msgid "Demo:"
 msgstr ""
 
-#: ../data/prefs.glade.h:79
+#: ../data/prefs.glade.h:80
 msgid "<b>Effects</b>"
 msgstr "<b>Efectos</b>"
 
-#: ../data/prefs.glade.h:80
+#: ../data/prefs.glade.h:81
 msgid "Transparency:"
 msgstr "Transparencia:"
 
-#: ../data/prefs.glade.h:81
+#: ../data/prefs.glade.h:82
 msgid "Background image:"
 msgstr "Imaxe de fondo:"
 
-#: ../data/prefs.glade.h:82
+#: ../data/prefs.glade.h:83 ../src/guake/prefs.py:130
 msgid "Appearance"
 msgstr "Aparencia"
 
-#: ../data/prefs.glade.h:83
+#: ../data/prefs.glade.h:84
 msgid ""
 "<small>Quick open is a feature allowing you to open a file directly into "
 "your favorite text editor by clicking on its filename when it appears in "
@@ -470,15 +474,15 @@ msgid ""
 "extract filename below.</small>"
 msgstr ""
 
-#: ../data/prefs.glade.h:84
+#: ../data/prefs.glade.h:85
 msgid "Enable Quick Open when Ctrl+clicking on a filename in the terminal"
 msgstr ""
 
-#: ../data/prefs.glade.h:85
+#: ../data/prefs.glade.h:86
 msgid "Editor command line:"
 msgstr ""
 
-#: ../data/prefs.glade.h:87
+#: ../data/prefs.glade.h:88
 #, no-c-format
 msgid ""
 "<small><i>Use the following elements in the open editor command line:\n"
@@ -490,36 +494,36 @@ msgid ""
 "</i></small>"
 msgstr ""
 
-#: ../data/prefs.glade.h:93
+#: ../data/prefs.glade.h:94
 msgid "Quick open in current terminal"
 msgstr ""
 
-#: ../data/prefs.glade.h:94
+#: ../data/prefs.glade.h:95
 msgid ""
 "Here is the list of supported patterns: (to add your own, please contact the "
 "Guake's authors)"
 msgstr ""
 
-#: ../data/prefs.glade.h:95
+#: ../data/prefs.glade.h:96
 #, fuzzy
 msgid "<b>Quick Open</b>"
 msgstr "<b>Paleta</b>"
 
-#: ../data/prefs.glade.h:96
+#: ../data/prefs.glade.h:97
 msgid "Quick Open"
 msgstr ""
 
-#: ../data/prefs.glade.h:97
+#: ../data/prefs.glade.h:98
 msgid ""
 "To change a shortcut simply click on its name.\n"
 "To disable a shortcut, press the \"Backspace\" key."
 msgstr ""
 
-#: ../data/prefs.glade.h:99
+#: ../data/prefs.glade.h:100
 msgid "Keyboard shortcuts"
 msgstr "Atallos de teclado"
 
-#: ../data/prefs.glade.h:100
+#: ../data/prefs.glade.h:101
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -531,7 +535,7 @@ msgstr ""
 "con certos aplicativos e sistemas operativos que se espera que teñan un "
 "comportamente diferencial no terminal.</i></small>"
 
-#: ../data/prefs.glade.h:101
+#: ../data/prefs.glade.h:102
 msgid ""
 "ASCII DEL\n"
 "Escape sequence\n"
@@ -541,38 +545,37 @@ msgstr ""
 "Secuencia de escape\n"
 "Control-H"
 
-#: ../data/prefs.glade.h:104
+#: ../data/prefs.glade.h:105
 msgid "_Backspace key generates:"
 msgstr "A tecla _Retroceso produce:"
 
-#: ../data/prefs.glade.h:105
+#: ../data/prefs.glade.h:106
 msgid "_Delete key generates:"
 msgstr "A tecla _Eliminar produce:"
 
-#: ../data/prefs.glade.h:106
+#: ../data/prefs.glade.h:107
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "_Reiniciar as opcións de compatibilidade predeterminadas"
 
-#: ../data/prefs.glade.h:107
+#: ../data/prefs.glade.h:108
 msgid "<b>Keyboard compatibility</b>"
 msgstr "<b>Compatibilidade co teclado</b>"
 
-#: ../data/prefs.glade.h:108
+#: ../data/prefs.glade.h:109
 msgid "Compatibility"
 msgstr "Compatibilidade"
 
-#: ../src/guake/about.py:47 ../src/guake/gconfhandler.py:427
-#: ../src/guake/guake_app.py:177 ../src/guake/guake_app.py:348
+#: ../src/guake/about.py:47 ../src/guake/gconfhandler.py:435
+#: ../src/guake/guake_app.py:181 ../src/guake/guake_app.py:376
 msgid "Guake Terminal"
 msgstr "Terminal Guake"
 
-#. Adding a new radio button to the tabbar
-#: ../src/guake/gconfhandler.py:365 ../src/guake/guake_app.py:1548
+#: ../src/guake/gconfhandler.py:368 ../src/guake/guake_app.py:1363
 #, fuzzy
 msgid "Terminal"
 msgstr "Terminal %s"
 
-#: ../src/guake/gconfhandler.py:428
+#: ../src/guake/gconfhandler.py:436
 #, python-format
 msgid ""
 "A problem happened when binding <b>%s</b> key.\n"
@@ -582,54 +585,54 @@ msgstr ""
 "Use as preferencias do Guake para escoller outra tecla (A icona de "
 "notificación estaba activada)"
 
-#: ../src/guake/guake_app.py:128
+#: ../src/guake/guake_app.py:132
 #, fuzzy
 msgid "Do you want to close the tab?"
 msgstr "Confirma que quere saír do Guake?"
 
-#: ../src/guake/guake_app.py:131
+#: ../src/guake/guake_app.py:135
 #, fuzzy
 msgid "Do you really want to quit Guake?"
 msgstr "Confirma que quere saír do Guake?"
 
-#: ../src/guake/guake_app.py:133
+#: ../src/guake/guake_app.py:137
 #, fuzzy
 msgid " and one tab open"
 msgstr "Engadir unha nova lapela"
 
-#: ../src/guake/guake_app.py:135
+#: ../src/guake/guake_app.py:139
 #, python-brace-format
 msgid " and {0} tabs open"
 msgstr ""
 
-#: ../src/guake/guake_app.py:138
+#: ../src/guake/guake_app.py:142
 #, fuzzy
 msgid "There are no processes running"
 msgstr "<b>Queda un proceso aínda en execución.</b>"
 
-#: ../src/guake/guake_app.py:140
+#: ../src/guake/guake_app.py:144
 #, fuzzy
 msgid "There is a process still running"
 msgstr "<b>Queda un proceso aínda en execución.</b>"
 
-#: ../src/guake/guake_app.py:142
+#: ../src/guake/guake_app.py:146
 #, fuzzy, python-brace-format
 msgid "There are {0} processes still running"
 msgstr "<b>Quedan %d procesos en execución.</b>"
 
-#: ../src/guake/guake_app.py:182
+#: ../src/guake/guake_app.py:186
 msgid "guake-indicator"
 msgstr ""
 
-#: ../src/guake/guake_app.py:182
+#: ../src/guake/guake_app.py:186
 msgid "guake-tray"
 msgstr ""
 
-#: ../src/guake/guake_app.py:186
+#: ../src/guake/guake_app.py:190
 msgid "Show"
 msgstr ""
 
-#: ../src/guake/guake_app.py:349
+#: ../src/guake/guake_app.py:377
 #, python-format
 msgid ""
 "Guake is now running,\n"
@@ -638,129 +641,133 @@ msgstr ""
 "Guake está agora en execución,\n"
 "prema <b>%s</b> para usalo."
 
-#: ../src/guake/guake_app.py:611
+#: ../src/guake/guake_app.py:665
 #, python-format
 msgid "Search on Web: '%s'"
 msgstr ""
 
-#: ../src/guake/guake_app.py:616
+#: ../src/guake/guake_app.py:670
 msgid "Search on Web (no selection)"
 msgstr ""
 
-#: ../src/guake/guake_app.py:622
+#: ../src/guake/guake_app.py:678
+msgid "Open Link: '{}...'"
+msgstr ""
+
+#: ../src/guake/guake_app.py:680
 msgid "Open Link: {}"
 msgstr ""
 
-#: ../src/guake/guake_app.py:625
+#: ../src/guake/guake_app.py:683
 msgid "Open Link..."
 msgstr ""
 
-#: ../src/guake/guake_app.py:1300
+#: ../src/guake/guake_app.py:1402
 msgid "Rename tab"
 msgstr "Renomear lapela"
 
-#: ../src/guake/guake_app.py:1591
+#: ../src/guake/guake_app.py:1716
 msgid "Save to..."
 msgstr ""
 
-#: ../src/guake/guake_app.py:1598 ../src/guake/prefs.py:930
+#: ../src/guake/guake_app.py:1723 ../src/guake/prefs.py:998
 msgid "All files"
 msgstr ""
 
-#: ../src/guake/guake_app.py:1603
+#: ../src/guake/guake_app.py:1728
 msgid "Text and Logs"
 msgstr ""
 
-#: ../src/guake/guake_app.py:1621
+#: ../src/guake/guake_app.py:1746
 msgid "Find"
 msgstr ""
 
-#: ../src/guake/guake_app.py:1623
+#: ../src/guake/guake_app.py:1748
 msgid "Forward"
 msgstr ""
 
-#: ../src/guake/guake_app.py:1624
+#: ../src/guake/guake_app.py:1749
 msgid "Backward"
 msgstr ""
 
-#: ../src/guake/main.py:67
+#: ../src/guake/main.py:68
 msgid "Put Guake in fullscreen mode"
 msgstr ""
 
-#: ../src/guake/main.py:71
+#: ../src/guake/main.py:72
 msgid "Toggles the visibility of the terminal window"
 msgstr "Alterna a visibilidade da xanela do terminal"
 
-#: ../src/guake/main.py:75
+#: ../src/guake/main.py:76
 #, fuzzy
 msgid "Shows Guake main window"
 msgstr "Amosa a xanela de preferencias do Guake"
 
-#: ../src/guake/main.py:79
+#: ../src/guake/main.py:80
 #, fuzzy
 msgid "Hides Guake main window"
 msgstr "Amosa a xanela de preferencias do Guake"
 
-#: ../src/guake/main.py:83
+#: ../src/guake/main.py:84
 msgid "Shows Guake preference window"
 msgstr "Amosa a xanela de preferencias do Guake"
 
-#: ../src/guake/main.py:87
+#: ../src/guake/main.py:88
 msgid "Shows Guake's about info"
 msgstr "Amosa info sobre o Guake!"
 
-#: ../src/guake/main.py:91
+#: ../src/guake/main.py:92
 #, fuzzy
 msgid "Add a new tab (with current directory set to NEW_TAB)"
 msgstr "_Abrir unha nova lapela no cartafol actual"
 
-#: ../src/guake/main.py:95
+#: ../src/guake/main.py:96
 msgid "Select a tab (SELECT_TAB is the index of the tab)"
 msgstr ""
 
-#: ../src/guake/main.py:99
+#: ../src/guake/main.py:100
 msgid "Return the selected tab index."
 msgstr "Volver ao índice da lapela seleccionada."
 
-#: ../src/guake/main.py:103
+#: ../src/guake/main.py:104
 msgid "Execute an arbitrary command in the selected tab."
 msgstr "Executar unha orde arbitraria na lapela seleccionada."
 
-#: ../src/guake/main.py:107
+#: ../src/guake/main.py:108
 msgid "Specify the tab to rename. Default is 0."
 msgstr ""
 
-#: ../src/guake/main.py:111
+#: ../src/guake/main.py:112
 msgid "Set the hexadecimal (#rrggbb) background color of the selected tab."
 msgstr ""
 
-#: ../src/guake/main.py:116
+#: ../src/guake/main.py:117
 msgid "Set the hexadecimal (#rrggbb) foreground color of the selected tab."
 msgstr ""
 
-#: ../src/guake/main.py:122
+#: ../src/guake/main.py:123
 msgid ""
 "Rename the specified tab. Reset to default if TITLE is a single dash \"-\"."
 msgstr ""
 
-#: ../src/guake/main.py:128
+#: ../src/guake/main.py:129
 msgid ""
 "Rename the current tab. Reset to default if TITLE is a single dash \"-\"."
 msgstr ""
 
-#: ../src/guake/main.py:133
+#: ../src/guake/main.py:134
 msgid "Says to Guake go away =("
 msgstr "Despedirse do Guake =("
 
-#: ../src/guake/main.py:137
+#: ../src/guake/main.py:138
 msgid "Do not execute the start up script"
 msgstr ""
 
-#: ../src/guake/main.py:231
+#: ../src/guake/main.py:235
 msgid "Guake can not init!"
 msgstr "Guake non pode iniciarse!"
 
-#: ../src/guake/main.py:232
+#: ../src/guake/main.py:236
 #, fuzzy
 msgid ""
 "Gconf Error.\n"
@@ -774,32 +781,190 @@ msgstr ""
 msgid "<user shell>"
 msgstr "<usuario de shell>"
 
-#: ../src/guake/prefs.py:467
+#: ../src/guake/prefs.py:77
+msgid "Toggle Guake visibility"
+msgstr "Alternar a visibilidade do Guake"
+
+#: ../src/guake/prefs.py:81
+#, fuzzy
+msgid "Toggle Hide on Lose Focus"
+msgstr "Agochar ao perder o foco"
+
+#: ../src/guake/prefs.py:88
+msgid "Tab management"
+msgstr "Xestión de lapela"
+
+#: ../src/guake/prefs.py:90
+#, fuzzy
+msgid "New tab"
+msgstr "Nova lapela"
+
+#: ../src/guake/prefs.py:92
+msgid "Close tab"
+msgstr "Pechar lapela"
+
+#: ../src/guake/prefs.py:94
+msgid "Rename current tab"
+msgstr "Renomear a lapela actual"
+
+#: ../src/guake/prefs.py:97
+msgid "Navigation"
+msgstr "Navegación"
+
+#: ../src/guake/prefs.py:99
+msgid "Go to previous tab"
+msgstr "Ir á lapela anterior"
+
+#: ../src/guake/prefs.py:101
+msgid "Go to next tab"
+msgstr "Ir á lapela seguinte"
+
+#: ../src/guake/prefs.py:103
+#, fuzzy
+msgid "Move current tab left"
+msgstr "Renomear a lapela actual"
+
+#: ../src/guake/prefs.py:105
+#, fuzzy
+msgid "Move current tab right"
+msgstr "Renomear a lapela actual"
+
+#: ../src/guake/prefs.py:107
+#, fuzzy
+msgid "Go to first tab"
+msgstr "Ir á lapela seguinte"
+
+#: ../src/guake/prefs.py:109
+#, fuzzy
+msgid "Go to second tab"
+msgstr "Ir á lapela seguinte"
+
+#: ../src/guake/prefs.py:111
+#, fuzzy
+msgid "Go to third tab"
+msgstr "Ir á lapela seguinte"
+
+#: ../src/guake/prefs.py:113
+#, fuzzy
+msgid "Go to fourth tab"
+msgstr "Ir á lapela seguinte"
+
+#: ../src/guake/prefs.py:115
+#, fuzzy
+msgid "Go to fifth tab"
+msgstr "Ir á lapela seguinte"
+
+#: ../src/guake/prefs.py:117
+#, fuzzy
+msgid "Go to sixth tab"
+msgstr "Ir á lapela seguinte"
+
+#: ../src/guake/prefs.py:119
+#, fuzzy
+msgid "Go to seventh tab"
+msgstr "Ir á lapela seguinte"
+
+#: ../src/guake/prefs.py:121
+#, fuzzy
+msgid "Go to eighth tab"
+msgstr "Ir á lapela seguinte"
+
+#: ../src/guake/prefs.py:123
+#, fuzzy
+msgid "Go to ninth tab"
+msgstr "Ir á lapela seguinte"
+
+#: ../src/guake/prefs.py:125
+#, fuzzy
+msgid "Go to tenth tab"
+msgstr "Ir á lapela seguinte"
+
+#: ../src/guake/prefs.py:127
+#, fuzzy
+msgid "Go to last tab"
+msgstr "Ir á lapela seguinte"
+
+#: ../src/guake/prefs.py:132
+msgid "Zoom out"
+msgstr ""
+
+#: ../src/guake/prefs.py:134
+msgid "Zoom in"
+msgstr ""
+
+#: ../src/guake/prefs.py:136
+msgid "Zoom in (alternative)"
+msgstr ""
+
+#: ../src/guake/prefs.py:138
+msgid "Increase height"
+msgstr ""
+
+#: ../src/guake/prefs.py:140
+msgid "Decrease height"
+msgstr ""
+
+#: ../src/guake/prefs.py:142
+#, fuzzy
+msgid "Increase transparency"
+msgstr "Transparencia:"
+
+#: ../src/guake/prefs.py:144
+#, fuzzy
+msgid "Decrease transparency"
+msgstr "Transparencia:"
+
+#: ../src/guake/prefs.py:146
+#, fuzzy
+msgid "Toggle transparency"
+msgstr "Transparencia:"
+
+#: ../src/guake/prefs.py:149
+msgid "Clipboard"
+msgstr "Portapapeis"
+
+#: ../src/guake/prefs.py:151
+msgid "Copy text to clipboard"
+msgstr "Copiar o texto ao portapapeis"
+
+#: ../src/guake/prefs.py:153
+msgid "Paste text from clipboard"
+msgstr "Pegar o texto do portapapeis"
+
+#: ../src/guake/prefs.py:156
+msgid "Extra features"
+msgstr ""
+
+#: ../src/guake/prefs.py:159
+msgid "Search select text on web"
+msgstr ""
+
+#: ../src/guake/prefs.py:519
 msgid "Action"
 msgstr "Acción"
 
-#: ../src/guake/prefs.py:477
+#: ../src/guake/prefs.py:529
 msgid "Shortcut"
 msgstr "Atallo de teclado"
 
-#: ../src/guake/prefs.py:619 ../src/guake/prefs.py:665
+#: ../src/guake/prefs.py:678 ../src/guake/prefs.py:724
 msgid "Custom"
 msgstr ""
 
-#: ../src/guake/prefs.py:926
+#: ../src/guake/prefs.py:994
 msgid "JSON files"
 msgstr ""
 
-#: ../src/guake/prefs.py:1019
+#: ../src/guake/prefs.py:1088
 #, python-format
 msgid "The shortcut \"%s\" is already in use."
 msgstr "O atallo «%s» xa está ocupado."
 
-#: ../src/guake/prefs.py:1020
+#: ../src/guake/prefs.py:1089
 msgid "Error setting keybinding."
 msgstr "Produciuse un erro na configuración da combinación de teclas."
 
-#: ../src/guake/prefs.py:1032
+#: ../src/guake/prefs.py:1101
 #, python-format
 msgid ""
 "The shortcut \"%s\" cannot be used because it will become impossible to type "
@@ -838,33 +1003,3 @@ msgstr ""
 
 #~ msgid "Rename the selected tab."
 #~ msgstr "Renomear a lapela seleccionada."
-
-#~ msgid "Toggle Guake visibility"
-#~ msgstr "Alternar a visibilidade do Guake"
-
-#~ msgid "Tab management"
-#~ msgstr "Xestión de lapela"
-
-#~ msgid "Close tab"
-#~ msgstr "Pechar lapela"
-
-#~ msgid "Rename current tab"
-#~ msgstr "Renomear a lapela actual"
-
-#~ msgid "Navigation"
-#~ msgstr "Navegación"
-
-#~ msgid "Go to previous tab"
-#~ msgstr "Ir á lapela anterior"
-
-#~ msgid "Go to next tab"
-#~ msgstr "Ir á lapela seguinte"
-
-#~ msgid "Clipboard"
-#~ msgstr "Portapapeis"
-
-#~ msgid "Copy text to clipboard"
-#~ msgstr "Copiar o texto ao portapapeis"
-
-#~ msgid "Paste text from clipboard"
-#~ msgstr "Pegar o texto do portapapeis"

--- a/po/hr.po
+++ b/po/hr.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Guake 0.4.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-12-01 16:49+0100\n"
+"POT-Creation-Date: 2016-08-17 21:41+0000\n"
 "PO-Revision-Date: 2013-06-09 23:46+0000\n"
 "Last-Translator: gogo <trebelnik2@gmail.com>\n"
 "Language-Team: Croatian (http://www.transifex.com/projects/p/guake/language/"
@@ -103,7 +103,7 @@ msgstr "Kopiraj"
 msgid "Paste"
 msgstr "Zalijepi"
 
-#: ../data/guake.glade.h:3
+#: ../data/guake.glade.h:3 ../src/guake/prefs.py:79
 msgid "Toggle Fullscreen"
 msgstr "Cijelozaslonski prikaz"
 
@@ -111,7 +111,7 @@ msgstr "Cijelozaslonski prikaz"
 msgid "Save to File..."
 msgstr ""
 
-#: ../data/guake.glade.h:5
+#: ../data/guake.glade.h:5 ../src/guake/prefs.py:85
 #, fuzzy
 msgid "Reset terminal"
 msgstr "Guake Terminal"
@@ -142,7 +142,7 @@ msgstr ""
 msgid "Search on Web"
 msgstr ""
 
-#: ../data/guake.glade.h:12
+#: ../data/guake.glade.h:12 ../src/guake/prefs.py:83
 msgid "Quit"
 msgstr "Zatvori"
 
@@ -265,202 +265,206 @@ msgid "Use VTE titles for tab names"
 msgstr ""
 
 #: ../data/prefs.glade.h:33
-msgid "Max tab name length:"
+msgid "Abbreviate directories in tab names"
 msgstr ""
 
 #: ../data/prefs.glade.h:34
+msgid "Max tab name length:"
+msgstr ""
+
+#: ../data/prefs.glade.h:35
 msgid "Hide on lose focus"
 msgstr "Sakrij pri gubitku fokusa"
 
-#: ../data/prefs.glade.h:35
+#: ../data/prefs.glade.h:36
 msgid "Show tab bar"
 msgstr "Prikaži donju traku"
 
-#: ../data/prefs.glade.h:36
+#: ../data/prefs.glade.h:37
 #, fuzzy
 msgid "Start fullscreen"
 msgstr "Cijelozaslonski prikaz"
 
-#: ../data/prefs.glade.h:37
+#: ../data/prefs.glade.h:38
 msgid "<b>Main Window</b>"
 msgstr "<b>Glavni prozor</b>"
 
-#: ../data/prefs.glade.h:38
+#: ../data/prefs.glade.h:39
 msgid "Left"
 msgstr ""
 
-#: ../data/prefs.glade.h:39
+#: ../data/prefs.glade.h:40
 msgid "Center"
 msgstr ""
 
-#: ../data/prefs.glade.h:40
+#: ../data/prefs.glade.h:41
 msgid "Right"
 msgstr ""
 
-#: ../data/prefs.glade.h:41
+#: ../data/prefs.glade.h:42
 #, fuzzy
 msgid "<b>Main Window Horizontal Alignment</b>"
 msgstr "<b>Visina glavnog prozora</b>"
 
-#: ../data/prefs.glade.h:42
+#: ../data/prefs.glade.h:43
 #, fuzzy
 msgid "<b>Main Window Height</b>"
 msgstr "<b>Visina glavnog prozora</b>"
 
-#: ../data/prefs.glade.h:43
+#: ../data/prefs.glade.h:44
 #, fuzzy
 msgid "<b>Main Window Width</b>"
 msgstr "<b>Visina glavnog prozora</b>"
 
-#: ../data/prefs.glade.h:44
+#: ../data/prefs.glade.h:45
 msgid "Custom command file path: "
 msgstr ""
 
-#: ../data/prefs.glade.h:45
+#: ../data/prefs.glade.h:46
 msgid "Please select a json file"
 msgstr ""
 
-#: ../data/prefs.glade.h:46
+#: ../data/prefs.glade.h:47 ../src/guake/prefs.py:75
 msgid "General"
 msgstr "Općenito"
 
-#: ../data/prefs.glade.h:47
+#: ../data/prefs.glade.h:48
 msgid "Default interpreter:"
 msgstr "Zadani interpretator:"
 
-#: ../data/prefs.glade.h:48
+#: ../data/prefs.glade.h:49
 msgid "_Run command as a login shell"
 msgstr "_Pokreni naredbu kao ljusku prijave"
 
-#: ../data/prefs.glade.h:49
+#: ../data/prefs.glade.h:50
 msgid "_Open new tab in current directory"
 msgstr "_Оtvori novu karticu u trenutnom direktoriju"
 
-#: ../data/prefs.glade.h:50
+#: ../data/prefs.glade.h:51
 msgid "<b>Shell</b>"
 msgstr "<b>Ljuska</b>"
 
-#: ../data/prefs.glade.h:51
+#: ../data/prefs.glade.h:52
 msgid "Shell"
 msgstr ""
 
-#: ../data/prefs.glade.h:52
+#: ../data/prefs.glade.h:53
 msgid "Show scrollbar"
 msgstr "Prikaži traku pomicanja"
 
-#: ../data/prefs.glade.h:53
+#: ../data/prefs.glade.h:54
 msgid "Scrollback lines:"
 msgstr "Redci pomicanja:"
 
-#: ../data/prefs.glade.h:54
+#: ../data/prefs.glade.h:55
 msgid "On output"
 msgstr "Pri izlazu"
 
-#: ../data/prefs.glade.h:55
+#: ../data/prefs.glade.h:56
 msgid "On key stroke"
 msgstr "Pri pritisku tipke"
 
-#: ../data/prefs.glade.h:56
+#: ../data/prefs.glade.h:57
 msgid "<b>Scroll</b>"
 msgstr "<b>Pomicanje kotačićem miša</b>"
 
-#: ../data/prefs.glade.h:57
+#: ../data/prefs.glade.h:58
 msgid "Scrolling"
 msgstr "Pomicanje kotačićem miša"
 
-#: ../data/prefs.glade.h:58
+#: ../data/prefs.glade.h:59
 msgid "Use the system fixed width font"
 msgstr "Koristi širinu slova ispravljenu sustavom"
 
-#: ../data/prefs.glade.h:59
+#: ../data/prefs.glade.h:60
 msgid "Font:"
 msgstr "Slova:"
 
-#: ../data/prefs.glade.h:60
+#: ../data/prefs.glade.h:61
 msgid "Choose some font"
 msgstr "Odaberite neka slova"
 
-#: ../data/prefs.glade.h:61
+#: ../data/prefs.glade.h:62
 msgid "Text color:"
 msgstr "Boja teksta:"
 
-#: ../data/prefs.glade.h:62
+#: ../data/prefs.glade.h:63
 msgid "Background color:"
 msgstr "Boja pozadine:"
 
-#: ../data/prefs.glade.h:63
+#: ../data/prefs.glade.h:64
 msgid "Cursor shape:"
 msgstr ""
 
-#: ../data/prefs.glade.h:64
+#: ../data/prefs.glade.h:65
 msgid ""
 "Block\n"
 "I-Beam\n"
 "Underline"
 msgstr ""
 
-#: ../data/prefs.glade.h:67
+#: ../data/prefs.glade.h:68
 msgid ""
 "Follow GTK+ setting\n"
 "Blink on\n"
 "Blink off"
 msgstr ""
 
-#: ../data/prefs.glade.h:70
+#: ../data/prefs.glade.h:71
 msgid "Cursor blink mode:"
 msgstr ""
 
-#: ../data/prefs.glade.h:71
+#: ../data/prefs.glade.h:72
 msgid "Allow bold font"
 msgstr ""
 
-#: ../data/prefs.glade.h:72
+#: ../data/prefs.glade.h:73
 msgid "<b>Palette</b>"
 msgstr "<b>Boje</b>"
 
-#: ../data/prefs.glade.h:73
+#: ../data/prefs.glade.h:74
 msgid "Built-in schemes:"
 msgstr "Ugrađene sheme:"
 
-#: ../data/prefs.glade.h:74
+#: ../data/prefs.glade.h:75
 msgid "Color palette:"
 msgstr "Paleta boja:"
 
-#: ../data/prefs.glade.h:75
+#: ../data/prefs.glade.h:76
 #, fuzzy
 msgid "Font color"
 msgstr "Boja teksta:"
 
-#: ../data/prefs.glade.h:76
+#: ../data/prefs.glade.h:77
 #, fuzzy
 msgid "Background color"
 msgstr "Boja pozadine:"
 
-#: ../data/prefs.glade.h:77
+#: ../data/prefs.glade.h:78
 msgid "Use font and background color from the palette"
 msgstr ""
 
-#: ../data/prefs.glade.h:78
+#: ../data/prefs.glade.h:79
 msgid "Demo:"
 msgstr ""
 
-#: ../data/prefs.glade.h:79
+#: ../data/prefs.glade.h:80
 msgid "<b>Effects</b>"
 msgstr "<b>Efekti</b>"
 
-#: ../data/prefs.glade.h:80
+#: ../data/prefs.glade.h:81
 msgid "Transparency:"
 msgstr "Prozirnost:"
 
-#: ../data/prefs.glade.h:81
+#: ../data/prefs.glade.h:82
 msgid "Background image:"
 msgstr "Slika pozadine:"
 
-#: ../data/prefs.glade.h:82
+#: ../data/prefs.glade.h:83 ../src/guake/prefs.py:130
 msgid "Appearance"
 msgstr "Izgled"
 
-#: ../data/prefs.glade.h:83
+#: ../data/prefs.glade.h:84
 msgid ""
 "<small>Quick open is a feature allowing you to open a file directly into "
 "your favorite text editor by clicking on its filename when it appears in "
@@ -468,15 +472,15 @@ msgid ""
 "extract filename below.</small>"
 msgstr ""
 
-#: ../data/prefs.glade.h:84
+#: ../data/prefs.glade.h:85
 msgid "Enable Quick Open when Ctrl+clicking on a filename in the terminal"
 msgstr ""
 
-#: ../data/prefs.glade.h:85
+#: ../data/prefs.glade.h:86
 msgid "Editor command line:"
 msgstr ""
 
-#: ../data/prefs.glade.h:87
+#: ../data/prefs.glade.h:88
 #, no-c-format
 msgid ""
 "<small><i>Use the following elements in the open editor command line:\n"
@@ -488,36 +492,36 @@ msgid ""
 "</i></small>"
 msgstr ""
 
-#: ../data/prefs.glade.h:93
+#: ../data/prefs.glade.h:94
 msgid "Quick open in current terminal"
 msgstr ""
 
-#: ../data/prefs.glade.h:94
+#: ../data/prefs.glade.h:95
 msgid ""
 "Here is the list of supported patterns: (to add your own, please contact the "
 "Guake's authors)"
 msgstr ""
 
-#: ../data/prefs.glade.h:95
+#: ../data/prefs.glade.h:96
 #, fuzzy
 msgid "<b>Quick Open</b>"
 msgstr "<b>Boje</b>"
 
-#: ../data/prefs.glade.h:96
+#: ../data/prefs.glade.h:97
 msgid "Quick Open"
 msgstr ""
 
-#: ../data/prefs.glade.h:97
+#: ../data/prefs.glade.h:98
 msgid ""
 "To change a shortcut simply click on its name.\n"
 "To disable a shortcut, press the \"Backspace\" key."
 msgstr ""
 
-#: ../data/prefs.glade.h:99
+#: ../data/prefs.glade.h:100
 msgid "Keyboard shortcuts"
 msgstr "Prečaci tipkovnice"
 
-#: ../data/prefs.glade.h:100
+#: ../data/prefs.glade.h:101
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -529,7 +533,7 @@ msgstr ""
 "aplikacijama i operativnim sustavima, to očekuje drugačije ponašanje "
 "terminala.</i></small>"
 
-#: ../data/prefs.glade.h:101
+#: ../data/prefs.glade.h:102
 msgid ""
 "ASCII DEL\n"
 "Escape sequence\n"
@@ -539,38 +543,37 @@ msgstr ""
 "Escape slijed\n"
 "Control-H"
 
-#: ../data/prefs.glade.h:104
+#: ../data/prefs.glade.h:105
 msgid "_Backspace key generates:"
 msgstr "_'Backspace' tipka generira:"
 
-#: ../data/prefs.glade.h:105
+#: ../data/prefs.glade.h:106
 msgid "_Delete key generates:"
 msgstr "_'Delete' tipka generira:"
 
-#: ../data/prefs.glade.h:106
+#: ../data/prefs.glade.h:107
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "_Vrati mogućnosti kompatibilnosti na početno"
 
-#: ../data/prefs.glade.h:107
+#: ../data/prefs.glade.h:108
 msgid "<b>Keyboard compatibility</b>"
 msgstr "<b>Кompatibilnost tipkovnice</b>"
 
-#: ../data/prefs.glade.h:108
+#: ../data/prefs.glade.h:109
 msgid "Compatibility"
 msgstr "Kompatibilnost"
 
-#: ../src/guake/about.py:47 ../src/guake/gconfhandler.py:427
-#: ../src/guake/guake_app.py:177 ../src/guake/guake_app.py:348
+#: ../src/guake/about.py:47 ../src/guake/gconfhandler.py:435
+#: ../src/guake/guake_app.py:181 ../src/guake/guake_app.py:376
 msgid "Guake Terminal"
 msgstr "Guake Terminal"
 
-#. Adding a new radio button to the tabbar
-#: ../src/guake/gconfhandler.py:365 ../src/guake/guake_app.py:1548
+#: ../src/guake/gconfhandler.py:368 ../src/guake/guake_app.py:1363
 #, fuzzy
 msgid "Terminal"
 msgstr "Terminal %s"
 
-#: ../src/guake/gconfhandler.py:428
+#: ../src/guake/gconfhandler.py:436
 #, python-format
 msgid ""
 "A problem happened when binding <b>%s</b> key.\n"
@@ -580,54 +583,54 @@ msgstr ""
 "Koristite Guake dijalog osobitosti za odabir druge tipke (ikona u traci "
 "sustava je omogućena)"
 
-#: ../src/guake/guake_app.py:128
+#: ../src/guake/guake_app.py:132
 #, fuzzy
 msgid "Do you want to close the tab?"
 msgstr "Sigurno želite zatvoriti Guake!?"
 
-#: ../src/guake/guake_app.py:131
+#: ../src/guake/guake_app.py:135
 #, fuzzy
 msgid "Do you really want to quit Guake?"
 msgstr "Sigurno želite zatvoriti Guake!?"
 
-#: ../src/guake/guake_app.py:133
+#: ../src/guake/guake_app.py:137
 #, fuzzy
 msgid " and one tab open"
 msgstr "Dodaj novu karticu"
 
-#: ../src/guake/guake_app.py:135
+#: ../src/guake/guake_app.py:139
 #, python-brace-format
 msgid " and {0} tabs open"
 msgstr ""
 
-#: ../src/guake/guake_app.py:138
+#: ../src/guake/guake_app.py:142
 #, fuzzy
 msgid "There are no processes running"
 msgstr "<b>Jedan proces se još uvijek izvodi.</b>"
 
-#: ../src/guake/guake_app.py:140
+#: ../src/guake/guake_app.py:144
 #, fuzzy
 msgid "There is a process still running"
 msgstr "<b>Jedan proces se još uvijek izvodi.</b>"
 
-#: ../src/guake/guake_app.py:142
+#: ../src/guake/guake_app.py:146
 #, fuzzy, python-brace-format
 msgid "There are {0} processes still running"
 msgstr "<b>Još uvijek se %d procesa izvodi.</b>"
 
-#: ../src/guake/guake_app.py:182
+#: ../src/guake/guake_app.py:186
 msgid "guake-indicator"
 msgstr ""
 
-#: ../src/guake/guake_app.py:182
+#: ../src/guake/guake_app.py:186
 msgid "guake-tray"
 msgstr ""
 
-#: ../src/guake/guake_app.py:186
+#: ../src/guake/guake_app.py:190
 msgid "Show"
 msgstr ""
 
-#: ../src/guake/guake_app.py:349
+#: ../src/guake/guake_app.py:377
 #, python-format
 msgid ""
 "Guake is now running,\n"
@@ -636,129 +639,133 @@ msgstr ""
 "Guake je pokrenut,\n"
 "pritisnite <b>%s</b> za korištenje."
 
-#: ../src/guake/guake_app.py:611
+#: ../src/guake/guake_app.py:665
 #, python-format
 msgid "Search on Web: '%s'"
 msgstr ""
 
-#: ../src/guake/guake_app.py:616
+#: ../src/guake/guake_app.py:670
 msgid "Search on Web (no selection)"
 msgstr ""
 
-#: ../src/guake/guake_app.py:622
+#: ../src/guake/guake_app.py:678
+msgid "Open Link: '{}...'"
+msgstr ""
+
+#: ../src/guake/guake_app.py:680
 msgid "Open Link: {}"
 msgstr ""
 
-#: ../src/guake/guake_app.py:625
+#: ../src/guake/guake_app.py:683
 msgid "Open Link..."
 msgstr ""
 
-#: ../src/guake/guake_app.py:1300
+#: ../src/guake/guake_app.py:1402
 msgid "Rename tab"
 msgstr "Preimenuj karticu"
 
-#: ../src/guake/guake_app.py:1591
+#: ../src/guake/guake_app.py:1716
 msgid "Save to..."
 msgstr ""
 
-#: ../src/guake/guake_app.py:1598 ../src/guake/prefs.py:930
+#: ../src/guake/guake_app.py:1723 ../src/guake/prefs.py:998
 msgid "All files"
 msgstr ""
 
-#: ../src/guake/guake_app.py:1603
+#: ../src/guake/guake_app.py:1728
 msgid "Text and Logs"
 msgstr ""
 
-#: ../src/guake/guake_app.py:1621
+#: ../src/guake/guake_app.py:1746
 msgid "Find"
 msgstr ""
 
-#: ../src/guake/guake_app.py:1623
+#: ../src/guake/guake_app.py:1748
 msgid "Forward"
 msgstr ""
 
-#: ../src/guake/guake_app.py:1624
+#: ../src/guake/guake_app.py:1749
 msgid "Backward"
 msgstr ""
 
-#: ../src/guake/main.py:67
+#: ../src/guake/main.py:68
 msgid "Put Guake in fullscreen mode"
 msgstr ""
 
-#: ../src/guake/main.py:71
+#: ../src/guake/main.py:72
 msgid "Toggles the visibility of the terminal window"
 msgstr "Isključivanje/Uključivanje vidljivosti prozora terminala"
 
-#: ../src/guake/main.py:75
+#: ../src/guake/main.py:76
 #, fuzzy
 msgid "Shows Guake main window"
 msgstr "Prikazuje Guake prozor osobitosti"
 
-#: ../src/guake/main.py:79
+#: ../src/guake/main.py:80
 #, fuzzy
 msgid "Hides Guake main window"
 msgstr "Prikazuje Guake prozor osobitosti"
 
-#: ../src/guake/main.py:83
+#: ../src/guake/main.py:84
 msgid "Shows Guake preference window"
 msgstr "Prikazuje Guake prozor osobitosti"
 
-#: ../src/guake/main.py:87
+#: ../src/guake/main.py:88
 msgid "Shows Guake's about info"
 msgstr "Prikazuje Guake prozor informacija"
 
-#: ../src/guake/main.py:91
+#: ../src/guake/main.py:92
 #, fuzzy
 msgid "Add a new tab (with current directory set to NEW_TAB)"
 msgstr "_Оtvori novu karticu u trenutnom direktoriju"
 
-#: ../src/guake/main.py:95
+#: ../src/guake/main.py:96
 msgid "Select a tab (SELECT_TAB is the index of the tab)"
 msgstr ""
 
-#: ../src/guake/main.py:99
+#: ../src/guake/main.py:100
 msgid "Return the selected tab index."
 msgstr "Vrati indeks odabrane kartice."
 
-#: ../src/guake/main.py:103
+#: ../src/guake/main.py:104
 msgid "Execute an arbitrary command in the selected tab."
 msgstr "Izvrši proizvoljnu naredbu u odabranoj kartici."
 
-#: ../src/guake/main.py:107
+#: ../src/guake/main.py:108
 msgid "Specify the tab to rename. Default is 0."
 msgstr ""
 
-#: ../src/guake/main.py:111
+#: ../src/guake/main.py:112
 msgid "Set the hexadecimal (#rrggbb) background color of the selected tab."
 msgstr ""
 
-#: ../src/guake/main.py:116
+#: ../src/guake/main.py:117
 msgid "Set the hexadecimal (#rrggbb) foreground color of the selected tab."
 msgstr ""
 
-#: ../src/guake/main.py:122
+#: ../src/guake/main.py:123
 msgid ""
 "Rename the specified tab. Reset to default if TITLE is a single dash \"-\"."
 msgstr ""
 
-#: ../src/guake/main.py:128
+#: ../src/guake/main.py:129
 msgid ""
 "Rename the current tab. Reset to default if TITLE is a single dash \"-\"."
 msgstr ""
 
-#: ../src/guake/main.py:133
+#: ../src/guake/main.py:134
 msgid "Says to Guake go away =("
 msgstr "Recite Guakeu, odlazi! =("
 
-#: ../src/guake/main.py:137
+#: ../src/guake/main.py:138
 msgid "Do not execute the start up script"
 msgstr ""
 
-#: ../src/guake/main.py:231
+#: ../src/guake/main.py:235
 msgid "Guake can not init!"
 msgstr "Guake se ne može pokrenuti!"
 
-#: ../src/guake/main.py:232
+#: ../src/guake/main.py:236
 #, fuzzy
 msgid ""
 "Gconf Error.\n"
@@ -772,32 +779,190 @@ msgstr ""
 msgid "<user shell>"
 msgstr "<Korisnikova ljuska>"
 
-#: ../src/guake/prefs.py:467
+#: ../src/guake/prefs.py:77
+msgid "Toggle Guake visibility"
+msgstr "Prikaži/Sakrij Guake"
+
+#: ../src/guake/prefs.py:81
+#, fuzzy
+msgid "Toggle Hide on Lose Focus"
+msgstr "Sakrij pri gubitku fokusa"
+
+#: ../src/guake/prefs.py:88
+msgid "Tab management"
+msgstr "Upravljanje karticama"
+
+#: ../src/guake/prefs.py:90
+#, fuzzy
+msgid "New tab"
+msgstr "Nova kartica"
+
+#: ../src/guake/prefs.py:92
+msgid "Close tab"
+msgstr "Zatvori karticu"
+
+#: ../src/guake/prefs.py:94
+msgid "Rename current tab"
+msgstr "Preimenuj trenutnu karticu"
+
+#: ../src/guake/prefs.py:97
+msgid "Navigation"
+msgstr "Navigacija"
+
+#: ../src/guake/prefs.py:99
+msgid "Go to previous tab"
+msgstr "Idi na prijašnju karticu"
+
+#: ../src/guake/prefs.py:101
+msgid "Go to next tab"
+msgstr "Idi na sljedeću karticu"
+
+#: ../src/guake/prefs.py:103
+#, fuzzy
+msgid "Move current tab left"
+msgstr "Preimenuj trenutnu karticu"
+
+#: ../src/guake/prefs.py:105
+#, fuzzy
+msgid "Move current tab right"
+msgstr "Preimenuj trenutnu karticu"
+
+#: ../src/guake/prefs.py:107
+#, fuzzy
+msgid "Go to first tab"
+msgstr "Idi na sljedeću karticu"
+
+#: ../src/guake/prefs.py:109
+#, fuzzy
+msgid "Go to second tab"
+msgstr "Idi na sljedeću karticu"
+
+#: ../src/guake/prefs.py:111
+#, fuzzy
+msgid "Go to third tab"
+msgstr "Idi na sljedeću karticu"
+
+#: ../src/guake/prefs.py:113
+#, fuzzy
+msgid "Go to fourth tab"
+msgstr "Idi na sljedeću karticu"
+
+#: ../src/guake/prefs.py:115
+#, fuzzy
+msgid "Go to fifth tab"
+msgstr "Idi na sljedeću karticu"
+
+#: ../src/guake/prefs.py:117
+#, fuzzy
+msgid "Go to sixth tab"
+msgstr "Idi na sljedeću karticu"
+
+#: ../src/guake/prefs.py:119
+#, fuzzy
+msgid "Go to seventh tab"
+msgstr "Idi na sljedeću karticu"
+
+#: ../src/guake/prefs.py:121
+#, fuzzy
+msgid "Go to eighth tab"
+msgstr "Idi na sljedeću karticu"
+
+#: ../src/guake/prefs.py:123
+#, fuzzy
+msgid "Go to ninth tab"
+msgstr "Idi na sljedeću karticu"
+
+#: ../src/guake/prefs.py:125
+#, fuzzy
+msgid "Go to tenth tab"
+msgstr "Idi na sljedeću karticu"
+
+#: ../src/guake/prefs.py:127
+#, fuzzy
+msgid "Go to last tab"
+msgstr "Idi na sljedeću karticu"
+
+#: ../src/guake/prefs.py:132
+msgid "Zoom out"
+msgstr ""
+
+#: ../src/guake/prefs.py:134
+msgid "Zoom in"
+msgstr ""
+
+#: ../src/guake/prefs.py:136
+msgid "Zoom in (alternative)"
+msgstr ""
+
+#: ../src/guake/prefs.py:138
+msgid "Increase height"
+msgstr ""
+
+#: ../src/guake/prefs.py:140
+msgid "Decrease height"
+msgstr ""
+
+#: ../src/guake/prefs.py:142
+#, fuzzy
+msgid "Increase transparency"
+msgstr "Prozirnost:"
+
+#: ../src/guake/prefs.py:144
+#, fuzzy
+msgid "Decrease transparency"
+msgstr "Prozirnost:"
+
+#: ../src/guake/prefs.py:146
+#, fuzzy
+msgid "Toggle transparency"
+msgstr "Prozirnost:"
+
+#: ../src/guake/prefs.py:149
+msgid "Clipboard"
+msgstr "Međuspremnik"
+
+#: ../src/guake/prefs.py:151
+msgid "Copy text to clipboard"
+msgstr "Kopiraj tekst u međuspremnik"
+
+#: ../src/guake/prefs.py:153
+msgid "Paste text from clipboard"
+msgstr "Zalijepi tekst iz međuspremnika"
+
+#: ../src/guake/prefs.py:156
+msgid "Extra features"
+msgstr ""
+
+#: ../src/guake/prefs.py:159
+msgid "Search select text on web"
+msgstr ""
+
+#: ../src/guake/prefs.py:519
 msgid "Action"
 msgstr "Radnja"
 
-#: ../src/guake/prefs.py:477
+#: ../src/guake/prefs.py:529
 msgid "Shortcut"
 msgstr "Tipke prečaca"
 
-#: ../src/guake/prefs.py:619 ../src/guake/prefs.py:665
+#: ../src/guake/prefs.py:678 ../src/guake/prefs.py:724
 msgid "Custom"
 msgstr ""
 
-#: ../src/guake/prefs.py:926
+#: ../src/guake/prefs.py:994
 msgid "JSON files"
 msgstr ""
 
-#: ../src/guake/prefs.py:1019
+#: ../src/guake/prefs.py:1088
 #, python-format
 msgid "The shortcut \"%s\" is already in use."
 msgstr "Prečac \"%s\" se već koristi."
 
-#: ../src/guake/prefs.py:1020
+#: ../src/guake/prefs.py:1089
 msgid "Error setting keybinding."
 msgstr "Greška u dodjeljivanju tipke."
 
-#: ../src/guake/prefs.py:1032
+#: ../src/guake/prefs.py:1101
 #, python-format
 msgid ""
 "The shortcut \"%s\" cannot be used because it will become impossible to type "
@@ -837,33 +1002,3 @@ msgstr ""
 
 #~ msgid "Rename the selected tab."
 #~ msgstr "Preimenuj odabranu karticu."
-
-#~ msgid "Toggle Guake visibility"
-#~ msgstr "Prikaži/Sakrij Guake"
-
-#~ msgid "Tab management"
-#~ msgstr "Upravljanje karticama"
-
-#~ msgid "Close tab"
-#~ msgstr "Zatvori karticu"
-
-#~ msgid "Rename current tab"
-#~ msgstr "Preimenuj trenutnu karticu"
-
-#~ msgid "Navigation"
-#~ msgstr "Navigacija"
-
-#~ msgid "Go to previous tab"
-#~ msgstr "Idi na prijašnju karticu"
-
-#~ msgid "Go to next tab"
-#~ msgstr "Idi na sljedeću karticu"
-
-#~ msgid "Clipboard"
-#~ msgstr "Međuspremnik"
-
-#~ msgid "Copy text to clipboard"
-#~ msgstr "Kopiraj tekst u međuspremnik"
-
-#~ msgid "Paste text from clipboard"
-#~ msgstr "Zalijepi tekst iz međuspremnika"

--- a/po/hu.po
+++ b/po/hu.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Guake 0.4.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-12-01 16:49+0100\n"
+"POT-Creation-Date: 2016-08-17 21:41+0000\n"
 "PO-Revision-Date: 2012-06-12 20:33+0000\n"
 "Last-Translator: Péter Trombitás <trombipeti@gmail.com>\n"
 "Language-Team: Hungarian (http://www.transifex.com/projects/p/guake/language/"
@@ -102,7 +102,7 @@ msgstr "Másol"
 msgid "Paste"
 msgstr "Beilleszt"
 
-#: ../data/guake.glade.h:3
+#: ../data/guake.glade.h:3 ../src/guake/prefs.py:79
 msgid "Toggle Fullscreen"
 msgstr "Teljes képernyő"
 
@@ -110,7 +110,7 @@ msgstr "Teljes képernyő"
 msgid "Save to File..."
 msgstr ""
 
-#: ../data/guake.glade.h:5
+#: ../data/guake.glade.h:5 ../src/guake/prefs.py:85
 #, fuzzy
 msgid "Reset terminal"
 msgstr "Guake Terminál"
@@ -141,7 +141,7 @@ msgstr ""
 msgid "Search on Web"
 msgstr ""
 
-#: ../data/guake.glade.h:12
+#: ../data/guake.glade.h:12 ../src/guake/prefs.py:83
 msgid "Quit"
 msgstr "Kilépés"
 
@@ -266,202 +266,206 @@ msgid "Use VTE titles for tab names"
 msgstr ""
 
 #: ../data/prefs.glade.h:33
-msgid "Max tab name length:"
+msgid "Abbreviate directories in tab names"
 msgstr ""
 
 #: ../data/prefs.glade.h:34
+msgid "Max tab name length:"
+msgstr ""
+
+#: ../data/prefs.glade.h:35
 msgid "Hide on lose focus"
 msgstr "Fókusz elvesztésekor elrejtés"
 
-#: ../data/prefs.glade.h:35
+#: ../data/prefs.glade.h:36
 msgid "Show tab bar"
 msgstr "Lapok mutatása"
 
-#: ../data/prefs.glade.h:36
+#: ../data/prefs.glade.h:37
 #, fuzzy
 msgid "Start fullscreen"
 msgstr "Teljes képernyő"
 
-#: ../data/prefs.glade.h:37
+#: ../data/prefs.glade.h:38
 msgid "<b>Main Window</b>"
 msgstr "<b>Fő ablak</b>"
 
-#: ../data/prefs.glade.h:38
+#: ../data/prefs.glade.h:39
 msgid "Left"
 msgstr ""
 
-#: ../data/prefs.glade.h:39
+#: ../data/prefs.glade.h:40
 msgid "Center"
 msgstr ""
 
-#: ../data/prefs.glade.h:40
+#: ../data/prefs.glade.h:41
 msgid "Right"
 msgstr ""
 
-#: ../data/prefs.glade.h:41
+#: ../data/prefs.glade.h:42
 #, fuzzy
 msgid "<b>Main Window Horizontal Alignment</b>"
 msgstr "<b>Főablak magassága</b>"
 
-#: ../data/prefs.glade.h:42
+#: ../data/prefs.glade.h:43
 #, fuzzy
 msgid "<b>Main Window Height</b>"
 msgstr "<b>Főablak magassága</b>"
 
-#: ../data/prefs.glade.h:43
+#: ../data/prefs.glade.h:44
 #, fuzzy
 msgid "<b>Main Window Width</b>"
 msgstr "<b>Főablak magassága</b>"
 
-#: ../data/prefs.glade.h:44
+#: ../data/prefs.glade.h:45
 msgid "Custom command file path: "
 msgstr ""
 
-#: ../data/prefs.glade.h:45
+#: ../data/prefs.glade.h:46
 msgid "Please select a json file"
 msgstr ""
 
-#: ../data/prefs.glade.h:46
+#: ../data/prefs.glade.h:47 ../src/guake/prefs.py:75
 msgid "General"
 msgstr "Általános"
 
-#: ../data/prefs.glade.h:47
+#: ../data/prefs.glade.h:48
 msgid "Default interpreter:"
 msgstr "Alapértelmezett héj:"
 
-#: ../data/prefs.glade.h:48
+#: ../data/prefs.glade.h:49
 msgid "_Run command as a login shell"
 msgstr "_Parancs futtatása bejelentkező héjban (login shell)"
 
-#: ../data/prefs.glade.h:49
+#: ../data/prefs.glade.h:50
 msgid "_Open new tab in current directory"
 msgstr "Új lap megnyitása a _jelenlegi könyvtárban"
 
-#: ../data/prefs.glade.h:50
+#: ../data/prefs.glade.h:51
 msgid "<b>Shell</b>"
 msgstr "<b>Héj (shell)</b>"
 
-#: ../data/prefs.glade.h:51
+#: ../data/prefs.glade.h:52
 msgid "Shell"
 msgstr ""
 
-#: ../data/prefs.glade.h:52
+#: ../data/prefs.glade.h:53
 msgid "Show scrollbar"
 msgstr "Görgetősáv mutatása"
 
-#: ../data/prefs.glade.h:53
+#: ../data/prefs.glade.h:54
 msgid "Scrollback lines:"
 msgstr "Sor megtartása:"
 
-#: ../data/prefs.glade.h:54
+#: ../data/prefs.glade.h:55
 msgid "On output"
 msgstr "Kimenetnél"
 
-#: ../data/prefs.glade.h:55
+#: ../data/prefs.glade.h:56
 msgid "On key stroke"
 msgstr "Billentyűkombináció lenyomásakor"
 
-#: ../data/prefs.glade.h:56
+#: ../data/prefs.glade.h:57
 msgid "<b>Scroll</b>"
 msgstr "<b>Görgetés</b>"
 
-#: ../data/prefs.glade.h:57
+#: ../data/prefs.glade.h:58
 msgid "Scrolling"
 msgstr "Görgetés"
 
-#: ../data/prefs.glade.h:58
+#: ../data/prefs.glade.h:59
 msgid "Use the system fixed width font"
 msgstr "A rendszer rögzített szélességű betűtípusának használata"
 
-#: ../data/prefs.glade.h:59
+#: ../data/prefs.glade.h:60
 msgid "Font:"
 msgstr "Betűtípus:"
 
-#: ../data/prefs.glade.h:60
+#: ../data/prefs.glade.h:61
 msgid "Choose some font"
 msgstr "Betűtípus kiválasztása"
 
-#: ../data/prefs.glade.h:61
+#: ../data/prefs.glade.h:62
 msgid "Text color:"
 msgstr "Szövegszín:"
 
-#: ../data/prefs.glade.h:62
+#: ../data/prefs.glade.h:63
 msgid "Background color:"
 msgstr "Háttérszín:"
 
-#: ../data/prefs.glade.h:63
+#: ../data/prefs.glade.h:64
 msgid "Cursor shape:"
 msgstr ""
 
-#: ../data/prefs.glade.h:64
+#: ../data/prefs.glade.h:65
 msgid ""
 "Block\n"
 "I-Beam\n"
 "Underline"
 msgstr ""
 
-#: ../data/prefs.glade.h:67
+#: ../data/prefs.glade.h:68
 msgid ""
 "Follow GTK+ setting\n"
 "Blink on\n"
 "Blink off"
 msgstr ""
 
-#: ../data/prefs.glade.h:70
+#: ../data/prefs.glade.h:71
 msgid "Cursor blink mode:"
 msgstr ""
 
-#: ../data/prefs.glade.h:71
+#: ../data/prefs.glade.h:72
 msgid "Allow bold font"
 msgstr ""
 
-#: ../data/prefs.glade.h:72
+#: ../data/prefs.glade.h:73
 msgid "<b>Palette</b>"
 msgstr "<b>Paletta</b>"
 
-#: ../data/prefs.glade.h:73
+#: ../data/prefs.glade.h:74
 msgid "Built-in schemes:"
 msgstr "Beépített sémák:"
 
-#: ../data/prefs.glade.h:74
+#: ../data/prefs.glade.h:75
 msgid "Color palette:"
 msgstr "Színpaletta:"
 
-#: ../data/prefs.glade.h:75
+#: ../data/prefs.glade.h:76
 #, fuzzy
 msgid "Font color"
 msgstr "Szövegszín:"
 
-#: ../data/prefs.glade.h:76
+#: ../data/prefs.glade.h:77
 #, fuzzy
 msgid "Background color"
 msgstr "Háttérszín:"
 
-#: ../data/prefs.glade.h:77
+#: ../data/prefs.glade.h:78
 msgid "Use font and background color from the palette"
 msgstr ""
 
-#: ../data/prefs.glade.h:78
+#: ../data/prefs.glade.h:79
 msgid "Demo:"
 msgstr ""
 
-#: ../data/prefs.glade.h:79
+#: ../data/prefs.glade.h:80
 msgid "<b>Effects</b>"
 msgstr "<b>Effektek</b>"
 
-#: ../data/prefs.glade.h:80
+#: ../data/prefs.glade.h:81
 msgid "Transparency:"
 msgstr "Átlátszóság:"
 
-#: ../data/prefs.glade.h:81
+#: ../data/prefs.glade.h:82
 msgid "Background image:"
 msgstr "Háttérkép:"
 
-#: ../data/prefs.glade.h:82
+#: ../data/prefs.glade.h:83 ../src/guake/prefs.py:130
 msgid "Appearance"
 msgstr "Megjelenés"
 
-#: ../data/prefs.glade.h:83
+#: ../data/prefs.glade.h:84
 msgid ""
 "<small>Quick open is a feature allowing you to open a file directly into "
 "your favorite text editor by clicking on its filename when it appears in "
@@ -469,15 +473,15 @@ msgid ""
 "extract filename below.</small>"
 msgstr ""
 
-#: ../data/prefs.glade.h:84
+#: ../data/prefs.glade.h:85
 msgid "Enable Quick Open when Ctrl+clicking on a filename in the terminal"
 msgstr ""
 
-#: ../data/prefs.glade.h:85
+#: ../data/prefs.glade.h:86
 msgid "Editor command line:"
 msgstr ""
 
-#: ../data/prefs.glade.h:87
+#: ../data/prefs.glade.h:88
 #, no-c-format
 msgid ""
 "<small><i>Use the following elements in the open editor command line:\n"
@@ -489,36 +493,36 @@ msgid ""
 "</i></small>"
 msgstr ""
 
-#: ../data/prefs.glade.h:93
+#: ../data/prefs.glade.h:94
 msgid "Quick open in current terminal"
 msgstr ""
 
-#: ../data/prefs.glade.h:94
+#: ../data/prefs.glade.h:95
 msgid ""
 "Here is the list of supported patterns: (to add your own, please contact the "
 "Guake's authors)"
 msgstr ""
 
-#: ../data/prefs.glade.h:95
+#: ../data/prefs.glade.h:96
 #, fuzzy
 msgid "<b>Quick Open</b>"
 msgstr "<b>Paletta</b>"
 
-#: ../data/prefs.glade.h:96
+#: ../data/prefs.glade.h:97
 msgid "Quick Open"
 msgstr ""
 
-#: ../data/prefs.glade.h:97
+#: ../data/prefs.glade.h:98
 msgid ""
 "To change a shortcut simply click on its name.\n"
 "To disable a shortcut, press the \"Backspace\" key."
 msgstr ""
 
-#: ../data/prefs.glade.h:99
+#: ../data/prefs.glade.h:100
 msgid "Keyboard shortcuts"
 msgstr "Gyorsbillentyűk"
 
-#: ../data/prefs.glade.h:100
+#: ../data/prefs.glade.h:101
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -529,7 +533,7 @@ msgstr ""
 "programokra, melyek nem biztos hogy helyesen fognak működni. Ezek csak a "
 "finomhangolás jellegük miatt maradtak itt.</i></small>"
 
-#: ../data/prefs.glade.h:101
+#: ../data/prefs.glade.h:102
 msgid ""
 "ASCII DEL\n"
 "Escape sequence\n"
@@ -539,38 +543,37 @@ msgstr ""
 "Escape szekvencia\n"
 "Control-H"
 
-#: ../data/prefs.glade.h:104
+#: ../data/prefs.glade.h:105
 msgid "_Backspace key generates:"
 msgstr "_Backspace működése:"
 
-#: ../data/prefs.glade.h:105
+#: ../data/prefs.glade.h:106
 msgid "_Delete key generates:"
 msgstr "_Delete működése:"
 
-#: ../data/prefs.glade.h:106
+#: ../data/prefs.glade.h:107
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "_Kompatibilitási beállítások visszaállítása "
 
-#: ../data/prefs.glade.h:107
+#: ../data/prefs.glade.h:108
 msgid "<b>Keyboard compatibility</b>"
 msgstr "<b>Billentyűkiosztás kompatibilitása </b>"
 
-#: ../data/prefs.glade.h:108
+#: ../data/prefs.glade.h:109
 msgid "Compatibility"
 msgstr "Egyéb"
 
-#: ../src/guake/about.py:47 ../src/guake/gconfhandler.py:427
-#: ../src/guake/guake_app.py:177 ../src/guake/guake_app.py:348
+#: ../src/guake/about.py:47 ../src/guake/gconfhandler.py:435
+#: ../src/guake/guake_app.py:181 ../src/guake/guake_app.py:376
 msgid "Guake Terminal"
 msgstr "Guake Terminál"
 
-#. Adding a new radio button to the tabbar
-#: ../src/guake/gconfhandler.py:365 ../src/guake/guake_app.py:1548
+#: ../src/guake/gconfhandler.py:368 ../src/guake/guake_app.py:1363
 #, fuzzy
 msgid "Terminal"
 msgstr "Terminál %s"
 
-#: ../src/guake/gconfhandler.py:428
+#: ../src/guake/gconfhandler.py:436
 #, python-format
 msgid ""
 "A problem happened when binding <b>%s</b> key.\n"
@@ -579,54 +582,54 @@ msgstr ""
 "Hiba történt a <b>%s</b> billentyűkombináció hozzárendelésekor.\n"
 "Kérlek állíts be egy másikat a Guake beállítások panelen."
 
-#: ../src/guake/guake_app.py:128
+#: ../src/guake/guake_app.py:132
 #, fuzzy
 msgid "Do you want to close the tab?"
 msgstr "Biztosan kilép a Guake-ből!?"
 
-#: ../src/guake/guake_app.py:131
+#: ../src/guake/guake_app.py:135
 #, fuzzy
 msgid "Do you really want to quit Guake?"
 msgstr "Biztosan kilép a Guake-ből!?"
 
-#: ../src/guake/guake_app.py:133
+#: ../src/guake/guake_app.py:137
 #, fuzzy
 msgid " and one tab open"
 msgstr "Új lap hozzáadása"
 
-#: ../src/guake/guake_app.py:135
+#: ../src/guake/guake_app.py:139
 #, python-brace-format
 msgid " and {0} tabs open"
 msgstr ""
 
-#: ../src/guake/guake_app.py:138
+#: ../src/guake/guake_app.py:142
 #, fuzzy
 msgid "There are no processes running"
 msgstr "<b>Egy folyamat még fut.</b>"
 
-#: ../src/guake/guake_app.py:140
+#: ../src/guake/guake_app.py:144
 #, fuzzy
 msgid "There is a process still running"
 msgstr "<b>Egy folyamat még fut.</b>"
 
-#: ../src/guake/guake_app.py:142
+#: ../src/guake/guake_app.py:146
 #, fuzzy, python-brace-format
 msgid "There are {0} processes still running"
 msgstr "<b>%d folyamat még fut.</b>"
 
-#: ../src/guake/guake_app.py:182
+#: ../src/guake/guake_app.py:186
 msgid "guake-indicator"
 msgstr ""
 
-#: ../src/guake/guake_app.py:182
+#: ../src/guake/guake_app.py:186
 msgid "guake-tray"
 msgstr ""
 
-#: ../src/guake/guake_app.py:186
+#: ../src/guake/guake_app.py:190
 msgid "Show"
 msgstr ""
 
-#: ../src/guake/guake_app.py:349
+#: ../src/guake/guake_app.py:377
 #, python-format
 msgid ""
 "Guake is now running,\n"
@@ -635,129 +638,133 @@ msgstr ""
 "A Guake fut,\n"
 "a használathoz nyomja meg a(z) <b>%s</b> gombot."
 
-#: ../src/guake/guake_app.py:611
+#: ../src/guake/guake_app.py:665
 #, python-format
 msgid "Search on Web: '%s'"
 msgstr ""
 
-#: ../src/guake/guake_app.py:616
+#: ../src/guake/guake_app.py:670
 msgid "Search on Web (no selection)"
 msgstr ""
 
-#: ../src/guake/guake_app.py:622
+#: ../src/guake/guake_app.py:678
+msgid "Open Link: '{}...'"
+msgstr ""
+
+#: ../src/guake/guake_app.py:680
 msgid "Open Link: {}"
 msgstr ""
 
-#: ../src/guake/guake_app.py:625
+#: ../src/guake/guake_app.py:683
 msgid "Open Link..."
 msgstr ""
 
-#: ../src/guake/guake_app.py:1300
+#: ../src/guake/guake_app.py:1402
 msgid "Rename tab"
 msgstr "Lap átnevezése"
 
-#: ../src/guake/guake_app.py:1591
+#: ../src/guake/guake_app.py:1716
 msgid "Save to..."
 msgstr ""
 
-#: ../src/guake/guake_app.py:1598 ../src/guake/prefs.py:930
+#: ../src/guake/guake_app.py:1723 ../src/guake/prefs.py:998
 msgid "All files"
 msgstr ""
 
-#: ../src/guake/guake_app.py:1603
+#: ../src/guake/guake_app.py:1728
 msgid "Text and Logs"
 msgstr ""
 
-#: ../src/guake/guake_app.py:1621
+#: ../src/guake/guake_app.py:1746
 msgid "Find"
 msgstr ""
 
-#: ../src/guake/guake_app.py:1623
+#: ../src/guake/guake_app.py:1748
 msgid "Forward"
 msgstr ""
 
-#: ../src/guake/guake_app.py:1624
+#: ../src/guake/guake_app.py:1749
 msgid "Backward"
 msgstr ""
 
-#: ../src/guake/main.py:67
+#: ../src/guake/main.py:68
 msgid "Put Guake in fullscreen mode"
 msgstr ""
 
-#: ../src/guake/main.py:71
+#: ../src/guake/main.py:72
 msgid "Toggles the visibility of the terminal window"
 msgstr "Guake láthatóságának váltása"
 
-#: ../src/guake/main.py:75
+#: ../src/guake/main.py:76
 #, fuzzy
 msgid "Shows Guake main window"
 msgstr "Guake beállításainak mutatása"
 
-#: ../src/guake/main.py:79
+#: ../src/guake/main.py:80
 #, fuzzy
 msgid "Hides Guake main window"
 msgstr "Guake beállításainak mutatása"
 
-#: ../src/guake/main.py:83
+#: ../src/guake/main.py:84
 msgid "Shows Guake preference window"
 msgstr "Guake beállításainak mutatása"
 
-#: ../src/guake/main.py:87
+#: ../src/guake/main.py:88
 msgid "Shows Guake's about info"
 msgstr "Guake-ről"
 
-#: ../src/guake/main.py:91
+#: ../src/guake/main.py:92
 #, fuzzy
 msgid "Add a new tab (with current directory set to NEW_TAB)"
 msgstr "Új lap megnyitása a _jelenlegi könyvtárban"
 
-#: ../src/guake/main.py:95
+#: ../src/guake/main.py:96
 msgid "Select a tab (SELECT_TAB is the index of the tab)"
 msgstr ""
 
-#: ../src/guake/main.py:99
+#: ../src/guake/main.py:100
 msgid "Return the selected tab index."
 msgstr "A kiválasztott lap indexének visszaadása."
 
-#: ../src/guake/main.py:103
+#: ../src/guake/main.py:104
 msgid "Execute an arbitrary command in the selected tab."
 msgstr "Egyéni parancs végrehajtása a kiválasztott lapon"
 
-#: ../src/guake/main.py:107
+#: ../src/guake/main.py:108
 msgid "Specify the tab to rename. Default is 0."
 msgstr ""
 
-#: ../src/guake/main.py:111
+#: ../src/guake/main.py:112
 msgid "Set the hexadecimal (#rrggbb) background color of the selected tab."
 msgstr ""
 
-#: ../src/guake/main.py:116
+#: ../src/guake/main.py:117
 msgid "Set the hexadecimal (#rrggbb) foreground color of the selected tab."
 msgstr ""
 
-#: ../src/guake/main.py:122
+#: ../src/guake/main.py:123
 msgid ""
 "Rename the specified tab. Reset to default if TITLE is a single dash \"-\"."
 msgstr ""
 
-#: ../src/guake/main.py:128
+#: ../src/guake/main.py:129
 msgid ""
 "Rename the current tab. Reset to default if TITLE is a single dash \"-\"."
 msgstr ""
 
-#: ../src/guake/main.py:133
+#: ../src/guake/main.py:134
 msgid "Says to Guake go away =("
 msgstr "Elbúcsúzás Guake-től =("
 
-#: ../src/guake/main.py:137
+#: ../src/guake/main.py:138
 msgid "Do not execute the start up script"
 msgstr ""
 
-#: ../src/guake/main.py:231
+#: ../src/guake/main.py:235
 msgid "Guake can not init!"
 msgstr "Guake nem tud elindulni!"
 
-#: ../src/guake/main.py:232
+#: ../src/guake/main.py:236
 #, fuzzy
 msgid ""
 "Gconf Error.\n"
@@ -771,32 +778,190 @@ msgstr ""
 msgid "<user shell>"
 msgstr "<felhasználói héj>"
 
-#: ../src/guake/prefs.py:467
+#: ../src/guake/prefs.py:77
+msgid "Toggle Guake visibility"
+msgstr "Guake láthatósága"
+
+#: ../src/guake/prefs.py:81
+#, fuzzy
+msgid "Toggle Hide on Lose Focus"
+msgstr "Fókusz elvesztésekor elrejtés"
+
+#: ../src/guake/prefs.py:88
+msgid "Tab management"
+msgstr "Lapok kezelése"
+
+#: ../src/guake/prefs.py:90
+#, fuzzy
+msgid "New tab"
+msgstr "Új lap"
+
+#: ../src/guake/prefs.py:92
+msgid "Close tab"
+msgstr "Lap bezárása"
+
+#: ../src/guake/prefs.py:94
+msgid "Rename current tab"
+msgstr "Lap átnevezése"
+
+#: ../src/guake/prefs.py:97
+msgid "Navigation"
+msgstr "Navigáció"
+
+#: ../src/guake/prefs.py:99
+msgid "Go to previous tab"
+msgstr "Előző lap"
+
+#: ../src/guake/prefs.py:101
+msgid "Go to next tab"
+msgstr "Következő lap"
+
+#: ../src/guake/prefs.py:103
+#, fuzzy
+msgid "Move current tab left"
+msgstr "Lap átnevezése"
+
+#: ../src/guake/prefs.py:105
+#, fuzzy
+msgid "Move current tab right"
+msgstr "Lap átnevezése"
+
+#: ../src/guake/prefs.py:107
+#, fuzzy
+msgid "Go to first tab"
+msgstr "Következő lap"
+
+#: ../src/guake/prefs.py:109
+#, fuzzy
+msgid "Go to second tab"
+msgstr "Következő lap"
+
+#: ../src/guake/prefs.py:111
+#, fuzzy
+msgid "Go to third tab"
+msgstr "Következő lap"
+
+#: ../src/guake/prefs.py:113
+#, fuzzy
+msgid "Go to fourth tab"
+msgstr "Következő lap"
+
+#: ../src/guake/prefs.py:115
+#, fuzzy
+msgid "Go to fifth tab"
+msgstr "Következő lap"
+
+#: ../src/guake/prefs.py:117
+#, fuzzy
+msgid "Go to sixth tab"
+msgstr "Következő lap"
+
+#: ../src/guake/prefs.py:119
+#, fuzzy
+msgid "Go to seventh tab"
+msgstr "Következő lap"
+
+#: ../src/guake/prefs.py:121
+#, fuzzy
+msgid "Go to eighth tab"
+msgstr "Következő lap"
+
+#: ../src/guake/prefs.py:123
+#, fuzzy
+msgid "Go to ninth tab"
+msgstr "Következő lap"
+
+#: ../src/guake/prefs.py:125
+#, fuzzy
+msgid "Go to tenth tab"
+msgstr "Következő lap"
+
+#: ../src/guake/prefs.py:127
+#, fuzzy
+msgid "Go to last tab"
+msgstr "Következő lap"
+
+#: ../src/guake/prefs.py:132
+msgid "Zoom out"
+msgstr ""
+
+#: ../src/guake/prefs.py:134
+msgid "Zoom in"
+msgstr ""
+
+#: ../src/guake/prefs.py:136
+msgid "Zoom in (alternative)"
+msgstr ""
+
+#: ../src/guake/prefs.py:138
+msgid "Increase height"
+msgstr ""
+
+#: ../src/guake/prefs.py:140
+msgid "Decrease height"
+msgstr ""
+
+#: ../src/guake/prefs.py:142
+#, fuzzy
+msgid "Increase transparency"
+msgstr "Átlátszóság:"
+
+#: ../src/guake/prefs.py:144
+#, fuzzy
+msgid "Decrease transparency"
+msgstr "Átlátszóság:"
+
+#: ../src/guake/prefs.py:146
+#, fuzzy
+msgid "Toggle transparency"
+msgstr "Átlátszóság:"
+
+#: ../src/guake/prefs.py:149
+msgid "Clipboard"
+msgstr "Vágólap"
+
+#: ../src/guake/prefs.py:151
+msgid "Copy text to clipboard"
+msgstr "Másolás vágólapra"
+
+#: ../src/guake/prefs.py:153
+msgid "Paste text from clipboard"
+msgstr "Beillesztés vágólapról"
+
+#: ../src/guake/prefs.py:156
+msgid "Extra features"
+msgstr ""
+
+#: ../src/guake/prefs.py:159
+msgid "Search select text on web"
+msgstr ""
+
+#: ../src/guake/prefs.py:519
 msgid "Action"
 msgstr "Művelet"
 
-#: ../src/guake/prefs.py:477
+#: ../src/guake/prefs.py:529
 msgid "Shortcut"
 msgstr "Gyorsbillentyű"
 
-#: ../src/guake/prefs.py:619 ../src/guake/prefs.py:665
+#: ../src/guake/prefs.py:678 ../src/guake/prefs.py:724
 msgid "Custom"
 msgstr ""
 
-#: ../src/guake/prefs.py:926
+#: ../src/guake/prefs.py:994
 msgid "JSON files"
 msgstr ""
 
-#: ../src/guake/prefs.py:1019
+#: ../src/guake/prefs.py:1088
 #, python-format
 msgid "The shortcut \"%s\" is already in use."
 msgstr "A \"%s\" gyorsbillentyű már használatban van."
 
-#: ../src/guake/prefs.py:1020
+#: ../src/guake/prefs.py:1089
 msgid "Error setting keybinding."
 msgstr "Hiba a billentyűkiosztás alkalmazásával"
 
-#: ../src/guake/prefs.py:1032
+#: ../src/guake/prefs.py:1101
 #, python-format
 msgid ""
 "The shortcut \"%s\" cannot be used because it will become impossible to type "
@@ -836,33 +1001,3 @@ msgstr ""
 
 #~ msgid "Rename the selected tab."
 #~ msgstr "A kiválasztott lap átnevezése."
-
-#~ msgid "Toggle Guake visibility"
-#~ msgstr "Guake láthatósága"
-
-#~ msgid "Tab management"
-#~ msgstr "Lapok kezelése"
-
-#~ msgid "Close tab"
-#~ msgstr "Lap bezárása"
-
-#~ msgid "Rename current tab"
-#~ msgstr "Lap átnevezése"
-
-#~ msgid "Navigation"
-#~ msgstr "Navigáció"
-
-#~ msgid "Go to previous tab"
-#~ msgstr "Előző lap"
-
-#~ msgid "Go to next tab"
-#~ msgstr "Következő lap"
-
-#~ msgid "Clipboard"
-#~ msgstr "Vágólap"
-
-#~ msgid "Copy text to clipboard"
-#~ msgstr "Másolás vágólapra"
-
-#~ msgid "Paste text from clipboard"
-#~ msgstr "Beillesztés vágólapról"

--- a/po/id.po
+++ b/po/id.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Guake 0.4.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-12-01 16:49+0100\n"
+"POT-Creation-Date: 2016-08-17 21:41+0000\n"
 "PO-Revision-Date: 2013-05-20 07:04+0000\n"
 "Last-Translator: operamaniac <rizkiaulia.r@gmail.com>\n"
 "Language-Team: Indonesian (http://www.transifex.com/projects/p/guake/"
@@ -103,7 +103,7 @@ msgstr "Gandakan"
 msgid "Paste"
 msgstr "Tempelkan"
 
-#: ../data/guake.glade.h:3
+#: ../data/guake.glade.h:3 ../src/guake/prefs.py:79
 msgid "Toggle Fullscreen"
 msgstr ""
 
@@ -111,7 +111,7 @@ msgstr ""
 msgid "Save to File..."
 msgstr ""
 
-#: ../data/guake.glade.h:5
+#: ../data/guake.glade.h:5 ../src/guake/prefs.py:85
 msgid "Reset terminal"
 msgstr ""
 
@@ -141,7 +141,7 @@ msgstr ""
 msgid "Search on Web"
 msgstr ""
 
-#: ../data/guake.glade.h:12
+#: ../data/guake.glade.h:12 ../src/guake/prefs.py:83
 msgid "Quit"
 msgstr "Keluar"
 
@@ -261,199 +261,203 @@ msgid "Use VTE titles for tab names"
 msgstr ""
 
 #: ../data/prefs.glade.h:33
-msgid "Max tab name length:"
+msgid "Abbreviate directories in tab names"
 msgstr ""
 
 #: ../data/prefs.glade.h:34
-msgid "Hide on lose focus"
+msgid "Max tab name length:"
 msgstr ""
 
 #: ../data/prefs.glade.h:35
-msgid "Show tab bar"
+msgid "Hide on lose focus"
 msgstr ""
 
 #: ../data/prefs.glade.h:36
-msgid "Start fullscreen"
+msgid "Show tab bar"
 msgstr ""
 
 #: ../data/prefs.glade.h:37
+msgid "Start fullscreen"
+msgstr ""
+
+#: ../data/prefs.glade.h:38
 msgid "<b>Main Window</b>"
 msgstr "<b>Jendela Utama</b>"
 
-#: ../data/prefs.glade.h:38
+#: ../data/prefs.glade.h:39
 msgid "Left"
 msgstr ""
 
-#: ../data/prefs.glade.h:39
+#: ../data/prefs.glade.h:40
 msgid "Center"
 msgstr ""
 
-#: ../data/prefs.glade.h:40
+#: ../data/prefs.glade.h:41
 msgid "Right"
 msgstr ""
 
-#: ../data/prefs.glade.h:41
+#: ../data/prefs.glade.h:42
 #, fuzzy
 msgid "<b>Main Window Horizontal Alignment</b>"
 msgstr "<b>Tinggi Jendela utama</b>"
 
-#: ../data/prefs.glade.h:42
+#: ../data/prefs.glade.h:43
 #, fuzzy
 msgid "<b>Main Window Height</b>"
 msgstr "<b>Tinggi Jendela utama</b>"
 
-#: ../data/prefs.glade.h:43
+#: ../data/prefs.glade.h:44
 #, fuzzy
 msgid "<b>Main Window Width</b>"
 msgstr "<b>Tinggi Jendela utama</b>"
 
-#: ../data/prefs.glade.h:44
+#: ../data/prefs.glade.h:45
 msgid "Custom command file path: "
 msgstr ""
 
-#: ../data/prefs.glade.h:45
+#: ../data/prefs.glade.h:46
 msgid "Please select a json file"
 msgstr ""
 
-#: ../data/prefs.glade.h:46
+#: ../data/prefs.glade.h:47 ../src/guake/prefs.py:75
 msgid "General"
 msgstr ""
 
-#: ../data/prefs.glade.h:47
+#: ../data/prefs.glade.h:48
 msgid "Default interpreter:"
 msgstr ""
 
-#: ../data/prefs.glade.h:48
+#: ../data/prefs.glade.h:49
 msgid "_Run command as a login shell"
 msgstr ""
 
-#: ../data/prefs.glade.h:49
+#: ../data/prefs.glade.h:50
 msgid "_Open new tab in current directory"
 msgstr ""
 
-#: ../data/prefs.glade.h:50
+#: ../data/prefs.glade.h:51
 msgid "<b>Shell</b>"
 msgstr "<b>Inti</b"
 
-#: ../data/prefs.glade.h:51
+#: ../data/prefs.glade.h:52
 msgid "Shell"
 msgstr ""
 
-#: ../data/prefs.glade.h:52
+#: ../data/prefs.glade.h:53
 msgid "Show scrollbar"
 msgstr ""
 
-#: ../data/prefs.glade.h:53
+#: ../data/prefs.glade.h:54
 msgid "Scrollback lines:"
 msgstr ""
 
-#: ../data/prefs.glade.h:54
+#: ../data/prefs.glade.h:55
 msgid "On output"
 msgstr ""
 
-#: ../data/prefs.glade.h:55
+#: ../data/prefs.glade.h:56
 msgid "On key stroke"
 msgstr ""
 
-#: ../data/prefs.glade.h:56
+#: ../data/prefs.glade.h:57
 msgid "<b>Scroll</b>"
 msgstr "<b>Gulir</b>"
 
-#: ../data/prefs.glade.h:57
+#: ../data/prefs.glade.h:58
 msgid "Scrolling"
 msgstr ""
 
-#: ../data/prefs.glade.h:58
+#: ../data/prefs.glade.h:59
 msgid "Use the system fixed width font"
 msgstr ""
 
-#: ../data/prefs.glade.h:59
+#: ../data/prefs.glade.h:60
 msgid "Font:"
 msgstr ""
 
-#: ../data/prefs.glade.h:60
+#: ../data/prefs.glade.h:61
 msgid "Choose some font"
 msgstr ""
 
-#: ../data/prefs.glade.h:61
+#: ../data/prefs.glade.h:62
 msgid "Text color:"
 msgstr ""
 
-#: ../data/prefs.glade.h:62
+#: ../data/prefs.glade.h:63
 msgid "Background color:"
 msgstr ""
 
-#: ../data/prefs.glade.h:63
+#: ../data/prefs.glade.h:64
 msgid "Cursor shape:"
 msgstr ""
 
-#: ../data/prefs.glade.h:64
+#: ../data/prefs.glade.h:65
 msgid ""
 "Block\n"
 "I-Beam\n"
 "Underline"
 msgstr ""
 
-#: ../data/prefs.glade.h:67
+#: ../data/prefs.glade.h:68
 msgid ""
 "Follow GTK+ setting\n"
 "Blink on\n"
 "Blink off"
 msgstr ""
 
-#: ../data/prefs.glade.h:70
+#: ../data/prefs.glade.h:71
 msgid "Cursor blink mode:"
 msgstr ""
 
-#: ../data/prefs.glade.h:71
+#: ../data/prefs.glade.h:72
 msgid "Allow bold font"
 msgstr ""
 
-#: ../data/prefs.glade.h:72
+#: ../data/prefs.glade.h:73
 msgid "<b>Palette</b>"
 msgstr "<b>Palet</b>"
 
-#: ../data/prefs.glade.h:73
+#: ../data/prefs.glade.h:74
 msgid "Built-in schemes:"
 msgstr ""
 
-#: ../data/prefs.glade.h:74
+#: ../data/prefs.glade.h:75
 msgid "Color palette:"
 msgstr ""
 
-#: ../data/prefs.glade.h:75
+#: ../data/prefs.glade.h:76
 msgid "Font color"
 msgstr ""
 
-#: ../data/prefs.glade.h:76
+#: ../data/prefs.glade.h:77
 msgid "Background color"
 msgstr ""
 
-#: ../data/prefs.glade.h:77
+#: ../data/prefs.glade.h:78
 msgid "Use font and background color from the palette"
 msgstr ""
 
-#: ../data/prefs.glade.h:78
+#: ../data/prefs.glade.h:79
 msgid "Demo:"
 msgstr ""
 
-#: ../data/prefs.glade.h:79
+#: ../data/prefs.glade.h:80
 msgid "<b>Effects</b>"
 msgstr "<b>Efek</b>"
 
-#: ../data/prefs.glade.h:80
+#: ../data/prefs.glade.h:81
 msgid "Transparency:"
 msgstr ""
 
-#: ../data/prefs.glade.h:81
+#: ../data/prefs.glade.h:82
 msgid "Background image:"
 msgstr ""
 
-#: ../data/prefs.glade.h:82
+#: ../data/prefs.glade.h:83 ../src/guake/prefs.py:130
 msgid "Appearance"
 msgstr ""
 
-#: ../data/prefs.glade.h:83
+#: ../data/prefs.glade.h:84
 msgid ""
 "<small>Quick open is a feature allowing you to open a file directly into "
 "your favorite text editor by clicking on its filename when it appears in "
@@ -461,15 +465,15 @@ msgid ""
 "extract filename below.</small>"
 msgstr ""
 
-#: ../data/prefs.glade.h:84
+#: ../data/prefs.glade.h:85
 msgid "Enable Quick Open when Ctrl+clicking on a filename in the terminal"
 msgstr ""
 
-#: ../data/prefs.glade.h:85
+#: ../data/prefs.glade.h:86
 msgid "Editor command line:"
 msgstr ""
 
-#: ../data/prefs.glade.h:87
+#: ../data/prefs.glade.h:88
 #, no-c-format
 msgid ""
 "<small><i>Use the following elements in the open editor command line:\n"
@@ -481,36 +485,36 @@ msgid ""
 "</i></small>"
 msgstr ""
 
-#: ../data/prefs.glade.h:93
+#: ../data/prefs.glade.h:94
 msgid "Quick open in current terminal"
 msgstr ""
 
-#: ../data/prefs.glade.h:94
+#: ../data/prefs.glade.h:95
 msgid ""
 "Here is the list of supported patterns: (to add your own, please contact the "
 "Guake's authors)"
 msgstr ""
 
-#: ../data/prefs.glade.h:95
+#: ../data/prefs.glade.h:96
 #, fuzzy
 msgid "<b>Quick Open</b>"
 msgstr "<b>Palet</b>"
 
-#: ../data/prefs.glade.h:96
+#: ../data/prefs.glade.h:97
 msgid "Quick Open"
 msgstr ""
 
-#: ../data/prefs.glade.h:97
+#: ../data/prefs.glade.h:98
 msgid ""
 "To change a shortcut simply click on its name.\n"
 "To disable a shortcut, press the \"Backspace\" key."
 msgstr ""
 
-#: ../data/prefs.glade.h:99
+#: ../data/prefs.glade.h:100
 msgid "Keyboard shortcuts"
 msgstr ""
 
-#: ../data/prefs.glade.h:100
+#: ../data/prefs.glade.h:101
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -518,220 +522,223 @@ msgid ""
 "i></small>"
 msgstr ""
 
-#: ../data/prefs.glade.h:101
+#: ../data/prefs.glade.h:102
 msgid ""
 "ASCII DEL\n"
 "Escape sequence\n"
 "Control-H"
 msgstr ""
 
-#: ../data/prefs.glade.h:104
+#: ../data/prefs.glade.h:105
 msgid "_Backspace key generates:"
 msgstr ""
 
-#: ../data/prefs.glade.h:105
+#: ../data/prefs.glade.h:106
 msgid "_Delete key generates:"
 msgstr ""
 
-#: ../data/prefs.glade.h:106
+#: ../data/prefs.glade.h:107
 msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
-#: ../data/prefs.glade.h:107
+#: ../data/prefs.glade.h:108
 msgid "<b>Keyboard compatibility</b>"
 msgstr "<b>Kompabilitas papan ketik</b>"
 
-#: ../data/prefs.glade.h:108
+#: ../data/prefs.glade.h:109
 msgid "Compatibility"
 msgstr ""
 
-#: ../src/guake/about.py:47 ../src/guake/gconfhandler.py:427
-#: ../src/guake/guake_app.py:177 ../src/guake/guake_app.py:348
+#: ../src/guake/about.py:47 ../src/guake/gconfhandler.py:435
+#: ../src/guake/guake_app.py:181 ../src/guake/guake_app.py:376
 msgid "Guake Terminal"
 msgstr ""
 
-#. Adding a new radio button to the tabbar
-#: ../src/guake/gconfhandler.py:365 ../src/guake/guake_app.py:1548
+#: ../src/guake/gconfhandler.py:368 ../src/guake/guake_app.py:1363
 msgid "Terminal"
 msgstr ""
 
-#: ../src/guake/gconfhandler.py:428
+#: ../src/guake/gconfhandler.py:436
 #, python-format
 msgid ""
 "A problem happened when binding <b>%s</b> key.\n"
 "Please use Guake Preferences dialog to choose another key"
 msgstr ""
 
-#: ../src/guake/guake_app.py:128
+#: ../src/guake/guake_app.py:132
 msgid "Do you want to close the tab?"
 msgstr ""
 
-#: ../src/guake/guake_app.py:131
+#: ../src/guake/guake_app.py:135
 msgid "Do you really want to quit Guake?"
 msgstr ""
 
-#: ../src/guake/guake_app.py:133
+#: ../src/guake/guake_app.py:137
 #, fuzzy
 msgid " and one tab open"
 msgstr "Tambah tab baru"
 
-#: ../src/guake/guake_app.py:135
+#: ../src/guake/guake_app.py:139
 #, python-brace-format
 msgid " and {0} tabs open"
 msgstr ""
 
-#: ../src/guake/guake_app.py:138
+#: ../src/guake/guake_app.py:142
 msgid "There are no processes running"
 msgstr ""
 
-#: ../src/guake/guake_app.py:140
+#: ../src/guake/guake_app.py:144
 msgid "There is a process still running"
 msgstr ""
 
-#: ../src/guake/guake_app.py:142
+#: ../src/guake/guake_app.py:146
 #, python-brace-format
 msgid "There are {0} processes still running"
 msgstr ""
 
-#: ../src/guake/guake_app.py:182
+#: ../src/guake/guake_app.py:186
 msgid "guake-indicator"
 msgstr ""
 
-#: ../src/guake/guake_app.py:182
+#: ../src/guake/guake_app.py:186
 msgid "guake-tray"
 msgstr ""
 
-#: ../src/guake/guake_app.py:186
+#: ../src/guake/guake_app.py:190
 msgid "Show"
 msgstr ""
 
-#: ../src/guake/guake_app.py:349
+#: ../src/guake/guake_app.py:377
 #, python-format
 msgid ""
 "Guake is now running,\n"
 "press <b>%s</b> to use it."
 msgstr ""
 
-#: ../src/guake/guake_app.py:611
+#: ../src/guake/guake_app.py:665
 #, python-format
 msgid "Search on Web: '%s'"
 msgstr ""
 
-#: ../src/guake/guake_app.py:616
+#: ../src/guake/guake_app.py:670
 msgid "Search on Web (no selection)"
 msgstr ""
 
-#: ../src/guake/guake_app.py:622
+#: ../src/guake/guake_app.py:678
+msgid "Open Link: '{}...'"
+msgstr ""
+
+#: ../src/guake/guake_app.py:680
 msgid "Open Link: {}"
 msgstr ""
 
-#: ../src/guake/guake_app.py:625
+#: ../src/guake/guake_app.py:683
 msgid "Open Link..."
 msgstr ""
 
-#: ../src/guake/guake_app.py:1300
+#: ../src/guake/guake_app.py:1402
 msgid "Rename tab"
 msgstr ""
 
-#: ../src/guake/guake_app.py:1591
+#: ../src/guake/guake_app.py:1716
 msgid "Save to..."
 msgstr ""
 
-#: ../src/guake/guake_app.py:1598 ../src/guake/prefs.py:930
+#: ../src/guake/guake_app.py:1723 ../src/guake/prefs.py:998
 msgid "All files"
 msgstr ""
 
-#: ../src/guake/guake_app.py:1603
+#: ../src/guake/guake_app.py:1728
 msgid "Text and Logs"
 msgstr ""
 
-#: ../src/guake/guake_app.py:1621
+#: ../src/guake/guake_app.py:1746
 msgid "Find"
 msgstr ""
 
-#: ../src/guake/guake_app.py:1623
+#: ../src/guake/guake_app.py:1748
 msgid "Forward"
 msgstr ""
 
-#: ../src/guake/guake_app.py:1624
+#: ../src/guake/guake_app.py:1749
 msgid "Backward"
 msgstr ""
 
-#: ../src/guake/main.py:67
+#: ../src/guake/main.py:68
 msgid "Put Guake in fullscreen mode"
 msgstr ""
 
-#: ../src/guake/main.py:71
+#: ../src/guake/main.py:72
 msgid "Toggles the visibility of the terminal window"
 msgstr ""
 
-#: ../src/guake/main.py:75
+#: ../src/guake/main.py:76
 msgid "Shows Guake main window"
 msgstr ""
 
-#: ../src/guake/main.py:79
+#: ../src/guake/main.py:80
 msgid "Hides Guake main window"
 msgstr ""
 
-#: ../src/guake/main.py:83
+#: ../src/guake/main.py:84
 msgid "Shows Guake preference window"
 msgstr ""
 
-#: ../src/guake/main.py:87
+#: ../src/guake/main.py:88
 msgid "Shows Guake's about info"
 msgstr ""
 
-#: ../src/guake/main.py:91
+#: ../src/guake/main.py:92
 msgid "Add a new tab (with current directory set to NEW_TAB)"
 msgstr ""
 
-#: ../src/guake/main.py:95
+#: ../src/guake/main.py:96
 msgid "Select a tab (SELECT_TAB is the index of the tab)"
 msgstr ""
 
-#: ../src/guake/main.py:99
+#: ../src/guake/main.py:100
 msgid "Return the selected tab index."
 msgstr ""
 
-#: ../src/guake/main.py:103
+#: ../src/guake/main.py:104
 msgid "Execute an arbitrary command in the selected tab."
 msgstr ""
 
-#: ../src/guake/main.py:107
+#: ../src/guake/main.py:108
 msgid "Specify the tab to rename. Default is 0."
 msgstr ""
 
-#: ../src/guake/main.py:111
+#: ../src/guake/main.py:112
 msgid "Set the hexadecimal (#rrggbb) background color of the selected tab."
 msgstr ""
 
-#: ../src/guake/main.py:116
+#: ../src/guake/main.py:117
 msgid "Set the hexadecimal (#rrggbb) foreground color of the selected tab."
 msgstr ""
 
-#: ../src/guake/main.py:122
+#: ../src/guake/main.py:123
 msgid ""
 "Rename the specified tab. Reset to default if TITLE is a single dash \"-\"."
 msgstr ""
 
-#: ../src/guake/main.py:128
+#: ../src/guake/main.py:129
 msgid ""
 "Rename the current tab. Reset to default if TITLE is a single dash \"-\"."
 msgstr ""
 
-#: ../src/guake/main.py:133
+#: ../src/guake/main.py:134
 msgid "Says to Guake go away =("
 msgstr ""
 
-#: ../src/guake/main.py:137
+#: ../src/guake/main.py:138
 msgid "Do not execute the start up script"
 msgstr ""
 
-#: ../src/guake/main.py:231
+#: ../src/guake/main.py:235
 msgid "Guake can not init!"
 msgstr ""
 
-#: ../src/guake/main.py:232
+#: ../src/guake/main.py:236
 msgid ""
 "Gconf Error.\n"
 "Have you installed <b>guake.schemas</b> properly?"
@@ -742,32 +749,175 @@ msgstr ""
 msgid "<user shell>"
 msgstr ""
 
-#: ../src/guake/prefs.py:467
+#: ../src/guake/prefs.py:77
+msgid "Toggle Guake visibility"
+msgstr ""
+
+#: ../src/guake/prefs.py:81
+msgid "Toggle Hide on Lose Focus"
+msgstr ""
+
+#: ../src/guake/prefs.py:88
+msgid "Tab management"
+msgstr ""
+
+#: ../src/guake/prefs.py:90
+#, fuzzy
+msgid "New tab"
+msgstr "Tutup Tab"
+
+#: ../src/guake/prefs.py:92
+#, fuzzy
+msgid "Close tab"
+msgstr "Tutup Tab"
+
+#: ../src/guake/prefs.py:94
+#, fuzzy
+msgid "Rename current tab"
+msgstr "Namai ulang"
+
+#: ../src/guake/prefs.py:97
+msgid "Navigation"
+msgstr ""
+
+#: ../src/guake/prefs.py:99
+msgid "Go to previous tab"
+msgstr ""
+
+#: ../src/guake/prefs.py:101
+msgid "Go to next tab"
+msgstr ""
+
+#: ../src/guake/prefs.py:103
+msgid "Move current tab left"
+msgstr ""
+
+#: ../src/guake/prefs.py:105
+msgid "Move current tab right"
+msgstr ""
+
+#: ../src/guake/prefs.py:107
+msgid "Go to first tab"
+msgstr ""
+
+#: ../src/guake/prefs.py:109
+msgid "Go to second tab"
+msgstr ""
+
+#: ../src/guake/prefs.py:111
+msgid "Go to third tab"
+msgstr ""
+
+#: ../src/guake/prefs.py:113
+msgid "Go to fourth tab"
+msgstr ""
+
+#: ../src/guake/prefs.py:115
+msgid "Go to fifth tab"
+msgstr ""
+
+#: ../src/guake/prefs.py:117
+msgid "Go to sixth tab"
+msgstr ""
+
+#: ../src/guake/prefs.py:119
+msgid "Go to seventh tab"
+msgstr ""
+
+#: ../src/guake/prefs.py:121
+msgid "Go to eighth tab"
+msgstr ""
+
+#: ../src/guake/prefs.py:123
+msgid "Go to ninth tab"
+msgstr ""
+
+#: ../src/guake/prefs.py:125
+msgid "Go to tenth tab"
+msgstr ""
+
+#: ../src/guake/prefs.py:127
+msgid "Go to last tab"
+msgstr ""
+
+#: ../src/guake/prefs.py:132
+msgid "Zoom out"
+msgstr ""
+
+#: ../src/guake/prefs.py:134
+msgid "Zoom in"
+msgstr ""
+
+#: ../src/guake/prefs.py:136
+msgid "Zoom in (alternative)"
+msgstr ""
+
+#: ../src/guake/prefs.py:138
+msgid "Increase height"
+msgstr ""
+
+#: ../src/guake/prefs.py:140
+msgid "Decrease height"
+msgstr ""
+
+#: ../src/guake/prefs.py:142
+msgid "Increase transparency"
+msgstr ""
+
+#: ../src/guake/prefs.py:144
+msgid "Decrease transparency"
+msgstr ""
+
+#: ../src/guake/prefs.py:146
+msgid "Toggle transparency"
+msgstr ""
+
+#: ../src/guake/prefs.py:149
+msgid "Clipboard"
+msgstr ""
+
+#: ../src/guake/prefs.py:151
+msgid "Copy text to clipboard"
+msgstr ""
+
+#: ../src/guake/prefs.py:153
+msgid "Paste text from clipboard"
+msgstr ""
+
+#: ../src/guake/prefs.py:156
+msgid "Extra features"
+msgstr ""
+
+#: ../src/guake/prefs.py:159
+msgid "Search select text on web"
+msgstr ""
+
+#: ../src/guake/prefs.py:519
 msgid "Action"
 msgstr ""
 
-#: ../src/guake/prefs.py:477
+#: ../src/guake/prefs.py:529
 msgid "Shortcut"
 msgstr ""
 
-#: ../src/guake/prefs.py:619 ../src/guake/prefs.py:665
+#: ../src/guake/prefs.py:678 ../src/guake/prefs.py:724
 msgid "Custom"
 msgstr ""
 
-#: ../src/guake/prefs.py:926
+#: ../src/guake/prefs.py:994
 msgid "JSON files"
 msgstr ""
 
-#: ../src/guake/prefs.py:1019
+#: ../src/guake/prefs.py:1088
 #, python-format
 msgid "The shortcut \"%s\" is already in use."
 msgstr ""
 
-#: ../src/guake/prefs.py:1020
+#: ../src/guake/prefs.py:1089
 msgid "Error setting keybinding."
 msgstr ""
 
-#: ../src/guake/prefs.py:1032
+#: ../src/guake/prefs.py:1101
 #, python-format
 msgid ""
 "The shortcut \"%s\" cannot be used because it will become impossible to type "

--- a/po/it.po
+++ b/po/it.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Guake 0.4.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-12-01 16:49+0100\n"
+"POT-Creation-Date: 2016-08-17 21:41+0000\n"
 "PO-Revision-Date: 2015-12-14 11:13+0100\n"
 "Last-Translator: Marco Leogrande <dark.knight.ita@gmail.com>\n"
 "Language-Team: Italian <LL@li.org>\n"
@@ -101,7 +101,7 @@ msgstr "Copia"
 msgid "Paste"
 msgstr "Incolla"
 
-#: ../data/guake.glade.h:3
+#: ../data/guake.glade.h:3 ../src/guake/prefs.py:79
 msgid "Toggle Fullscreen"
 msgstr "Alterna schermo intero"
 
@@ -109,7 +109,7 @@ msgstr "Alterna schermo intero"
 msgid "Save to File..."
 msgstr "Salva su File..."
 
-#: ../data/guake.glade.h:5
+#: ../data/guake.glade.h:5 ../src/guake/prefs.py:85
 msgid "Reset terminal"
 msgstr "Resetta terminale"
 
@@ -137,7 +137,7 @@ msgstr "Apri link..."
 msgid "Search on Web"
 msgstr "Cerca sul Web"
 
-#: ../data/guake.glade.h:12
+#: ../data/guake.glade.h:12 ../src/guake/prefs.py:83
 msgid "Quit"
 msgstr "Esci"
 
@@ -272,130 +272,134 @@ msgid "Use VTE titles for tab names"
 msgstr "Usa i titoli VTE per i nomi delle schede"
 
 #: ../data/prefs.glade.h:33
+msgid "Abbreviate directories in tab names"
+msgstr ""
+
+#: ../data/prefs.glade.h:34
 msgid "Max tab name length:"
 msgstr "Lunghezza massima nome scheda:"
 
-#: ../data/prefs.glade.h:34
+#: ../data/prefs.glade.h:35
 msgid "Hide on lose focus"
 msgstr "Nascondere alla perdita del focus"
 
-#: ../data/prefs.glade.h:35
+#: ../data/prefs.glade.h:36
 msgid "Show tab bar"
 msgstr "Mostrare barra delle schede"
 
-#: ../data/prefs.glade.h:36
+#: ../data/prefs.glade.h:37
 msgid "Start fullscreen"
 msgstr "Avvia in schermo intero"
 
-#: ../data/prefs.glade.h:37
+#: ../data/prefs.glade.h:38
 msgid "<b>Main Window</b>"
 msgstr "<b>Finestra principale</b>"
 
-#: ../data/prefs.glade.h:38
+#: ../data/prefs.glade.h:39
 msgid "Left"
 msgstr "Sinistra"
 
-#: ../data/prefs.glade.h:39
+#: ../data/prefs.glade.h:40
 msgid "Center"
 msgstr "Centro"
 
-#: ../data/prefs.glade.h:40
+#: ../data/prefs.glade.h:41
 msgid "Right"
 msgstr "Destra"
 
-#: ../data/prefs.glade.h:41
+#: ../data/prefs.glade.h:42
 msgid "<b>Main Window Horizontal Alignment</b>"
 msgstr "<b>Allineamento Orizzontale Finestra Principale</b>"
 
-#: ../data/prefs.glade.h:42
+#: ../data/prefs.glade.h:43
 msgid "<b>Main Window Height</b>"
 msgstr "<b>Altezza Finestra Principale</b>"
 
-#: ../data/prefs.glade.h:43
+#: ../data/prefs.glade.h:44
 msgid "<b>Main Window Width</b>"
 msgstr "<b>Larghezza Finestra Principale</b>"
 
-#: ../data/prefs.glade.h:44
+#: ../data/prefs.glade.h:45
 msgid "Custom command file path: "
 msgstr "Percorso file di comando personalizzato:"
 
-#: ../data/prefs.glade.h:45
+#: ../data/prefs.glade.h:46
 msgid "Please select a json file"
 msgstr "Per favore seleziona un file json"
 
-#: ../data/prefs.glade.h:46
+#: ../data/prefs.glade.h:47 ../src/guake/prefs.py:75
 msgid "General"
 msgstr "Generale"
 
-#: ../data/prefs.glade.h:47
+#: ../data/prefs.glade.h:48
 msgid "Default interpreter:"
 msgstr "Interprete predefinito:"
 
-#: ../data/prefs.glade.h:48
+#: ../data/prefs.glade.h:49
 msgid "_Run command as a login shell"
 msgstr "_Eseguire il comando come shell di login"
 
-#: ../data/prefs.glade.h:49
+#: ../data/prefs.glade.h:50
 msgid "_Open new tab in current directory"
 msgstr "_Apri nuova scheda nella directory corrente"
 
-#: ../data/prefs.glade.h:50
+#: ../data/prefs.glade.h:51
 msgid "<b>Shell</b>"
 msgstr "<b>Shell</b>"
 
-#: ../data/prefs.glade.h:51
+#: ../data/prefs.glade.h:52
 msgid "Shell"
 msgstr "Terminale"
 
-#: ../data/prefs.glade.h:52
+#: ../data/prefs.glade.h:53
 msgid "Show scrollbar"
 msgstr "Mostrare barra di scorrimento"
 
-#: ../data/prefs.glade.h:53
+#: ../data/prefs.glade.h:54
 msgid "Scrollback lines:"
 msgstr "Linee scorrimento:"
 
-#: ../data/prefs.glade.h:54
+#: ../data/prefs.glade.h:55
 msgid "On output"
 msgstr "In presenza di output"
 
-#: ../data/prefs.glade.h:55
+#: ../data/prefs.glade.h:56
 msgid "On key stroke"
 msgstr "Alla pressione dei tasti"
 
-#: ../data/prefs.glade.h:56
+#: ../data/prefs.glade.h:57
 msgid "<b>Scroll</b>"
 msgstr "<b>Scorrimento</b>"
 
-#: ../data/prefs.glade.h:57
+#: ../data/prefs.glade.h:58
 msgid "Scrolling"
 msgstr "Scorrimento"
 
-#: ../data/prefs.glade.h:58
+#: ../data/prefs.glade.h:59
 msgid "Use the system fixed width font"
 msgstr "Usa il carattere di sistema a larghezza fissa"
 
-#: ../data/prefs.glade.h:59
+#: ../data/prefs.glade.h:60
 msgid "Font:"
 msgstr "Carattere:"
 
-#: ../data/prefs.glade.h:60
+#: ../data/prefs.glade.h:61
 msgid "Choose some font"
 msgstr "Scegliere un carattere"
 
-#: ../data/prefs.glade.h:61
+#: ../data/prefs.glade.h:62
 msgid "Text color:"
 msgstr "Colore del testo:"
 
-#: ../data/prefs.glade.h:62
+#: ../data/prefs.glade.h:63
 msgid "Background color:"
 msgstr "Colore di sfondo:"
 
-#: ../data/prefs.glade.h:63
+#: ../data/prefs.glade.h:64
 msgid "Cursor shape:"
 msgstr "Forma del cursore:"
 
-#: ../data/prefs.glade.h:64
+#: ../data/prefs.glade.h:65
 msgid ""
 "Block\n"
 "I-Beam\n"
@@ -405,7 +409,7 @@ msgstr ""
 "I-Beam\n"
 "Sottolinea"
 
-#: ../data/prefs.glade.h:67
+#: ../data/prefs.glade.h:68
 msgid ""
 "Follow GTK+ setting\n"
 "Blink on\n"
@@ -415,59 +419,59 @@ msgstr ""
 "Lampeggia si\n"
 "Lampeggia no"
 
-#: ../data/prefs.glade.h:70
+#: ../data/prefs.glade.h:71
 msgid "Cursor blink mode:"
 msgstr "Modalità lampeggiamento cursore:"
 
-#: ../data/prefs.glade.h:71
+#: ../data/prefs.glade.h:72
 msgid "Allow bold font"
 msgstr "Permetti testo in grassetto"
 
-#: ../data/prefs.glade.h:72
+#: ../data/prefs.glade.h:73
 msgid "<b>Palette</b>"
 msgstr "<b>Tavolozza</b>"
 
-#: ../data/prefs.glade.h:73
+#: ../data/prefs.glade.h:74
 msgid "Built-in schemes:"
 msgstr "Schemi predefiniti:"
 
-#: ../data/prefs.glade.h:74
+#: ../data/prefs.glade.h:75
 msgid "Color palette:"
 msgstr "Tavolozza colori:"
 
-#: ../data/prefs.glade.h:75
+#: ../data/prefs.glade.h:76
 msgid "Font color"
 msgstr "Colore del testo"
 
-#: ../data/prefs.glade.h:76
+#: ../data/prefs.glade.h:77
 msgid "Background color"
 msgstr "Colore di sfondo"
 
-#: ../data/prefs.glade.h:77
+#: ../data/prefs.glade.h:78
 msgid "Use font and background color from the palette"
 msgstr "Usa font e colore di sfondo dalla palette"
 
-#: ../data/prefs.glade.h:78
+#: ../data/prefs.glade.h:79
 msgid "Demo:"
 msgstr "Dimostrazione:"
 
-#: ../data/prefs.glade.h:79
+#: ../data/prefs.glade.h:80
 msgid "<b>Effects</b>"
 msgstr "<b>Effetti</b>"
 
-#: ../data/prefs.glade.h:80
+#: ../data/prefs.glade.h:81
 msgid "Transparency:"
 msgstr "Trasparenza:"
 
-#: ../data/prefs.glade.h:81
+#: ../data/prefs.glade.h:82
 msgid "Background image:"
 msgstr "Immagine di sfondo:"
 
-#: ../data/prefs.glade.h:82
+#: ../data/prefs.glade.h:83 ../src/guake/prefs.py:130
 msgid "Appearance"
 msgstr "Aspetto"
 
-#: ../data/prefs.glade.h:83
+#: ../data/prefs.glade.h:84
 msgid ""
 "<small>Quick open is a feature allowing you to open a file directly into "
 "your favorite text editor by clicking on its filename when it appears in "
@@ -479,17 +483,17 @@ msgstr ""
 "nel terminale. Controlla di seguito la lista dei pattern di testo "
 "attualmente supportati utilizzati per estrarre il nome del file.</small>"
 
-#: ../data/prefs.glade.h:84
+#: ../data/prefs.glade.h:85
 msgid "Enable Quick Open when Ctrl+clicking on a filename in the terminal"
 msgstr ""
 "Abilita Apertura Rapida quando si CTRL+clicca su un nome di un file nel "
 "terminale"
 
-#: ../data/prefs.glade.h:85
+#: ../data/prefs.glade.h:86
 msgid "Editor command line:"
 msgstr "Editor linea di comando:"
 
-#: ../data/prefs.glade.h:87
+#: ../data/prefs.glade.h:88
 #, no-c-format
 msgid ""
 "<small><i>Use the following elements in the open editor command line:\n"
@@ -508,11 +512,11 @@ msgstr ""
 "Per esempio, per sublime, usa <b>subl %(file_path)s:%(line_number)s</b>\n"
 "</i></small>"
 
-#: ../data/prefs.glade.h:93
+#: ../data/prefs.glade.h:94
 msgid "Quick open in current terminal"
 msgstr "Apertura rapida nel terminale corrente"
 
-#: ../data/prefs.glade.h:94
+#: ../data/prefs.glade.h:95
 msgid ""
 "Here is the list of supported patterns: (to add your own, please contact the "
 "Guake's authors)"
@@ -520,15 +524,15 @@ msgstr ""
 "Ecco la lista dei pattern supportati: (per aggiungere il tuo, per favore "
 "contatta gli autori di Guake)"
 
-#: ../data/prefs.glade.h:95
+#: ../data/prefs.glade.h:96
 msgid "<b>Quick Open</b>"
 msgstr "<b>Apertura Rapida</b>"
 
-#: ../data/prefs.glade.h:96
+#: ../data/prefs.glade.h:97
 msgid "Quick Open"
 msgstr "Apertura Rapida"
 
-#: ../data/prefs.glade.h:97
+#: ../data/prefs.glade.h:98
 msgid ""
 "To change a shortcut simply click on its name.\n"
 "To disable a shortcut, press the \"Backspace\" key."
@@ -536,11 +540,11 @@ msgstr ""
 "Per cambiare una scorciatoia, clicca sul suo nome.\n"
 "Per disabilitare una scorciatoia, premi il tasto \"Backspace\"."
 
-#: ../data/prefs.glade.h:99
+#: ../data/prefs.glade.h:100
 msgid "Keyboard shortcuts"
 msgstr "Scorciatoie da tastiera"
 
-#: ../data/prefs.glade.h:100
+#: ../data/prefs.glade.h:101
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -552,7 +556,7 @@ msgstr ""
 "applicazioni e sistemi operativi che si aspettano un diverso funzionamento "
 "del terminale.</i></small>"
 
-#: ../data/prefs.glade.h:101
+#: ../data/prefs.glade.h:102
 msgid ""
 "ASCII DEL\n"
 "Escape sequence\n"
@@ -562,37 +566,36 @@ msgstr ""
 "Escape sequence\n"
 "Control-H"
 
-#: ../data/prefs.glade.h:104
+#: ../data/prefs.glade.h:105
 msgid "_Backspace key generates:"
 msgstr "Il tasto _Backspace genera:"
 
-#: ../data/prefs.glade.h:105
+#: ../data/prefs.glade.h:106
 msgid "_Delete key generates:"
 msgstr "Il tasto _Canc genera:"
 
-#: ../data/prefs.glade.h:106
+#: ../data/prefs.glade.h:107
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "_Ripristina valori di default per le opzioni di compatibilità"
 
-#: ../data/prefs.glade.h:107
+#: ../data/prefs.glade.h:108
 msgid "<b>Keyboard compatibility</b>"
 msgstr "<b>Compatibilità tastiera</b>"
 
-#: ../data/prefs.glade.h:108
+#: ../data/prefs.glade.h:109
 msgid "Compatibility"
 msgstr "Compatibilità"
 
-#: ../src/guake/about.py:47 ../src/guake/gconfhandler.py:427
-#: ../src/guake/guake_app.py:177 ../src/guake/guake_app.py:348
+#: ../src/guake/about.py:47 ../src/guake/gconfhandler.py:435
+#: ../src/guake/guake_app.py:181 ../src/guake/guake_app.py:376
 msgid "Guake Terminal"
 msgstr "Guake Terminal"
 
-#. Adding a new radio button to the tabbar
-#: ../src/guake/gconfhandler.py:365 ../src/guake/guake_app.py:1548
+#: ../src/guake/gconfhandler.py:368 ../src/guake/guake_app.py:1363
 msgid "Terminal"
 msgstr "Terminale"
 
-#: ../src/guake/gconfhandler.py:428
+#: ../src/guake/gconfhandler.py:436
 #, python-format
 msgid ""
 "A problem happened when binding <b>%s</b> key.\n"
@@ -602,49 +605,49 @@ msgstr ""
 "Per favore usa la finestra delle preferenze di Guake per scegliere un nuovo "
 "tasto (è stata abilitata l'icona nel vassoio)"
 
-#: ../src/guake/guake_app.py:128
+#: ../src/guake/guake_app.py:132
 msgid "Do you want to close the tab?"
 msgstr "Vuoi chiudere la scheda?"
 
-#: ../src/guake/guake_app.py:131
+#: ../src/guake/guake_app.py:135
 msgid "Do you really want to quit Guake?"
 msgstr "Vuoi davvero uscire da Guake?"
 
-#: ../src/guake/guake_app.py:133
+#: ../src/guake/guake_app.py:137
 msgid " and one tab open"
 msgstr "ed una scheda aperta"
 
-#: ../src/guake/guake_app.py:135
+#: ../src/guake/guake_app.py:139
 #, python-brace-format
 msgid " and {0} tabs open"
 msgstr "e {0} schede aperte"
 
-#: ../src/guake/guake_app.py:138
+#: ../src/guake/guake_app.py:142
 msgid "There are no processes running"
 msgstr "Non ci sono processi in esecuzione"
 
-#: ../src/guake/guake_app.py:140
+#: ../src/guake/guake_app.py:144
 msgid "There is a process still running"
 msgstr "Un processo è ancora in esecuzione"
 
-#: ../src/guake/guake_app.py:142
+#: ../src/guake/guake_app.py:146
 #, python-brace-format
 msgid "There are {0} processes still running"
 msgstr "Ci sono {0} processi in esecuzione"
 
-#: ../src/guake/guake_app.py:182
+#: ../src/guake/guake_app.py:186
 msgid "guake-indicator"
 msgstr "guake-indicator"
 
-#: ../src/guake/guake_app.py:182
+#: ../src/guake/guake_app.py:186
 msgid "guake-tray"
 msgstr "guake-tray"
 
-#: ../src/guake/guake_app.py:186
+#: ../src/guake/guake_app.py:190
 msgid "Show"
 msgstr "Mostra"
 
-#: ../src/guake/guake_app.py:349
+#: ../src/guake/guake_app.py:377
 #, python-format
 msgid ""
 "Guake is now running,\n"
@@ -653,134 +656,139 @@ msgstr ""
 "Guake è in esecuzione,\n"
 "premere <b>%s</b> per usarlo."
 
-#: ../src/guake/guake_app.py:611
+#: ../src/guake/guake_app.py:665
 #, python-format
 msgid "Search on Web: '%s'"
 msgstr "Cerca sul Web: '%s'"
 
-#: ../src/guake/guake_app.py:616
+#: ../src/guake/guake_app.py:670
 msgid "Search on Web (no selection)"
 msgstr "Cerca sul Web (nessuna selezione)"
 
-#: ../src/guake/guake_app.py:622
+#: ../src/guake/guake_app.py:678
+#, fuzzy
+msgid "Open Link: '{}...'"
+msgstr "Apri Link: {}"
+
+#: ../src/guake/guake_app.py:680
 msgid "Open Link: {}"
 msgstr "Apri Link: {}"
 
-#: ../src/guake/guake_app.py:625
+#: ../src/guake/guake_app.py:683
 msgid "Open Link..."
 msgstr "Apri Link..."
 
-#: ../src/guake/guake_app.py:1300
+#: ../src/guake/guake_app.py:1402
 msgid "Rename tab"
 msgstr "Rinominare scheda"
 
-#: ../src/guake/guake_app.py:1591
+#: ../src/guake/guake_app.py:1716
 msgid "Save to..."
 msgstr "Salva come..."
 
-#: ../src/guake/guake_app.py:1598 ../src/guake/prefs.py:930
+#: ../src/guake/guake_app.py:1723 ../src/guake/prefs.py:998
 msgid "All files"
 msgstr "Tutti i file"
 
-#: ../src/guake/guake_app.py:1603
+#: ../src/guake/guake_app.py:1728
 msgid "Text and Logs"
 msgstr "Testi e Registri"
 
-#: ../src/guake/guake_app.py:1621
+#: ../src/guake/guake_app.py:1746
 msgid "Find"
 msgstr "Cerca"
 
-#: ../src/guake/guake_app.py:1623
+#: ../src/guake/guake_app.py:1748
 msgid "Forward"
 msgstr "Avanti"
 
-#: ../src/guake/guake_app.py:1624
+#: ../src/guake/guake_app.py:1749
 msgid "Backward"
 msgstr "Indietro"
 
-#: ../src/guake/main.py:67
+#: ../src/guake/main.py:68
 msgid "Put Guake in fullscreen mode"
 msgstr "Imposta Guake a schermo intero"
 
-#: ../src/guake/main.py:71
+#: ../src/guake/main.py:72
 msgid "Toggles the visibility of the terminal window"
 msgstr "Alterna la visibilità della finestra del terminale"
 
-#: ../src/guake/main.py:75
+#: ../src/guake/main.py:76
 msgid "Shows Guake main window"
 msgstr "Mostra la finestra principale di Guake"
 
-#: ../src/guake/main.py:79
+#: ../src/guake/main.py:80
 msgid "Hides Guake main window"
 msgstr "Nasconde la finestra principale di Guake"
 
-#: ../src/guake/main.py:83
+#: ../src/guake/main.py:84
 msgid "Shows Guake preference window"
 msgstr "Mostra la finestra delle preferenze di Guake"
 
-#: ../src/guake/main.py:87
+#: ../src/guake/main.py:88
 msgid "Shows Guake's about info"
 msgstr "Mostra le informazioni su Guake"
 
-#: ../src/guake/main.py:91
+#: ../src/guake/main.py:92
 msgid "Add a new tab (with current directory set to NEW_TAB)"
 msgstr "Apri una nuova scheda (con cartella corrente impostata a NEW_TAB)"
 
-#: ../src/guake/main.py:95
+#: ../src/guake/main.py:96
 msgid "Select a tab (SELECT_TAB is the index of the tab)"
 msgstr "Seleziona una scheda (SELECT_TAB è l'indice della scheda)"
 
-#: ../src/guake/main.py:99
+#: ../src/guake/main.py:100
 msgid "Return the selected tab index."
 msgstr "Restituisce l'indice della scheda selezionata."
 
-#: ../src/guake/main.py:103
+#: ../src/guake/main.py:104
 msgid "Execute an arbitrary command in the selected tab."
 msgstr "Esegue un comando arbitrario nella scheda selezionata."
 
-#: ../src/guake/main.py:107
+#: ../src/guake/main.py:108
 msgid "Specify the tab to rename. Default is 0."
 msgstr "Specifica la tabella da rinominare. La predefinita è la 0."
 
-#: ../src/guake/main.py:111
+#: ../src/guake/main.py:112
 msgid "Set the hexadecimal (#rrggbb) background color of the selected tab."
 msgstr ""
 "Imposta il colore di sfondo in esadecimale (#rrggbb) per la scheda "
 "selezionata."
 
-#: ../src/guake/main.py:116
+#: ../src/guake/main.py:117
 msgid "Set the hexadecimal (#rrggbb) foreground color of the selected tab."
 msgstr ""
 "Imposta il colore d'evidenza in esadecimale (#rrggbb) della scheda "
 "selezionata."
 
-#: ../src/guake/main.py:122
+#: ../src/guake/main.py:123
 msgid ""
 "Rename the specified tab. Reset to default if TITLE is a single dash \"-\"."
 msgstr ""
 "Rinomina la scheda selezionata. Resetta al nome predefinito se TITLE è un "
 "trattino singolo \"-\"."
 
-#: ../src/guake/main.py:128
+#: ../src/guake/main.py:129
 msgid ""
 "Rename the current tab. Reset to default if TITLE is a single dash \"-\"."
 msgstr ""
 "Rinomina la scheda corrent. Resetta al nome predefinito se TITLE è un "
 "trattino singolo \"-\"."
 
-#: ../src/guake/main.py:133
+#: ../src/guake/main.py:134
 msgid "Says to Guake go away =("
 msgstr "Chiude Guake =("
 
-#: ../src/guake/main.py:137
+#: ../src/guake/main.py:138
 msgid "Do not execute the start up script"
 msgstr "Non eseguire lo script d'avvio"
 
-#: ../src/guake/main.py:231
+#: ../src/guake/main.py:235
 msgid "Guake can not init!"
 msgstr "Impossibile far partire Guake!"
 
-#: ../src/guake/main.py:232
+#: ../src/guake/main.py:236
 msgid ""
 "Gconf Error.\n"
 "Have you installed <b>guake.schemas</b> properly?"
@@ -793,32 +801,191 @@ msgstr ""
 msgid "<user shell>"
 msgstr "<shell utente>"
 
-#: ../src/guake/prefs.py:467
+#: ../src/guake/prefs.py:77
+msgid "Toggle Guake visibility"
+msgstr "Alterna visibilità di Guake"
+
+#: ../src/guake/prefs.py:81
+#, fuzzy
+msgid "Toggle Hide on Lose Focus"
+msgstr "Nascondere alla perdita del focus"
+
+#: ../src/guake/prefs.py:88
+msgid "Tab management"
+msgstr "Gestione schede"
+
+#: ../src/guake/prefs.py:90
+#, fuzzy
+msgid "New tab"
+msgstr "Nuova scheda"
+
+#: ../src/guake/prefs.py:92
+msgid "Close tab"
+msgstr "Chiudi scheda"
+
+#: ../src/guake/prefs.py:94
+msgid "Rename current tab"
+msgstr "Rinomina scheda corrente"
+
+#: ../src/guake/prefs.py:97
+msgid "Navigation"
+msgstr "Navigazione"
+
+#: ../src/guake/prefs.py:99
+msgid "Go to previous tab"
+msgstr "Vai alla scheda precedente"
+
+#: ../src/guake/prefs.py:101
+msgid "Go to next tab"
+msgstr "Vai alla prossima scheda"
+
+#: ../src/guake/prefs.py:103
+#, fuzzy
+msgid "Move current tab left"
+msgstr "Rinomina scheda corrente"
+
+#: ../src/guake/prefs.py:105
+#, fuzzy
+msgid "Move current tab right"
+msgstr "Rinomina scheda corrente"
+
+#: ../src/guake/prefs.py:107
+#, fuzzy
+msgid "Go to first tab"
+msgstr "Vai alla prossima scheda"
+
+#: ../src/guake/prefs.py:109
+#, fuzzy
+msgid "Go to second tab"
+msgstr "Vai alla prossima scheda"
+
+#: ../src/guake/prefs.py:111
+#, fuzzy
+msgid "Go to third tab"
+msgstr "Vai alla prossima scheda"
+
+#: ../src/guake/prefs.py:113
+#, fuzzy
+msgid "Go to fourth tab"
+msgstr "Vai alla prossima scheda"
+
+#: ../src/guake/prefs.py:115
+#, fuzzy
+msgid "Go to fifth tab"
+msgstr "Vai alla prossima scheda"
+
+#: ../src/guake/prefs.py:117
+#, fuzzy
+msgid "Go to sixth tab"
+msgstr "Vai alla prossima scheda"
+
+#: ../src/guake/prefs.py:119
+#, fuzzy
+msgid "Go to seventh tab"
+msgstr "Vai alla prossima scheda"
+
+#: ../src/guake/prefs.py:121
+#, fuzzy
+msgid "Go to eighth tab"
+msgstr "Vai alla prossima scheda"
+
+#: ../src/guake/prefs.py:123
+#, fuzzy
+msgid "Go to ninth tab"
+msgstr "Vai alla prossima scheda"
+
+#: ../src/guake/prefs.py:125
+#, fuzzy
+msgid "Go to tenth tab"
+msgstr "Vai alla prossima scheda"
+
+#: ../src/guake/prefs.py:127
+#, fuzzy
+msgid "Go to last tab"
+msgstr "Vai alla prossima scheda"
+
+#: ../src/guake/prefs.py:132
+msgid "Zoom out"
+msgstr ""
+
+#: ../src/guake/prefs.py:134
+msgid "Zoom in"
+msgstr ""
+
+#: ../src/guake/prefs.py:136
+msgid "Zoom in (alternative)"
+msgstr ""
+
+#: ../src/guake/prefs.py:138
+msgid "Increase height"
+msgstr ""
+
+#: ../src/guake/prefs.py:140
+msgid "Decrease height"
+msgstr ""
+
+#: ../src/guake/prefs.py:142
+#, fuzzy
+msgid "Increase transparency"
+msgstr "Trasparenza:"
+
+#: ../src/guake/prefs.py:144
+#, fuzzy
+msgid "Decrease transparency"
+msgstr "Trasparenza:"
+
+#: ../src/guake/prefs.py:146
+#, fuzzy
+msgid "Toggle transparency"
+msgstr "Trasparenza:"
+
+#: ../src/guake/prefs.py:149
+msgid "Clipboard"
+msgstr "Appunti"
+
+#: ../src/guake/prefs.py:151
+msgid "Copy text to clipboard"
+msgstr "Copia testo negli appunti"
+
+#: ../src/guake/prefs.py:153
+msgid "Paste text from clipboard"
+msgstr "Incolla testo dagli appunti"
+
+#: ../src/guake/prefs.py:156
+msgid "Extra features"
+msgstr ""
+
+#: ../src/guake/prefs.py:159
+#, fuzzy
+msgid "Search select text on web"
+msgstr "Cerca sul Web"
+
+#: ../src/guake/prefs.py:519
 msgid "Action"
 msgstr "Azione"
 
-#: ../src/guake/prefs.py:477
+#: ../src/guake/prefs.py:529
 msgid "Shortcut"
 msgstr "Scorciatoia"
 
-#: ../src/guake/prefs.py:619 ../src/guake/prefs.py:665
+#: ../src/guake/prefs.py:678 ../src/guake/prefs.py:724
 msgid "Custom"
 msgstr "Personalizzato"
 
-#: ../src/guake/prefs.py:926
+#: ../src/guake/prefs.py:994
 msgid "JSON files"
 msgstr "File JSON"
 
-#: ../src/guake/prefs.py:1019
+#: ../src/guake/prefs.py:1088
 #, python-format
 msgid "The shortcut \"%s\" is already in use."
 msgstr "La scorciatoia \"%s\" è già in uso."
 
-#: ../src/guake/prefs.py:1020
+#: ../src/guake/prefs.py:1089
 msgid "Error setting keybinding."
 msgstr "Errore impostazione scorciatoia."
 
-#: ../src/guake/prefs.py:1032
+#: ../src/guake/prefs.py:1101
 #, python-format
 msgid ""
 "The shortcut \"%s\" cannot be used because it will become impossible to type "
@@ -859,36 +1026,6 @@ msgstr ""
 
 #~ msgid "Rename the selected tab."
 #~ msgstr "Rinomina la scheda selezionata."
-
-#~ msgid "Toggle Guake visibility"
-#~ msgstr "Alterna visibilità di Guake"
-
-#~ msgid "Tab management"
-#~ msgstr "Gestione schede"
-
-#~ msgid "Close tab"
-#~ msgstr "Chiudi scheda"
-
-#~ msgid "Rename current tab"
-#~ msgstr "Rinomina scheda corrente"
-
-#~ msgid "Navigation"
-#~ msgstr "Navigazione"
-
-#~ msgid "Go to previous tab"
-#~ msgstr "Vai alla scheda precedente"
-
-#~ msgid "Go to next tab"
-#~ msgstr "Vai alla prossima scheda"
-
-#~ msgid "Clipboard"
-#~ msgstr "Appunti"
-
-#~ msgid "Copy text to clipboard"
-#~ msgstr "Copia testo negli appunti"
-
-#~ msgid "Paste text from clipboard"
-#~ msgstr "Incolla testo dagli appunti"
 
 #~ msgid "<b>Background</b>"
 #~ msgstr "<b>Sfondo</b>"

--- a/po/ja.po
+++ b/po/ja.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Guake 0.4.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-12-01 16:49+0100\n"
+"POT-Creation-Date: 2016-08-17 21:41+0000\n"
 "PO-Revision-Date: 2010-07-24 14:58+0900\n"
 "Last-Translator: Nishio Futoshi <futoshi@momonga-linux.org>\n"
 "Language-Team: guake@lists.guake.org\n"
@@ -86,7 +86,7 @@ msgstr "コピー"
 msgid "Paste"
 msgstr "貼り付け"
 
-#: ../data/guake.glade.h:3
+#: ../data/guake.glade.h:3 ../src/guake/prefs.py:79
 msgid "Toggle Fullscreen"
 msgstr "全画面表示"
 
@@ -94,7 +94,7 @@ msgstr "全画面表示"
 msgid "Save to File..."
 msgstr ""
 
-#: ../data/guake.glade.h:5
+#: ../data/guake.glade.h:5 ../src/guake/prefs.py:85
 #, fuzzy
 msgid "Reset terminal"
 msgstr "Guake 端末"
@@ -124,7 +124,7 @@ msgstr ""
 msgid "Search on Web"
 msgstr ""
 
-#: ../data/guake.glade.h:12
+#: ../data/guake.glade.h:12 ../src/guake/prefs.py:83
 msgid "Quit"
 msgstr "終了"
 
@@ -247,202 +247,206 @@ msgid "Use VTE titles for tab names"
 msgstr ""
 
 #: ../data/prefs.glade.h:33
-msgid "Max tab name length:"
+msgid "Abbreviate directories in tab names"
 msgstr ""
 
 #: ../data/prefs.glade.h:34
+msgid "Max tab name length:"
+msgstr ""
+
+#: ../data/prefs.glade.h:35
 msgid "Hide on lose focus"
 msgstr "フォーカスを失ったら隠す"
 
-#: ../data/prefs.glade.h:35
+#: ../data/prefs.glade.h:36
 msgid "Show tab bar"
 msgstr "タブバーを表示する"
 
-#: ../data/prefs.glade.h:36
+#: ../data/prefs.glade.h:37
 #, fuzzy
 msgid "Start fullscreen"
 msgstr "全画面表示"
 
-#: ../data/prefs.glade.h:37
+#: ../data/prefs.glade.h:38
 msgid "<b>Main Window</b>"
 msgstr "<b>メインウィンドウ</b>"
 
-#: ../data/prefs.glade.h:38
+#: ../data/prefs.glade.h:39
 msgid "Left"
 msgstr ""
 
-#: ../data/prefs.glade.h:39
+#: ../data/prefs.glade.h:40
 msgid "Center"
 msgstr ""
 
-#: ../data/prefs.glade.h:40
+#: ../data/prefs.glade.h:41
 msgid "Right"
 msgstr ""
 
-#: ../data/prefs.glade.h:41
+#: ../data/prefs.glade.h:42
 #, fuzzy
 msgid "<b>Main Window Horizontal Alignment</b>"
 msgstr "<b>ウィンドウサイズ</b>"
 
-#: ../data/prefs.glade.h:42
+#: ../data/prefs.glade.h:43
 #, fuzzy
 msgid "<b>Main Window Height</b>"
 msgstr "<b>メインウィンドウの高さ</b>"
 
-#: ../data/prefs.glade.h:43
+#: ../data/prefs.glade.h:44
 #, fuzzy
 msgid "<b>Main Window Width</b>"
 msgstr "<b>メインウィンドウの高さ</b>"
 
-#: ../data/prefs.glade.h:44
+#: ../data/prefs.glade.h:45
 msgid "Custom command file path: "
 msgstr ""
 
-#: ../data/prefs.glade.h:45
+#: ../data/prefs.glade.h:46
 msgid "Please select a json file"
 msgstr ""
 
-#: ../data/prefs.glade.h:46
+#: ../data/prefs.glade.h:47 ../src/guake/prefs.py:75
 msgid "General"
 msgstr "全般"
 
-#: ../data/prefs.glade.h:47
+#: ../data/prefs.glade.h:48
 msgid "Default interpreter:"
 msgstr "デフォルトのシェル:"
 
-#: ../data/prefs.glade.h:48
+#: ../data/prefs.glade.h:49
 msgid "_Run command as a login shell"
 msgstr "ログイン・シェルとしてコマンドを実行する(_R)"
 
-#: ../data/prefs.glade.h:49
+#: ../data/prefs.glade.h:50
 msgid "_Open new tab in current directory"
 msgstr "カレントディレクトリを新しいタブに開く(_O)"
 
-#: ../data/prefs.glade.h:50
+#: ../data/prefs.glade.h:51
 msgid "<b>Shell</b>"
 msgstr "<b>シェル</b>"
 
-#: ../data/prefs.glade.h:51
+#: ../data/prefs.glade.h:52
 msgid "Shell"
 msgstr ""
 
-#: ../data/prefs.glade.h:52
+#: ../data/prefs.glade.h:53
 msgid "Show scrollbar"
 msgstr "スクロールバーを表示する"
 
-#: ../data/prefs.glade.h:53
+#: ../data/prefs.glade.h:54
 msgid "Scrollback lines:"
 msgstr "スクロールバック行:"
 
-#: ../data/prefs.glade.h:54
+#: ../data/prefs.glade.h:55
 msgid "On output"
 msgstr "出力するたびにスクロールする"
 
-#: ../data/prefs.glade.h:55
+#: ../data/prefs.glade.h:56
 msgid "On key stroke"
 msgstr "キー入力するたびにスクロールする"
 
-#: ../data/prefs.glade.h:56
+#: ../data/prefs.glade.h:57
 msgid "<b>Scroll</b>"
 msgstr "<b>スクロール</b>"
 
-#: ../data/prefs.glade.h:57
+#: ../data/prefs.glade.h:58
 msgid "Scrolling"
 msgstr "スクロール"
 
-#: ../data/prefs.glade.h:58
+#: ../data/prefs.glade.h:59
 msgid "Use the system fixed width font"
 msgstr "\"固定幅のフォント\" を使用する"
 
-#: ../data/prefs.glade.h:59
+#: ../data/prefs.glade.h:60
 msgid "Font:"
 msgstr "フォント:"
 
-#: ../data/prefs.glade.h:60
+#: ../data/prefs.glade.h:61
 msgid "Choose some font"
 msgstr "フォントの選択"
 
-#: ../data/prefs.glade.h:61
+#: ../data/prefs.glade.h:62
 msgid "Text color:"
 msgstr "文字の色:"
 
-#: ../data/prefs.glade.h:62
+#: ../data/prefs.glade.h:63
 msgid "Background color:"
 msgstr "背景色"
 
-#: ../data/prefs.glade.h:63
+#: ../data/prefs.glade.h:64
 msgid "Cursor shape:"
 msgstr ""
 
-#: ../data/prefs.glade.h:64
+#: ../data/prefs.glade.h:65
 msgid ""
 "Block\n"
 "I-Beam\n"
 "Underline"
 msgstr ""
 
-#: ../data/prefs.glade.h:67
+#: ../data/prefs.glade.h:68
 msgid ""
 "Follow GTK+ setting\n"
 "Blink on\n"
 "Blink off"
 msgstr ""
 
-#: ../data/prefs.glade.h:70
+#: ../data/prefs.glade.h:71
 msgid "Cursor blink mode:"
 msgstr ""
 
-#: ../data/prefs.glade.h:71
+#: ../data/prefs.glade.h:72
 msgid "Allow bold font"
 msgstr ""
 
-#: ../data/prefs.glade.h:72
+#: ../data/prefs.glade.h:73
 msgid "<b>Palette</b>"
 msgstr "<b>パレット</b>"
 
-#: ../data/prefs.glade.h:73
+#: ../data/prefs.glade.h:74
 msgid "Built-in schemes:"
 msgstr "組み込みのスキーム:"
 
-#: ../data/prefs.glade.h:74
+#: ../data/prefs.glade.h:75
 msgid "Color palette:"
 msgstr "色:"
 
-#: ../data/prefs.glade.h:75
+#: ../data/prefs.glade.h:76
 #, fuzzy
 msgid "Font color"
 msgstr "文字の色:"
 
-#: ../data/prefs.glade.h:76
+#: ../data/prefs.glade.h:77
 #, fuzzy
 msgid "Background color"
 msgstr "背景色"
 
-#: ../data/prefs.glade.h:77
+#: ../data/prefs.glade.h:78
 msgid "Use font and background color from the palette"
 msgstr ""
 
-#: ../data/prefs.glade.h:78
+#: ../data/prefs.glade.h:79
 msgid "Demo:"
 msgstr ""
 
-#: ../data/prefs.glade.h:79
+#: ../data/prefs.glade.h:80
 msgid "<b>Effects</b>"
 msgstr "<b>効果</b>"
 
-#: ../data/prefs.glade.h:80
+#: ../data/prefs.glade.h:81
 msgid "Transparency:"
 msgstr "透明度:"
 
-#: ../data/prefs.glade.h:81
+#: ../data/prefs.glade.h:82
 msgid "Background image:"
 msgstr "背景の画像:"
 
-#: ../data/prefs.glade.h:82
+#: ../data/prefs.glade.h:83 ../src/guake/prefs.py:130
 msgid "Appearance"
 msgstr "外観"
 
-#: ../data/prefs.glade.h:83
+#: ../data/prefs.glade.h:84
 msgid ""
 "<small>Quick open is a feature allowing you to open a file directly into "
 "your favorite text editor by clicking on its filename when it appears in "
@@ -450,15 +454,15 @@ msgid ""
 "extract filename below.</small>"
 msgstr ""
 
-#: ../data/prefs.glade.h:84
+#: ../data/prefs.glade.h:85
 msgid "Enable Quick Open when Ctrl+clicking on a filename in the terminal"
 msgstr ""
 
-#: ../data/prefs.glade.h:85
+#: ../data/prefs.glade.h:86
 msgid "Editor command line:"
 msgstr ""
 
-#: ../data/prefs.glade.h:87
+#: ../data/prefs.glade.h:88
 #, no-c-format
 msgid ""
 "<small><i>Use the following elements in the open editor command line:\n"
@@ -470,36 +474,36 @@ msgid ""
 "</i></small>"
 msgstr ""
 
-#: ../data/prefs.glade.h:93
+#: ../data/prefs.glade.h:94
 msgid "Quick open in current terminal"
 msgstr ""
 
-#: ../data/prefs.glade.h:94
+#: ../data/prefs.glade.h:95
 msgid ""
 "Here is the list of supported patterns: (to add your own, please contact the "
 "Guake's authors)"
 msgstr ""
 
-#: ../data/prefs.glade.h:95
+#: ../data/prefs.glade.h:96
 #, fuzzy
 msgid "<b>Quick Open</b>"
 msgstr "<b>TABの位置</b>"
 
-#: ../data/prefs.glade.h:96
+#: ../data/prefs.glade.h:97
 msgid "Quick Open"
 msgstr ""
 
-#: ../data/prefs.glade.h:97
+#: ../data/prefs.glade.h:98
 msgid ""
 "To change a shortcut simply click on its name.\n"
 "To disable a shortcut, press the \"Backspace\" key."
 msgstr ""
 
-#: ../data/prefs.glade.h:99
+#: ../data/prefs.glade.h:100
 msgid "Keyboard shortcuts"
 msgstr "キーボードショートカット"
 
-#: ../data/prefs.glade.h:100
+#: ../data/prefs.glade.h:101
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -511,7 +515,7 @@ msgstr ""
 "OS 上で異なった動作になってしまう問題を解決するために提供されています。</i></"
 "small>"
 
-#: ../data/prefs.glade.h:101
+#: ../data/prefs.glade.h:102
 msgid ""
 "ASCII DEL\n"
 "Escape sequence\n"
@@ -521,38 +525,37 @@ msgstr ""
 "エスケープ・シーケンス\n"
 "Control-H"
 
-#: ../data/prefs.glade.h:104
+#: ../data/prefs.glade.h:105
 msgid "_Backspace key generates:"
 msgstr "[BS] キーが生成するコード(_B):"
 
-#: ../data/prefs.glade.h:105
+#: ../data/prefs.glade.h:106
 msgid "_Delete key generates:"
 msgstr "[DEL] キーが生成するコード(_D):"
 
-#: ../data/prefs.glade.h:106
+#: ../data/prefs.glade.h:107
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "互換性のオプションをデフォルトに戻す(_R)"
 
-#: ../data/prefs.glade.h:107
+#: ../data/prefs.glade.h:108
 msgid "<b>Keyboard compatibility</b>"
 msgstr "<b>キーボードの互換性</b>"
 
-#: ../data/prefs.glade.h:108
+#: ../data/prefs.glade.h:109
 msgid "Compatibility"
 msgstr "互換性"
 
-#: ../src/guake/about.py:47 ../src/guake/gconfhandler.py:427
-#: ../src/guake/guake_app.py:177 ../src/guake/guake_app.py:348
+#: ../src/guake/about.py:47 ../src/guake/gconfhandler.py:435
+#: ../src/guake/guake_app.py:181 ../src/guake/guake_app.py:376
 msgid "Guake Terminal"
 msgstr "Guake 端末"
 
-#. Adding a new radio button to the tabbar
-#: ../src/guake/gconfhandler.py:365 ../src/guake/guake_app.py:1548
+#: ../src/guake/gconfhandler.py:368 ../src/guake/guake_app.py:1363
 #, fuzzy
 msgid "Terminal"
 msgstr "端末 %s"
 
-#: ../src/guake/gconfhandler.py:428
+#: ../src/guake/gconfhandler.py:436
 #, python-format
 msgid ""
 "A problem happened when binding <b>%s</b> key.\n"
@@ -561,54 +564,54 @@ msgstr ""
 "<b>%s</b>キーの割り当てで問題が発生しました。\n"
 "設定画面で別のキーを選択してください。(通知エリアのアイコンが有効でした)"
 
-#: ../src/guake/guake_app.py:128
+#: ../src/guake/guake_app.py:132
 #, fuzzy
 msgid "Do you want to close the tab?"
 msgstr "本当に Guake を終了しますか?"
 
-#: ../src/guake/guake_app.py:131
+#: ../src/guake/guake_app.py:135
 #, fuzzy
 msgid "Do you really want to quit Guake?"
 msgstr "本当に Guake を終了しますか?"
 
-#: ../src/guake/guake_app.py:133
+#: ../src/guake/guake_app.py:137
 #, fuzzy
 msgid " and one tab open"
 msgstr "新しいタブを追加します"
 
-#: ../src/guake/guake_app.py:135
+#: ../src/guake/guake_app.py:139
 #, python-brace-format
 msgid " and {0} tabs open"
 msgstr ""
 
-#: ../src/guake/guake_app.py:138
+#: ../src/guake/guake_app.py:142
 #, fuzzy
 msgid "There are no processes running"
 msgstr "<b>1つのプロセスが実行中です</b>"
 
-#: ../src/guake/guake_app.py:140
+#: ../src/guake/guake_app.py:144
 #, fuzzy
 msgid "There is a process still running"
 msgstr "<b>1つのプロセスが実行中です</b>"
 
-#: ../src/guake/guake_app.py:142
+#: ../src/guake/guake_app.py:146
 #, fuzzy, python-brace-format
 msgid "There are {0} processes still running"
 msgstr "<b>%dつのプロセスが実行中です</b>"
 
-#: ../src/guake/guake_app.py:182
+#: ../src/guake/guake_app.py:186
 msgid "guake-indicator"
 msgstr ""
 
-#: ../src/guake/guake_app.py:182
+#: ../src/guake/guake_app.py:186
 msgid "guake-tray"
 msgstr ""
 
-#: ../src/guake/guake_app.py:186
+#: ../src/guake/guake_app.py:190
 msgid "Show"
 msgstr ""
 
-#: ../src/guake/guake_app.py:349
+#: ../src/guake/guake_app.py:377
 #, python-format
 msgid ""
 "Guake is now running,\n"
@@ -617,129 +620,133 @@ msgstr ""
 "Guakeを起動しました。\n"
 "<b>%s</b>を押すと表示されます。"
 
-#: ../src/guake/guake_app.py:611
+#: ../src/guake/guake_app.py:665
 #, python-format
 msgid "Search on Web: '%s'"
 msgstr ""
 
-#: ../src/guake/guake_app.py:616
+#: ../src/guake/guake_app.py:670
 msgid "Search on Web (no selection)"
 msgstr ""
 
-#: ../src/guake/guake_app.py:622
+#: ../src/guake/guake_app.py:678
+msgid "Open Link: '{}...'"
+msgstr ""
+
+#: ../src/guake/guake_app.py:680
 msgid "Open Link: {}"
 msgstr ""
 
-#: ../src/guake/guake_app.py:625
+#: ../src/guake/guake_app.py:683
 msgid "Open Link..."
 msgstr ""
 
-#: ../src/guake/guake_app.py:1300
+#: ../src/guake/guake_app.py:1402
 msgid "Rename tab"
 msgstr "タブの名前を変更"
 
-#: ../src/guake/guake_app.py:1591
+#: ../src/guake/guake_app.py:1716
 msgid "Save to..."
 msgstr ""
 
-#: ../src/guake/guake_app.py:1598 ../src/guake/prefs.py:930
+#: ../src/guake/guake_app.py:1723 ../src/guake/prefs.py:998
 msgid "All files"
 msgstr ""
 
-#: ../src/guake/guake_app.py:1603
+#: ../src/guake/guake_app.py:1728
 msgid "Text and Logs"
 msgstr ""
 
-#: ../src/guake/guake_app.py:1621
+#: ../src/guake/guake_app.py:1746
 msgid "Find"
 msgstr ""
 
-#: ../src/guake/guake_app.py:1623
+#: ../src/guake/guake_app.py:1748
 msgid "Forward"
 msgstr ""
 
-#: ../src/guake/guake_app.py:1624
+#: ../src/guake/guake_app.py:1749
 msgid "Backward"
 msgstr ""
 
-#: ../src/guake/main.py:67
+#: ../src/guake/main.py:68
 msgid "Put Guake in fullscreen mode"
 msgstr ""
 
-#: ../src/guake/main.py:71
+#: ../src/guake/main.py:72
 msgid "Toggles the visibility of the terminal window"
 msgstr "端末の表示を変更します"
 
-#: ../src/guake/main.py:75
+#: ../src/guake/main.py:76
 #, fuzzy
 msgid "Shows Guake main window"
 msgstr "Guakeの設定画面を表示します"
 
-#: ../src/guake/main.py:79
+#: ../src/guake/main.py:80
 #, fuzzy
 msgid "Hides Guake main window"
 msgstr "Guakeの設定画面を表示します"
 
-#: ../src/guake/main.py:83
+#: ../src/guake/main.py:84
 msgid "Shows Guake preference window"
 msgstr "Guakeの設定画面を表示します"
 
-#: ../src/guake/main.py:87
+#: ../src/guake/main.py:88
 msgid "Shows Guake's about info"
 msgstr "Guakeの情報を表示します"
 
-#: ../src/guake/main.py:91
+#: ../src/guake/main.py:92
 #, fuzzy
 msgid "Add a new tab (with current directory set to NEW_TAB)"
 msgstr "カレントディレクトリを新しいタブに開く(_O)"
 
-#: ../src/guake/main.py:95
+#: ../src/guake/main.py:96
 msgid "Select a tab (SELECT_TAB is the index of the tab)"
 msgstr ""
 
-#: ../src/guake/main.py:99
+#: ../src/guake/main.py:100
 msgid "Return the selected tab index."
 msgstr "選択したタブのインデックスを返す"
 
-#: ../src/guake/main.py:103
+#: ../src/guake/main.py:104
 msgid "Execute an arbitrary command in the selected tab."
 msgstr "選択したタブでコマンドを実行する"
 
-#: ../src/guake/main.py:107
+#: ../src/guake/main.py:108
 msgid "Specify the tab to rename. Default is 0."
 msgstr ""
 
-#: ../src/guake/main.py:111
+#: ../src/guake/main.py:112
 msgid "Set the hexadecimal (#rrggbb) background color of the selected tab."
 msgstr ""
 
-#: ../src/guake/main.py:116
+#: ../src/guake/main.py:117
 msgid "Set the hexadecimal (#rrggbb) foreground color of the selected tab."
 msgstr ""
 
-#: ../src/guake/main.py:122
+#: ../src/guake/main.py:123
 msgid ""
 "Rename the specified tab. Reset to default if TITLE is a single dash \"-\"."
 msgstr ""
 
-#: ../src/guake/main.py:128
+#: ../src/guake/main.py:129
 msgid ""
 "Rename the current tab. Reset to default if TITLE is a single dash \"-\"."
 msgstr ""
 
-#: ../src/guake/main.py:133
+#: ../src/guake/main.py:134
 msgid "Says to Guake go away =("
 msgstr "Guakeに消えてなくなれと言ってください (T_T)"
 
-#: ../src/guake/main.py:137
+#: ../src/guake/main.py:138
 msgid "Do not execute the start up script"
 msgstr ""
 
-#: ../src/guake/main.py:231
+#: ../src/guake/main.py:235
 msgid "Guake can not init!"
 msgstr "Guakeを初期化できません"
 
-#: ../src/guake/main.py:232
+#: ../src/guake/main.py:236
 #, fuzzy
 msgid ""
 "Gconf Error.\n"
@@ -753,32 +760,190 @@ msgstr ""
 msgid "<user shell>"
 msgstr "<ユーザのシェル>"
 
-#: ../src/guake/prefs.py:467
+#: ../src/guake/prefs.py:77
+msgid "Toggle Guake visibility"
+msgstr "端末表示の切り替え"
+
+#: ../src/guake/prefs.py:81
+#, fuzzy
+msgid "Toggle Hide on Lose Focus"
+msgstr "フォーカスを失ったら隠す"
+
+#: ../src/guake/prefs.py:88
+msgid "Tab management"
+msgstr "タブの管理"
+
+#: ../src/guake/prefs.py:90
+#, fuzzy
+msgid "New tab"
+msgstr "新規TAB"
+
+#: ../src/guake/prefs.py:92
+msgid "Close tab"
+msgstr "タブを閉じる"
+
+#: ../src/guake/prefs.py:94
+msgid "Rename current tab"
+msgstr "現在のタブの名前を変更"
+
+#: ../src/guake/prefs.py:97
+msgid "Navigation"
+msgstr "ナビゲーション"
+
+#: ../src/guake/prefs.py:99
+msgid "Go to previous tab"
+msgstr "前のタブに移動"
+
+#: ../src/guake/prefs.py:101
+msgid "Go to next tab"
+msgstr "次のタブに移動"
+
+#: ../src/guake/prefs.py:103
+#, fuzzy
+msgid "Move current tab left"
+msgstr "現在のタブの名前を変更"
+
+#: ../src/guake/prefs.py:105
+#, fuzzy
+msgid "Move current tab right"
+msgstr "現在のタブの名前を変更"
+
+#: ../src/guake/prefs.py:107
+#, fuzzy
+msgid "Go to first tab"
+msgstr "次のタブに移動"
+
+#: ../src/guake/prefs.py:109
+#, fuzzy
+msgid "Go to second tab"
+msgstr "次のタブに移動"
+
+#: ../src/guake/prefs.py:111
+#, fuzzy
+msgid "Go to third tab"
+msgstr "次のタブに移動"
+
+#: ../src/guake/prefs.py:113
+#, fuzzy
+msgid "Go to fourth tab"
+msgstr "次のタブに移動"
+
+#: ../src/guake/prefs.py:115
+#, fuzzy
+msgid "Go to fifth tab"
+msgstr "次のタブに移動"
+
+#: ../src/guake/prefs.py:117
+#, fuzzy
+msgid "Go to sixth tab"
+msgstr "次のタブに移動"
+
+#: ../src/guake/prefs.py:119
+#, fuzzy
+msgid "Go to seventh tab"
+msgstr "次のタブに移動"
+
+#: ../src/guake/prefs.py:121
+#, fuzzy
+msgid "Go to eighth tab"
+msgstr "次のタブに移動"
+
+#: ../src/guake/prefs.py:123
+#, fuzzy
+msgid "Go to ninth tab"
+msgstr "次のタブに移動"
+
+#: ../src/guake/prefs.py:125
+#, fuzzy
+msgid "Go to tenth tab"
+msgstr "次のタブに移動"
+
+#: ../src/guake/prefs.py:127
+#, fuzzy
+msgid "Go to last tab"
+msgstr "次のタブに移動"
+
+#: ../src/guake/prefs.py:132
+msgid "Zoom out"
+msgstr ""
+
+#: ../src/guake/prefs.py:134
+msgid "Zoom in"
+msgstr ""
+
+#: ../src/guake/prefs.py:136
+msgid "Zoom in (alternative)"
+msgstr ""
+
+#: ../src/guake/prefs.py:138
+msgid "Increase height"
+msgstr ""
+
+#: ../src/guake/prefs.py:140
+msgid "Decrease height"
+msgstr ""
+
+#: ../src/guake/prefs.py:142
+#, fuzzy
+msgid "Increase transparency"
+msgstr "透明度:"
+
+#: ../src/guake/prefs.py:144
+#, fuzzy
+msgid "Decrease transparency"
+msgstr "透明度:"
+
+#: ../src/guake/prefs.py:146
+#, fuzzy
+msgid "Toggle transparency"
+msgstr "透明度:"
+
+#: ../src/guake/prefs.py:149
+msgid "Clipboard"
+msgstr "クリップボード"
+
+#: ../src/guake/prefs.py:151
+msgid "Copy text to clipboard"
+msgstr "テキストをクリップボードにコピー"
+
+#: ../src/guake/prefs.py:153
+msgid "Paste text from clipboard"
+msgstr "クリップボードからテキストをペースト"
+
+#: ../src/guake/prefs.py:156
+msgid "Extra features"
+msgstr ""
+
+#: ../src/guake/prefs.py:159
+msgid "Search select text on web"
+msgstr ""
+
+#: ../src/guake/prefs.py:519
 msgid "Action"
 msgstr "動作"
 
-#: ../src/guake/prefs.py:477
+#: ../src/guake/prefs.py:529
 msgid "Shortcut"
 msgstr "ショートカット"
 
-#: ../src/guake/prefs.py:619 ../src/guake/prefs.py:665
+#: ../src/guake/prefs.py:678 ../src/guake/prefs.py:724
 msgid "Custom"
 msgstr ""
 
-#: ../src/guake/prefs.py:926
+#: ../src/guake/prefs.py:994
 msgid "JSON files"
 msgstr ""
 
-#: ../src/guake/prefs.py:1019
+#: ../src/guake/prefs.py:1088
 #, python-format
 msgid "The shortcut \"%s\" is already in use."
 msgstr "ショートカット \"%s\"は既に使用されています."
 
-#: ../src/guake/prefs.py:1020
+#: ../src/guake/prefs.py:1089
 msgid "Error setting keybinding."
 msgstr "ショートカットの設定中にエラーが起きました"
 
-#: ../src/guake/prefs.py:1032
+#: ../src/guake/prefs.py:1101
 #, python-format
 msgid ""
 "The shortcut \"%s\" cannot be used because it will become impossible to type "
@@ -819,36 +984,6 @@ msgstr ""
 
 #~ msgid "Rename the selected tab."
 #~ msgstr "選択したタブの名前を変更する"
-
-#~ msgid "Toggle Guake visibility"
-#~ msgstr "端末表示の切り替え"
-
-#~ msgid "Tab management"
-#~ msgstr "タブの管理"
-
-#~ msgid "Close tab"
-#~ msgstr "タブを閉じる"
-
-#~ msgid "Rename current tab"
-#~ msgstr "現在のタブの名前を変更"
-
-#~ msgid "Navigation"
-#~ msgstr "ナビゲーション"
-
-#~ msgid "Go to previous tab"
-#~ msgstr "前のタブに移動"
-
-#~ msgid "Go to next tab"
-#~ msgstr "次のタブに移動"
-
-#~ msgid "Clipboard"
-#~ msgstr "クリップボード"
-
-#~ msgid "Copy text to clipboard"
-#~ msgstr "テキストをクリップボードにコピー"
-
-#~ msgid "Paste text from clipboard"
-#~ msgstr "クリップボードからテキストをペースト"
 
 #~ msgid "<b>Background</b>"
 #~ msgstr "<b>背景</b>"

--- a/po/ko.po
+++ b/po/ko.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Guake 0.4.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-12-01 16:49+0100\n"
+"POT-Creation-Date: 2016-08-17 21:41+0000\n"
 "PO-Revision-Date: 2016-07-07 00:03-0700\n"
 "Last-Translator: Nessun Kim <nessunkim@gmail.com>\n"
 "Language-Team: \n"
@@ -101,7 +101,7 @@ msgstr "복사"
 msgid "Paste"
 msgstr "붙여넣기"
 
-#: ../data/guake.glade.h:3
+#: ../data/guake.glade.h:3 ../src/guake/prefs.py:79
 msgid "Toggle Fullscreen"
 msgstr "전체 화면 설정"
 
@@ -109,7 +109,7 @@ msgstr "전체 화면 설정"
 msgid "Save to File..."
 msgstr "파일로 저장"
 
-#: ../data/guake.glade.h:5
+#: ../data/guake.glade.h:5 ../src/guake/prefs.py:85
 msgid "Reset terminal"
 msgstr "터미널 초기화"
 
@@ -137,7 +137,7 @@ msgstr "링크 열기"
 msgid "Search on Web"
 msgstr "선택된 텍스트를 웹에 검색"
 
-#: ../data/guake.glade.h:12
+#: ../data/guake.glade.h:12 ../src/guake/prefs.py:83
 msgid "Quit"
 msgstr "닫기"
 
@@ -271,130 +271,134 @@ msgid "Use VTE titles for tab names"
 msgstr "탭 이름에 VTE 타일 사용하기"
 
 #: ../data/prefs.glade.h:33
+msgid "Abbreviate directories in tab names"
+msgstr ""
+
+#: ../data/prefs.glade.h:34
 msgid "Max tab name length:"
 msgstr "탭 이름 최대 길이:"
 
-#: ../data/prefs.glade.h:34
+#: ../data/prefs.glade.h:35
 msgid "Hide on lose focus"
 msgstr "포커스를 잃을 때 감추기"
 
-#: ../data/prefs.glade.h:35
+#: ../data/prefs.glade.h:36
 msgid "Show tab bar"
 msgstr "탭바 보이기"
 
-#: ../data/prefs.glade.h:36
+#: ../data/prefs.glade.h:37
 msgid "Start fullscreen"
 msgstr "전체화면으로 시작하기"
 
-#: ../data/prefs.glade.h:37
+#: ../data/prefs.glade.h:38
 msgid "<b>Main Window</b>"
 msgstr "<b>메인 윈도우</b>"
 
-#: ../data/prefs.glade.h:38
+#: ../data/prefs.glade.h:39
 msgid "Left"
 msgstr "왼쪽"
 
-#: ../data/prefs.glade.h:39
+#: ../data/prefs.glade.h:40
 msgid "Center"
 msgstr "가운데"
 
-#: ../data/prefs.glade.h:40
+#: ../data/prefs.glade.h:41
 msgid "Right"
 msgstr "오른쪽"
 
-#: ../data/prefs.glade.h:41
+#: ../data/prefs.glade.h:42
 msgid "<b>Main Window Horizontal Alignment</b>"
 msgstr "<b>메인 윈도우 수평 정렬</b>"
 
-#: ../data/prefs.glade.h:42
+#: ../data/prefs.glade.h:43
 msgid "<b>Main Window Height</b>"
 msgstr "<b>메인 윈도우 높이 설정</b>"
 
-#: ../data/prefs.glade.h:43
+#: ../data/prefs.glade.h:44
 msgid "<b>Main Window Width</b>"
 msgstr "<b>메인 윈도우 너미 설정</b>"
 
-#: ../data/prefs.glade.h:44
+#: ../data/prefs.glade.h:45
 msgid "Custom command file path: "
 msgstr "사용자 정의 명령어 파일 위치:"
 
-#: ../data/prefs.glade.h:45
+#: ../data/prefs.glade.h:46
 msgid "Please select a json file"
 msgstr "json 파일 선택"
 
-#: ../data/prefs.glade.h:46
+#: ../data/prefs.glade.h:47 ../src/guake/prefs.py:75
 msgid "General"
 msgstr "일반"
 
-#: ../data/prefs.glade.h:47
+#: ../data/prefs.glade.h:48
 msgid "Default interpreter:"
 msgstr "기본 인터프리터:"
 
-#: ../data/prefs.glade.h:48
+#: ../data/prefs.glade.h:49
 msgid "_Run command as a login shell"
 msgstr "로그인 쉘 실행시 명령어 실행"
 
-#: ../data/prefs.glade.h:49
+#: ../data/prefs.glade.h:50
 msgid "_Open new tab in current directory"
 msgstr "새 탭 생성시 현재 디렉토리로 설정"
 
-#: ../data/prefs.glade.h:50
+#: ../data/prefs.glade.h:51
 msgid "<b>Shell</b>"
 msgstr "<b>쉘</b>"
 
-#: ../data/prefs.glade.h:51
+#: ../data/prefs.glade.h:52
 msgid "Shell"
 msgstr "쉘"
 
-#: ../data/prefs.glade.h:52
+#: ../data/prefs.glade.h:53
 msgid "Show scrollbar"
 msgstr "스크롤바 보이기"
 
-#: ../data/prefs.glade.h:53
+#: ../data/prefs.glade.h:54
 msgid "Scrollback lines:"
 msgstr "스크롤 할 라인 수:"
 
-#: ../data/prefs.glade.h:54
+#: ../data/prefs.glade.h:55
 msgid "On output"
 msgstr "콘솔 출력시"
 
-#: ../data/prefs.glade.h:55
+#: ../data/prefs.glade.h:56
 msgid "On key stroke"
 msgstr "키가 눌렸을 때"
 
-#: ../data/prefs.glade.h:56
+#: ../data/prefs.glade.h:57
 msgid "<b>Scroll</b>"
 msgstr "<b>스크롤</b>"
 
-#: ../data/prefs.glade.h:57
+#: ../data/prefs.glade.h:58
 msgid "Scrolling"
 msgstr "스크롤"
 
-#: ../data/prefs.glade.h:58
+#: ../data/prefs.glade.h:59
 msgid "Use the system fixed width font"
 msgstr "시스템 폰트 사용"
 
-#: ../data/prefs.glade.h:59
+#: ../data/prefs.glade.h:60
 msgid "Font:"
 msgstr "글꼴:"
 
-#: ../data/prefs.glade.h:60
+#: ../data/prefs.glade.h:61
 msgid "Choose some font"
 msgstr "글꼴 선택"
 
-#: ../data/prefs.glade.h:61
+#: ../data/prefs.glade.h:62
 msgid "Text color:"
 msgstr "글자 색상:"
 
-#: ../data/prefs.glade.h:62
+#: ../data/prefs.glade.h:63
 msgid "Background color:"
 msgstr "배경색:"
 
-#: ../data/prefs.glade.h:63
+#: ../data/prefs.glade.h:64
 msgid "Cursor shape:"
 msgstr "커서 모양:"
 
-#: ../data/prefs.glade.h:64
+#: ../data/prefs.glade.h:65
 msgid ""
 "Block\n"
 "I-Beam\n"
@@ -404,7 +408,7 @@ msgstr ""
 "I-Beam\n"
 "밑줄"
 
-#: ../data/prefs.glade.h:67
+#: ../data/prefs.glade.h:68
 msgid ""
 "Follow GTK+ setting\n"
 "Blink on\n"
@@ -414,59 +418,59 @@ msgstr ""
 "깜빡임\n"
 "깜빡이지 않음"
 
-#: ../data/prefs.glade.h:70
+#: ../data/prefs.glade.h:71
 msgid "Cursor blink mode:"
 msgstr "커서 깜빡임:"
 
-#: ../data/prefs.glade.h:71
+#: ../data/prefs.glade.h:72
 msgid "Allow bold font"
 msgstr "볼드체 허용"
 
-#: ../data/prefs.glade.h:72
+#: ../data/prefs.glade.h:73
 msgid "<b>Palette</b>"
 msgstr "<b>팔레트</b>"
 
-#: ../data/prefs.glade.h:73
+#: ../data/prefs.glade.h:74
 msgid "Built-in schemes:"
 msgstr "지정된 테마:"
 
-#: ../data/prefs.glade.h:74
+#: ../data/prefs.glade.h:75
 msgid "Color palette:"
 msgstr "색상 파레트:"
 
-#: ../data/prefs.glade.h:75
+#: ../data/prefs.glade.h:76
 msgid "Font color"
 msgstr "글자 색상:"
 
-#: ../data/prefs.glade.h:76
+#: ../data/prefs.glade.h:77
 msgid "Background color"
 msgstr "배경색:"
 
-#: ../data/prefs.glade.h:77
+#: ../data/prefs.glade.h:78
 msgid "Use font and background color from the palette"
 msgstr "글자색과 배경색을 팔레트에서 가져오기"
 
-#: ../data/prefs.glade.h:78
+#: ../data/prefs.glade.h:79
 msgid "Demo:"
 msgstr "미리 보기:"
 
-#: ../data/prefs.glade.h:79
+#: ../data/prefs.glade.h:80
 msgid "<b>Effects</b>"
 msgstr "<b>효과</b>"
 
-#: ../data/prefs.glade.h:80
+#: ../data/prefs.glade.h:81
 msgid "Transparency:"
 msgstr "투명도:"
 
-#: ../data/prefs.glade.h:81
+#: ../data/prefs.glade.h:82
 msgid "Background image:"
 msgstr "배경 이미지:"
 
-#: ../data/prefs.glade.h:82
+#: ../data/prefs.glade.h:83 ../src/guake/prefs.py:130
 msgid "Appearance"
 msgstr "모양"
 
-#: ../data/prefs.glade.h:83
+#: ../data/prefs.glade.h:84
 msgid ""
 "<small>Quick open is a feature allowing you to open a file directly into "
 "your favorite text editor by clicking on its filename when it appears in "
@@ -476,15 +480,15 @@ msgstr ""
 "<small>빠른 열기는 파일명을 클릭하면 지정된 텍스트 에디터로 실행할 수 있는 기"
 "능입니다. 아래에서 현재 지원되는 패턴을 확인하실 수 있습니다.</small>"
 
-#: ../data/prefs.glade.h:84
+#: ../data/prefs.glade.h:85
 msgid "Enable Quick Open when Ctrl+clicking on a filename in the terminal"
 msgstr "빠른 열기 (파일 이름 위에서 Ctrl+클릭) 활성화"
 
-#: ../data/prefs.glade.h:85
+#: ../data/prefs.glade.h:86
 msgid "Editor command line:"
 msgstr "에디터 실행 명령어:"
 
-#: ../data/prefs.glade.h:87
+#: ../data/prefs.glade.h:88
 #, no-c-format
 msgid ""
 "<small><i>Use the following elements in the open editor command line:\n"
@@ -503,25 +507,25 @@ msgstr ""
 "다.\n"
 "</i></small>"
 
-#: ../data/prefs.glade.h:93
+#: ../data/prefs.glade.h:94
 msgid "Quick open in current terminal"
 msgstr "현재 터미널에서 빠른 열기 사용"
 
-#: ../data/prefs.glade.h:94
+#: ../data/prefs.glade.h:95
 msgid ""
 "Here is the list of supported patterns: (to add your own, please contact the "
 "Guake's authors)"
 msgstr "지원되는 패턴 목록: (추가하고 싶다면 Guake의 개발자에게 연락해 주세요)"
 
-#: ../data/prefs.glade.h:95
+#: ../data/prefs.glade.h:96
 msgid "<b>Quick Open</b>"
 msgstr "<b>빠른 열기</b>"
 
-#: ../data/prefs.glade.h:96
+#: ../data/prefs.glade.h:97
 msgid "Quick Open"
 msgstr "빠른 열기"
 
-#: ../data/prefs.glade.h:97
+#: ../data/prefs.glade.h:98
 msgid ""
 "To change a shortcut simply click on its name.\n"
 "To disable a shortcut, press the \"Backspace\" key."
@@ -529,11 +533,11 @@ msgstr ""
 "단축키를 변경하려면 클릭하세요.\n"
 "해당 단축키를 비활성화하고 싶다면, Backspace 키를 누르세요."
 
-#: ../data/prefs.glade.h:99
+#: ../data/prefs.glade.h:100
 msgid "Keyboard shortcuts"
 msgstr "키보드 단축키"
 
-#: ../data/prefs.glade.h:100
+#: ../data/prefs.glade.h:101
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -545,7 +549,7 @@ msgstr ""
 "한 행동을 유발 할 수 있기 때문에 확실한 경우에만 변경하시기 바랍니다.</i></"
 "small>"
 
-#: ../data/prefs.glade.h:101
+#: ../data/prefs.glade.h:102
 msgid ""
 "ASCII DEL\n"
 "Escape sequence\n"
@@ -555,37 +559,36 @@ msgstr ""
 "Escape sequence\n"
 "Control-H"
 
-#: ../data/prefs.glade.h:104
+#: ../data/prefs.glade.h:105
 msgid "_Backspace key generates:"
 msgstr "_Backspace 키가 생성:"
 
-#: ../data/prefs.glade.h:105
+#: ../data/prefs.glade.h:106
 msgid "_Delete key generates:"
 msgstr "_Delete 키가 생성:"
 
-#: ../data/prefs.glade.h:106
+#: ../data/prefs.glade.h:107
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "호환성 옵션을 모두 초기화"
 
-#: ../data/prefs.glade.h:107
+#: ../data/prefs.glade.h:108
 msgid "<b>Keyboard compatibility</b>"
 msgstr "<b>키보드 호환성</b>"
 
-#: ../data/prefs.glade.h:108
+#: ../data/prefs.glade.h:109
 msgid "Compatibility"
 msgstr "호환성"
 
-#: ../src/guake/about.py:47 ../src/guake/gconfhandler.py:427
-#: ../src/guake/guake_app.py:177 ../src/guake/guake_app.py:348
+#: ../src/guake/about.py:47 ../src/guake/gconfhandler.py:435
+#: ../src/guake/guake_app.py:181 ../src/guake/guake_app.py:376
 msgid "Guake Terminal"
 msgstr "Guake 터미널"
 
-#. Adding a new radio button to the tabbar
-#: ../src/guake/gconfhandler.py:365 ../src/guake/guake_app.py:1548
+#: ../src/guake/gconfhandler.py:368 ../src/guake/guake_app.py:1363
 msgid "Terminal"
 msgstr "터미널 %s"
 
-#: ../src/guake/gconfhandler.py:428
+#: ../src/guake/gconfhandler.py:436
 #, python-format
 msgid ""
 "A problem happened when binding <b>%s</b> key.\n"
@@ -594,49 +597,49 @@ msgstr ""
 "<b>%s</b> 키를 바인딩 할때 문제가 발생되었습니다.\n"
 "Guake 대화상자 설정 탭에서 다른키를 선택하여주세요."
 
-#: ../src/guake/guake_app.py:128
+#: ../src/guake/guake_app.py:132
 msgid "Do you want to close the tab?"
 msgstr "이 탭을 정말 닫습니까?"
 
-#: ../src/guake/guake_app.py:131
+#: ../src/guake/guake_app.py:135
 msgid "Do you really want to quit Guake?"
 msgstr "Guake를 정말로 종료합니까?"
 
-#: ../src/guake/guake_app.py:133
+#: ../src/guake/guake_app.py:137
 msgid " and one tab open"
 msgstr "새 탭 열기"
 
-#: ../src/guake/guake_app.py:135
+#: ../src/guake/guake_app.py:139
 #, python-brace-format
 msgid " and {0} tabs open"
 msgstr "탭 {0}개 열기"
 
-#: ../src/guake/guake_app.py:138
+#: ../src/guake/guake_app.py:142
 msgid "There are no processes running"
 msgstr "실행중인 프로세스가 없습니다."
 
-#: ../src/guake/guake_app.py:140
+#: ../src/guake/guake_app.py:144
 msgid "There is a process still running"
 msgstr "아직 프로세스가 실행중입니다."
 
-#: ../src/guake/guake_app.py:142
+#: ../src/guake/guake_app.py:146
 #, python-brace-format
 msgid "There are {0} processes still running"
 msgstr "아직 {0}개의 프로세스가 실행중입니다."
 
-#: ../src/guake/guake_app.py:182
+#: ../src/guake/guake_app.py:186
 msgid "guake-indicator"
 msgstr "guake 알림줄"
 
-#: ../src/guake/guake_app.py:182
+#: ../src/guake/guake_app.py:186
 msgid "guake-tray"
 msgstr "guake 트레이"
 
-#: ../src/guake/guake_app.py:186
+#: ../src/guake/guake_app.py:190
 msgid "Show"
 msgstr "보이기"
 
-#: ../src/guake/guake_app.py:349
+#: ../src/guake/guake_app.py:377
 #, python-format
 msgid ""
 "Guake is now running,\n"
@@ -645,126 +648,131 @@ msgstr ""
 "Guake 가 실행중입니다.,\n"
 "<b>%s</b> 키를 눌러서 실행합니다."
 
-#: ../src/guake/guake_app.py:611
+#: ../src/guake/guake_app.py:665
 #, python-format
 msgid "Search on Web: '%s'"
 msgstr "'%s' 웹에서 검색"
 
-#: ../src/guake/guake_app.py:616
+#: ../src/guake/guake_app.py:670
 msgid "Search on Web (no selection)"
 msgstr "웹에서 검색 (선택 안 함)"
 
-#: ../src/guake/guake_app.py:622
+#: ../src/guake/guake_app.py:678
+#, fuzzy
+msgid "Open Link: '{}...'"
+msgstr "링크 열기: {}"
+
+#: ../src/guake/guake_app.py:680
 msgid "Open Link: {}"
 msgstr "링크 열기: {}"
 
-#: ../src/guake/guake_app.py:625
+#: ../src/guake/guake_app.py:683
 msgid "Open Link..."
 msgstr "링크 열기"
 
-#: ../src/guake/guake_app.py:1300
+#: ../src/guake/guake_app.py:1402
 msgid "Rename tab"
 msgstr "탭 이름변경"
 
-#: ../src/guake/guake_app.py:1591
+#: ../src/guake/guake_app.py:1716
 msgid "Save to..."
 msgstr "다음으로 저장"
 
-#: ../src/guake/guake_app.py:1598 ../src/guake/prefs.py:930
+#: ../src/guake/guake_app.py:1723 ../src/guake/prefs.py:998
 msgid "All files"
 msgstr "모든 파일"
 
-#: ../src/guake/guake_app.py:1603
+#: ../src/guake/guake_app.py:1728
 msgid "Text and Logs"
 msgstr "텍스트와 로그"
 
-#: ../src/guake/guake_app.py:1621
+#: ../src/guake/guake_app.py:1746
 msgid "Find"
 msgstr "찾기"
 
-#: ../src/guake/guake_app.py:1623
+#: ../src/guake/guake_app.py:1748
 msgid "Forward"
 msgstr "다음으로"
 
-#: ../src/guake/guake_app.py:1624
+#: ../src/guake/guake_app.py:1749
 msgid "Backward"
 msgstr "이전으로"
 
-#: ../src/guake/main.py:67
+#: ../src/guake/main.py:68
 msgid "Put Guake in fullscreen mode"
 msgstr "전체화면으로"
 
-#: ../src/guake/main.py:71
+#: ../src/guake/main.py:72
 msgid "Toggles the visibility of the terminal window"
 msgstr "터미널 창 보이기/숨기기 토글"
 
-#: ../src/guake/main.py:75
+#: ../src/guake/main.py:76
 msgid "Shows Guake main window"
 msgstr "Guake 메인 화면 보이기"
 
-#: ../src/guake/main.py:79
+#: ../src/guake/main.py:80
 msgid "Hides Guake main window"
 msgstr "Guake 메인 화면 숨기기"
 
-#: ../src/guake/main.py:83
+#: ../src/guake/main.py:84
 msgid "Shows Guake preference window"
 msgstr "Guake 설정 윈도우 보이기"
 
-#: ../src/guake/main.py:87
+#: ../src/guake/main.py:88
 msgid "Shows Guake's about info"
 msgstr "Guake 정보 보기"
 
-#: ../src/guake/main.py:91
+#: ../src/guake/main.py:92
 msgid "Add a new tab (with current directory set to NEW_TAB)"
 msgstr "새 탭 생성시 현재 디렉토리로 설정"
 
-#: ../src/guake/main.py:95
+#: ../src/guake/main.py:96
 msgid "Select a tab (SELECT_TAB is the index of the tab)"
 msgstr "탭 선택 (SELECT_TAB은 탭의 번호입니다)"
 
-#: ../src/guake/main.py:99
+#: ../src/guake/main.py:100
 msgid "Return the selected tab index."
 msgstr "선택된 탭으로 이동합니다."
 
-#: ../src/guake/main.py:103
+#: ../src/guake/main.py:104
 msgid "Execute an arbitrary command in the selected tab."
 msgstr "선택된 탭에서 임의의 명령을 실행합니다."
 
-#: ../src/guake/main.py:107
+#: ../src/guake/main.py:108
 msgid "Specify the tab to rename. Default is 0."
 msgstr "변경할 이름을 지정하세요. 기본값은 0입니다."
 
-#: ../src/guake/main.py:111
+#: ../src/guake/main.py:112
 msgid "Set the hexadecimal (#rrggbb) background color of the selected tab."
 msgstr "선택된 탭의 배경색을 #rrggbb와 같이 지정하세요."
 
-#: ../src/guake/main.py:116
+#: ../src/guake/main.py:117
 msgid "Set the hexadecimal (#rrggbb) foreground color of the selected tab."
 msgstr "선택된 탭의 전경색을 #rrggbb와 같이 지정하세요."
 
-#: ../src/guake/main.py:122
+#: ../src/guake/main.py:123
 msgid ""
 "Rename the specified tab. Reset to default if TITLE is a single dash \"-\"."
 msgstr "지정된 탭의 이름을 변경합니다. -를 입력하면 기본값으로 되돌립니다."
 
-#: ../src/guake/main.py:128
+#: ../src/guake/main.py:129
 msgid ""
 "Rename the current tab. Reset to default if TITLE is a single dash \"-\"."
 msgstr "현재 탭의 이름을 변경합니다. -를 입력하면 기본값으로 되돌립니다."
 
-#: ../src/guake/main.py:133
+#: ../src/guake/main.py:134
 msgid "Says to Guake go away =("
 msgstr "Guake 치워버리기 =("
 
-#: ../src/guake/main.py:137
+#: ../src/guake/main.py:138
 msgid "Do not execute the start up script"
 msgstr "시작 스크립트를 실행하지 않습니다."
 
-#: ../src/guake/main.py:231
+#: ../src/guake/main.py:235
 msgid "Guake can not init!"
 msgstr "Guake 초기화에 실패했습니다."
 
-#: ../src/guake/main.py:232
+#: ../src/guake/main.py:236
 msgid ""
 "Gconf Error.\n"
 "Have you installed <b>guake.schemas</b> properly?"
@@ -777,32 +785,180 @@ msgstr ""
 msgid "<user shell>"
 msgstr "<사용자 쉘>"
 
-#: ../src/guake/prefs.py:467
+#: ../src/guake/prefs.py:77
+msgid "Toggle Guake visibility"
+msgstr "Guake 보이기/감추기"
+
+#: ../src/guake/prefs.py:81
+msgid "Toggle Hide on Lose Focus"
+msgstr "포커스를 잃을 때 감추기 기능 사용"
+
+#: ../src/guake/prefs.py:88
+msgid "Tab management"
+msgstr "탭 관리"
+
+#: ../src/guake/prefs.py:90
+#, fuzzy
+msgid "New tab"
+msgstr "새 탭"
+
+#: ../src/guake/prefs.py:92
+msgid "Close tab"
+msgstr "탭 닫기"
+
+#: ../src/guake/prefs.py:94
+msgid "Rename current tab"
+msgstr "현재 탭 이름변경"
+
+#: ../src/guake/prefs.py:97
+msgid "Navigation"
+msgstr "네비게이션"
+
+#: ../src/guake/prefs.py:99
+msgid "Go to previous tab"
+msgstr "이전탭으로 전환"
+
+#: ../src/guake/prefs.py:101
+msgid "Go to next tab"
+msgstr "다음탭으로 전환"
+
+#: ../src/guake/prefs.py:103
+#, fuzzy
+msgid "Move current tab left"
+msgstr "현재 탭 이름변경"
+
+#: ../src/guake/prefs.py:105
+#, fuzzy
+msgid "Move current tab right"
+msgstr "현재 탭 이름변경"
+
+#: ../src/guake/prefs.py:107
+msgid "Go to first tab"
+msgstr "첫 번째 탭으로 이동"
+
+#: ../src/guake/prefs.py:109
+msgid "Go to second tab"
+msgstr "두 번째 탭으로 이동"
+
+#: ../src/guake/prefs.py:111
+msgid "Go to third tab"
+msgstr "세 번째 탭으로 이동"
+
+#: ../src/guake/prefs.py:113
+msgid "Go to fourth tab"
+msgstr "네 번째 탭으로 이동"
+
+#: ../src/guake/prefs.py:115
+msgid "Go to fifth tab"
+msgstr "다섯 번째 탭으로 이동"
+
+#: ../src/guake/prefs.py:117
+msgid "Go to sixth tab"
+msgstr "여섯 번째 탭으로 이동"
+
+#: ../src/guake/prefs.py:119
+msgid "Go to seventh tab"
+msgstr "일곱 번째 탭으로 이동"
+
+#: ../src/guake/prefs.py:121
+msgid "Go to eighth tab"
+msgstr "여덞 번째 탭으로 이동"
+
+#: ../src/guake/prefs.py:123
+msgid "Go to ninth tab"
+msgstr "아홉 번째 탭으로 이동"
+
+#: ../src/guake/prefs.py:125
+msgid "Go to tenth tab"
+msgstr "열 번째 탭으로 이동"
+
+#: ../src/guake/prefs.py:127
+#, fuzzy
+msgid "Go to last tab"
+msgstr "첫 번째 탭으로 이동"
+
+#: ../src/guake/prefs.py:132
+msgid "Zoom out"
+msgstr "화면 확대"
+
+#: ../src/guake/prefs.py:134
+msgid "Zoom in"
+msgstr "화면 축소"
+
+#: ../src/guake/prefs.py:136
+msgid "Zoom in (alternative)"
+msgstr "화면 축소 (추가 단축키)"
+
+#: ../src/guake/prefs.py:138
+msgid "Increase height"
+msgstr "높이 키우기"
+
+#: ../src/guake/prefs.py:140
+msgid "Decrease height"
+msgstr "높이 줄이기"
+
+#: ../src/guake/prefs.py:142
+#, fuzzy
+msgid "Increase transparency"
+msgstr "투명도:"
+
+#: ../src/guake/prefs.py:144
+#, fuzzy
+msgid "Decrease transparency"
+msgstr "투명도:"
+
+#: ../src/guake/prefs.py:146
+#, fuzzy
+msgid "Toggle transparency"
+msgstr "투명도:"
+
+#: ../src/guake/prefs.py:149
+msgid "Clipboard"
+msgstr "클립보드"
+
+#: ../src/guake/prefs.py:151
+msgid "Copy text to clipboard"
+msgstr "글자를 클립보드로 복사"
+
+#: ../src/guake/prefs.py:153
+msgid "Paste text from clipboard"
+msgstr "클립보드의 글자를 붙여넣기"
+
+#: ../src/guake/prefs.py:156
+msgid "Extra features"
+msgstr "추가 기능"
+
+#: ../src/guake/prefs.py:159
+#, fuzzy
+msgid "Search select text on web"
+msgstr "선택된 텍스트를 웹에 검색"
+
+#: ../src/guake/prefs.py:519
 msgid "Action"
 msgstr "액션"
 
-#: ../src/guake/prefs.py:477
+#: ../src/guake/prefs.py:529
 msgid "Shortcut"
 msgstr "단축키"
 
-#: ../src/guake/prefs.py:619 ../src/guake/prefs.py:665
+#: ../src/guake/prefs.py:678 ../src/guake/prefs.py:724
 msgid "Custom"
 msgstr "사용자 정의"
 
-#: ../src/guake/prefs.py:926
+#: ../src/guake/prefs.py:994
 msgid "JSON files"
 msgstr "JSON 파일"
 
-#: ../src/guake/prefs.py:1019
+#: ../src/guake/prefs.py:1088
 #, python-format
 msgid "The shortcut \"%s\" is already in use."
 msgstr "지정된 \"%s\" 단축키는 이미 사용중입니다."
 
-#: ../src/guake/prefs.py:1020
+#: ../src/guake/prefs.py:1089
 msgid "Error setting keybinding."
 msgstr "키 바인딩에 에러가 발견되었습니다."
 
-#: ../src/guake/prefs.py:1032
+#: ../src/guake/prefs.py:1101
 #, python-format
 msgid ""
 "The shortcut \"%s\" cannot be used because it will become impossible to type "
@@ -847,84 +1003,3 @@ msgstr ""
 
 #~ msgid "Rename the selected tab."
 #~ msgstr "선택된 탭의 이름을 변경합니다."
-
-#~ msgid "Toggle Guake visibility"
-#~ msgstr "Guake 보이기/감추기"
-
-#~ msgid "Tab management"
-#~ msgstr "탭 관리"
-
-#~ msgid "Close tab"
-#~ msgstr "탭 닫기"
-
-#~ msgid "Rename current tab"
-#~ msgstr "현재 탭 이름변경"
-
-#~ msgid "Navigation"
-#~ msgstr "네비게이션"
-
-#~ msgid "Toggle Hide on Lose Focus"
-#~ msgstr "포커스를 잃을 때 감추기 기능 사용"
-
-#~ msgid "Go to previous tab"
-#~ msgstr "이전탭으로 전환"
-
-#~ msgid "Go to next tab"
-#~ msgstr "다음탭으로 전환"
-
-#~ msgid "Clipboard"
-#~ msgstr "클립보드"
-
-#~ msgid "Copy text to clipboard"
-#~ msgstr "글자를 클립보드로 복사"
-
-#~ msgid "Paste text from clipboard"
-#~ msgstr "클립보드의 글자를 붙여넣기"
-
-#~ msgid "Go to first tab"
-#~ msgstr "첫 번째 탭으로 이동"
-
-#~ msgid "Go to second tab"
-#~ msgstr "두 번째 탭으로 이동"
-
-#~ msgid "Go to third tab"
-#~ msgstr "세 번째 탭으로 이동"
-
-#~ msgid "Go to fourth tab"
-#~ msgstr "네 번째 탭으로 이동"
-
-#~ msgid "Go to fifth tab"
-#~ msgstr "다섯 번째 탭으로 이동"
-
-#~ msgid "Go to sixth tab"
-#~ msgstr "여섯 번째 탭으로 이동"
-
-#~ msgid "Go to seventh tab"
-#~ msgstr "일곱 번째 탭으로 이동"
-
-#~ msgid "Go to eighth tab"
-#~ msgstr "여덞 번째 탭으로 이동"
-
-#~ msgid "Go to ninth tab"
-#~ msgstr "아홉 번째 탭으로 이동"
-
-#~ msgid "Go to tenth tab"
-#~ msgstr "열 번째 탭으로 이동"
-
-#~ msgid "Zoom out"
-#~ msgstr "화면 확대"
-
-#~ msgid "Zoom in"
-#~ msgstr "화면 축소"
-
-#~ msgid "Zoom in (alternative)"
-#~ msgstr "화면 축소 (추가 단축키)"
-
-#~ msgid "Increase height"
-#~ msgstr "높이 키우기"
-
-#~ msgid "Decrease height"
-#~ msgstr "높이 줄이기"
-
-#~ msgid "Extra features"
-#~ msgstr "추가 기능"

--- a/po/nb.po
+++ b/po/nb.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Guake 0.4.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-12-01 16:49+0100\n"
+"POT-Creation-Date: 2016-08-17 21:41+0000\n"
 "PO-Revision-Date: 2010-01-18 15:26+CET\n"
 "Last-Translator: Håvard Havdal <haavard@havdal.net>\n"
 "Language-Team: guake@lists.guake.org\n"
@@ -98,7 +98,7 @@ msgstr "Kopier"
 msgid "Paste"
 msgstr "Lim inn"
 
-#: ../data/guake.glade.h:3
+#: ../data/guake.glade.h:3 ../src/guake/prefs.py:79
 msgid "Toggle Fullscreen"
 msgstr "Endre til fullskjerm"
 
@@ -106,7 +106,7 @@ msgstr "Endre til fullskjerm"
 msgid "Save to File..."
 msgstr ""
 
-#: ../data/guake.glade.h:5
+#: ../data/guake.glade.h:5 ../src/guake/prefs.py:85
 #, fuzzy
 msgid "Reset terminal"
 msgstr "Guake Terminal"
@@ -137,7 +137,7 @@ msgstr ""
 msgid "Search on Web"
 msgstr ""
 
-#: ../data/guake.glade.h:12
+#: ../data/guake.glade.h:12 ../src/guake/prefs.py:83
 msgid "Quit"
 msgstr "Avslutt"
 
@@ -260,202 +260,206 @@ msgid "Use VTE titles for tab names"
 msgstr ""
 
 #: ../data/prefs.glade.h:33
-msgid "Max tab name length:"
+msgid "Abbreviate directories in tab names"
 msgstr ""
 
 #: ../data/prefs.glade.h:34
+msgid "Max tab name length:"
+msgstr ""
+
+#: ../data/prefs.glade.h:35
 msgid "Hide on lose focus"
 msgstr "Skjul ved inaktivt vindu"
 
-#: ../data/prefs.glade.h:35
+#: ../data/prefs.glade.h:36
 msgid "Show tab bar"
 msgstr "Vis fanelinje"
 
-#: ../data/prefs.glade.h:36
+#: ../data/prefs.glade.h:37
 #, fuzzy
 msgid "Start fullscreen"
 msgstr "Endre til fullskjerm"
 
-#: ../data/prefs.glade.h:37
+#: ../data/prefs.glade.h:38
 msgid "<b>Main Window</b>"
 msgstr "<b>Hovedvindu</b>"
 
-#: ../data/prefs.glade.h:38
+#: ../data/prefs.glade.h:39
 msgid "Left"
 msgstr ""
 
-#: ../data/prefs.glade.h:39
+#: ../data/prefs.glade.h:40
 msgid "Center"
 msgstr ""
 
-#: ../data/prefs.glade.h:40
+#: ../data/prefs.glade.h:41
 msgid "Right"
 msgstr ""
 
-#: ../data/prefs.glade.h:41
+#: ../data/prefs.glade.h:42
 #, fuzzy
 msgid "<b>Main Window Horizontal Alignment</b>"
 msgstr "<b>Position horizontale de la fenêtre principale</b>"
 
-#: ../data/prefs.glade.h:42
+#: ../data/prefs.glade.h:43
 #, fuzzy
 msgid "<b>Main Window Height</b>"
 msgstr "<b>Hovedvindu høyde</b>"
 
-#: ../data/prefs.glade.h:43
+#: ../data/prefs.glade.h:44
 #, fuzzy
 msgid "<b>Main Window Width</b>"
 msgstr "<b>Largeur de la fenêtre principale</b>"
 
-#: ../data/prefs.glade.h:44
+#: ../data/prefs.glade.h:45
 msgid "Custom command file path: "
 msgstr ""
 
-#: ../data/prefs.glade.h:45
+#: ../data/prefs.glade.h:46
 msgid "Please select a json file"
 msgstr ""
 
-#: ../data/prefs.glade.h:46
+#: ../data/prefs.glade.h:47 ../src/guake/prefs.py:75
 msgid "General"
 msgstr "Generell"
 
-#: ../data/prefs.glade.h:47
+#: ../data/prefs.glade.h:48
 msgid "Default interpreter:"
 msgstr "Standard tolk:"
 
-#: ../data/prefs.glade.h:48
+#: ../data/prefs.glade.h:49
 msgid "_Run command as a login shell"
 msgstr "_Kjør kommando som loginskall"
 
-#: ../data/prefs.glade.h:49
+#: ../data/prefs.glade.h:50
 msgid "_Open new tab in current directory"
 msgstr "_Åpne ny fane i aktiv sti"
 
-#: ../data/prefs.glade.h:50
+#: ../data/prefs.glade.h:51
 msgid "<b>Shell</b>"
 msgstr "<b>Skall</b>"
 
-#: ../data/prefs.glade.h:51
+#: ../data/prefs.glade.h:52
 msgid "Shell"
 msgstr ""
 
-#: ../data/prefs.glade.h:52
+#: ../data/prefs.glade.h:53
 msgid "Show scrollbar"
 msgstr "Vis skrollbar"
 
-#: ../data/prefs.glade.h:53
+#: ../data/prefs.glade.h:54
 msgid "Scrollback lines:"
 msgstr "Skrollback linjer:"
 
-#: ../data/prefs.glade.h:54
+#: ../data/prefs.glade.h:55
 msgid "On output"
 msgstr "On output"
 
-#: ../data/prefs.glade.h:55
+#: ../data/prefs.glade.h:56
 msgid "On key stroke"
 msgstr "Ved tastetrykk"
 
-#: ../data/prefs.glade.h:56
+#: ../data/prefs.glade.h:57
 msgid "<b>Scroll</b>"
 msgstr "<b>Skroll</b>"
 
-#: ../data/prefs.glade.h:57
+#: ../data/prefs.glade.h:58
 msgid "Scrolling"
 msgstr "Skrolling"
 
-#: ../data/prefs.glade.h:58
+#: ../data/prefs.glade.h:59
 msgid "Use the system fixed width font"
 msgstr "Bruk breddefont"
 
-#: ../data/prefs.glade.h:59
+#: ../data/prefs.glade.h:60
 msgid "Font:"
 msgstr "Skrifttype:"
 
-#: ../data/prefs.glade.h:60
+#: ../data/prefs.glade.h:61
 msgid "Choose some font"
 msgstr "Velg en skrifttype"
 
-#: ../data/prefs.glade.h:61
+#: ../data/prefs.glade.h:62
 msgid "Text color:"
 msgstr "Tekst farge:"
 
-#: ../data/prefs.glade.h:62
+#: ../data/prefs.glade.h:63
 msgid "Background color:"
 msgstr "Bakgrunnsfarge:"
 
-#: ../data/prefs.glade.h:63
+#: ../data/prefs.glade.h:64
 msgid "Cursor shape:"
 msgstr ""
 
-#: ../data/prefs.glade.h:64
+#: ../data/prefs.glade.h:65
 msgid ""
 "Block\n"
 "I-Beam\n"
 "Underline"
 msgstr ""
 
-#: ../data/prefs.glade.h:67
+#: ../data/prefs.glade.h:68
 msgid ""
 "Follow GTK+ setting\n"
 "Blink on\n"
 "Blink off"
 msgstr ""
 
-#: ../data/prefs.glade.h:70
+#: ../data/prefs.glade.h:71
 msgid "Cursor blink mode:"
 msgstr ""
 
-#: ../data/prefs.glade.h:71
+#: ../data/prefs.glade.h:72
 msgid "Allow bold font"
 msgstr ""
 
-#: ../data/prefs.glade.h:72
+#: ../data/prefs.glade.h:73
 msgid "<b>Palette</b>"
 msgstr "<b>Palette</b>"
 
-#: ../data/prefs.glade.h:73
+#: ../data/prefs.glade.h:74
 msgid "Built-in schemes:"
 msgstr "Bygd inn skjemaer"
 
-#: ../data/prefs.glade.h:74
+#: ../data/prefs.glade.h:75
 msgid "Color palette:"
 msgstr "Farge palette:"
 
-#: ../data/prefs.glade.h:75
+#: ../data/prefs.glade.h:76
 #, fuzzy
 msgid "Font color"
 msgstr "Tekst farge:"
 
-#: ../data/prefs.glade.h:76
+#: ../data/prefs.glade.h:77
 #, fuzzy
 msgid "Background color"
 msgstr "Bakgrunnsfarge:"
 
-#: ../data/prefs.glade.h:77
+#: ../data/prefs.glade.h:78
 msgid "Use font and background color from the palette"
 msgstr ""
 
-#: ../data/prefs.glade.h:78
+#: ../data/prefs.glade.h:79
 msgid "Demo:"
 msgstr ""
 
-#: ../data/prefs.glade.h:79
+#: ../data/prefs.glade.h:80
 msgid "<b>Effects</b>"
 msgstr "<b>Effekter</b>"
 
-#: ../data/prefs.glade.h:80
+#: ../data/prefs.glade.h:81
 msgid "Transparency:"
 msgstr "Gjennomsiktighet"
 
-#: ../data/prefs.glade.h:81
+#: ../data/prefs.glade.h:82
 msgid "Background image:"
 msgstr "Bakgrunnsbildet:"
 
-#: ../data/prefs.glade.h:82
+#: ../data/prefs.glade.h:83 ../src/guake/prefs.py:130
 msgid "Appearance"
 msgstr "Utseende"
 
-#: ../data/prefs.glade.h:83
+#: ../data/prefs.glade.h:84
 msgid ""
 "<small>Quick open is a feature allowing you to open a file directly into "
 "your favorite text editor by clicking on its filename when it appears in "
@@ -463,15 +467,15 @@ msgid ""
 "extract filename below.</small>"
 msgstr ""
 
-#: ../data/prefs.glade.h:84
+#: ../data/prefs.glade.h:85
 msgid "Enable Quick Open when Ctrl+clicking on a filename in the terminal"
 msgstr ""
 
-#: ../data/prefs.glade.h:85
+#: ../data/prefs.glade.h:86
 msgid "Editor command line:"
 msgstr ""
 
-#: ../data/prefs.glade.h:87
+#: ../data/prefs.glade.h:88
 #, no-c-format
 msgid ""
 "<small><i>Use the following elements in the open editor command line:\n"
@@ -483,36 +487,36 @@ msgid ""
 "</i></small>"
 msgstr ""
 
-#: ../data/prefs.glade.h:93
+#: ../data/prefs.glade.h:94
 msgid "Quick open in current terminal"
 msgstr ""
 
-#: ../data/prefs.glade.h:94
+#: ../data/prefs.glade.h:95
 msgid ""
 "Here is the list of supported patterns: (to add your own, please contact the "
 "Guake's authors)"
 msgstr ""
 
-#: ../data/prefs.glade.h:95
+#: ../data/prefs.glade.h:96
 #, fuzzy
 msgid "<b>Quick Open</b>"
 msgstr "<b>Palette</b>"
 
-#: ../data/prefs.glade.h:96
+#: ../data/prefs.glade.h:97
 msgid "Quick Open"
 msgstr ""
 
-#: ../data/prefs.glade.h:97
+#: ../data/prefs.glade.h:98
 msgid ""
 "To change a shortcut simply click on its name.\n"
 "To disable a shortcut, press the \"Backspace\" key."
 msgstr ""
 
-#: ../data/prefs.glade.h:99
+#: ../data/prefs.glade.h:100
 msgid "Keyboard shortcuts"
 msgstr "Hurtigtaster"
 
-#: ../data/prefs.glade.h:100
+#: ../data/prefs.glade.h:101
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -524,7 +528,7 @@ msgstr ""
 "til å arbeide rundt visse applikasjoner og operativ systemer som forventer "
 "forskjellig terminaloppførsel.</i></small>"
 
-#: ../data/prefs.glade.h:101
+#: ../data/prefs.glade.h:102
 msgid ""
 "ASCII DEL\n"
 "Escape sequence\n"
@@ -534,38 +538,37 @@ msgstr ""
 "Escape sequence\n"
 "Control-H"
 
-#: ../data/prefs.glade.h:104
+#: ../data/prefs.glade.h:105
 msgid "_Backspace key generates:"
 msgstr "_Tilbaketast genererer:"
 
-#: ../data/prefs.glade.h:105
+#: ../data/prefs.glade.h:106
 msgid "_Delete key generates:"
 msgstr "_Slettetast genererer:"
 
-#: ../data/prefs.glade.h:106
+#: ../data/prefs.glade.h:107
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "_Tilbakestill kompabilitet alternativer til standard"
 
-#: ../data/prefs.glade.h:107
+#: ../data/prefs.glade.h:108
 msgid "<b>Keyboard compatibility</b>"
 msgstr "<b>Tastatur kompabilitet</b>"
 
-#: ../data/prefs.glade.h:108
+#: ../data/prefs.glade.h:109
 msgid "Compatibility"
 msgstr "Kompabilitet"
 
-#: ../src/guake/about.py:47 ../src/guake/gconfhandler.py:427
-#: ../src/guake/guake_app.py:177 ../src/guake/guake_app.py:348
+#: ../src/guake/about.py:47 ../src/guake/gconfhandler.py:435
+#: ../src/guake/guake_app.py:181 ../src/guake/guake_app.py:376
 msgid "Guake Terminal"
 msgstr "Guake Terminal"
 
-#. Adding a new radio button to the tabbar
-#: ../src/guake/gconfhandler.py:365 ../src/guake/guake_app.py:1548
+#: ../src/guake/gconfhandler.py:368 ../src/guake/guake_app.py:1363
 #, fuzzy
 msgid "Terminal"
 msgstr "Terminal %s"
 
-#: ../src/guake/gconfhandler.py:428
+#: ../src/guake/gconfhandler.py:436
 #, python-format
 msgid ""
 "A problem happened when binding <b>%s</b> key.\n"
@@ -574,54 +577,54 @@ msgstr ""
 "Et problem har oppstått under lagringen av <b>%s</b> tasten.\n"
 "Vennligst benytt guake egenskaper for å velge en annen tast"
 
-#: ../src/guake/guake_app.py:128
+#: ../src/guake/guake_app.py:132
 #, fuzzy
 msgid "Do you want to close the tab?"
 msgstr "Vil du virkelig avslutte Guake!?"
 
-#: ../src/guake/guake_app.py:131
+#: ../src/guake/guake_app.py:135
 #, fuzzy
 msgid "Do you really want to quit Guake?"
 msgstr "Vil du virkelig avslutte Guake!?"
 
-#: ../src/guake/guake_app.py:133
+#: ../src/guake/guake_app.py:137
 #, fuzzy
 msgid " and one tab open"
 msgstr "Legg til fane"
 
-#: ../src/guake/guake_app.py:135
+#: ../src/guake/guake_app.py:139
 #, python-brace-format
 msgid " and {0} tabs open"
 msgstr ""
 
-#: ../src/guake/guake_app.py:138
+#: ../src/guake/guake_app.py:142
 #, fuzzy
 msgid "There are no processes running"
 msgstr "<b>Det er forsatt én prosess kjørende.</b>"
 
-#: ../src/guake/guake_app.py:140
+#: ../src/guake/guake_app.py:144
 #, fuzzy
 msgid "There is a process still running"
 msgstr "<b>Det er forsatt én prosess kjørende.</b>"
 
-#: ../src/guake/guake_app.py:142
+#: ../src/guake/guake_app.py:146
 #, fuzzy, python-brace-format
 msgid "There are {0} processes still running"
 msgstr "<b>Det er %d prosesser kjørende.</b>"
 
-#: ../src/guake/guake_app.py:182
+#: ../src/guake/guake_app.py:186
 msgid "guake-indicator"
 msgstr ""
 
-#: ../src/guake/guake_app.py:182
+#: ../src/guake/guake_app.py:186
 msgid "guake-tray"
 msgstr ""
 
-#: ../src/guake/guake_app.py:186
+#: ../src/guake/guake_app.py:190
 msgid "Show"
 msgstr ""
 
-#: ../src/guake/guake_app.py:349
+#: ../src/guake/guake_app.py:377
 #, python-format
 msgid ""
 "Guake is now running,\n"
@@ -630,129 +633,133 @@ msgstr ""
 "Guake er nå startet,\n"
 "trykk <b>%s</b> for å ta den i bruk."
 
-#: ../src/guake/guake_app.py:611
+#: ../src/guake/guake_app.py:665
 #, python-format
 msgid "Search on Web: '%s'"
 msgstr ""
 
-#: ../src/guake/guake_app.py:616
+#: ../src/guake/guake_app.py:670
 msgid "Search on Web (no selection)"
 msgstr ""
 
-#: ../src/guake/guake_app.py:622
+#: ../src/guake/guake_app.py:678
+msgid "Open Link: '{}...'"
+msgstr ""
+
+#: ../src/guake/guake_app.py:680
 msgid "Open Link: {}"
 msgstr ""
 
-#: ../src/guake/guake_app.py:625
+#: ../src/guake/guake_app.py:683
 msgid "Open Link..."
 msgstr ""
 
-#: ../src/guake/guake_app.py:1300
+#: ../src/guake/guake_app.py:1402
 msgid "Rename tab"
 msgstr "Gi nytt navn til fane"
 
-#: ../src/guake/guake_app.py:1591
+#: ../src/guake/guake_app.py:1716
 msgid "Save to..."
 msgstr ""
 
-#: ../src/guake/guake_app.py:1598 ../src/guake/prefs.py:930
+#: ../src/guake/guake_app.py:1723 ../src/guake/prefs.py:998
 msgid "All files"
 msgstr ""
 
-#: ../src/guake/guake_app.py:1603
+#: ../src/guake/guake_app.py:1728
 msgid "Text and Logs"
 msgstr ""
 
-#: ../src/guake/guake_app.py:1621
+#: ../src/guake/guake_app.py:1746
 msgid "Find"
 msgstr ""
 
-#: ../src/guake/guake_app.py:1623
+#: ../src/guake/guake_app.py:1748
 msgid "Forward"
 msgstr ""
 
-#: ../src/guake/guake_app.py:1624
+#: ../src/guake/guake_app.py:1749
 msgid "Backward"
 msgstr ""
 
-#: ../src/guake/main.py:67
+#: ../src/guake/main.py:68
 msgid "Put Guake in fullscreen mode"
 msgstr ""
 
-#: ../src/guake/main.py:71
+#: ../src/guake/main.py:72
 msgid "Toggles the visibility of the terminal window"
 msgstr "Endrer synligheten av terminalvinduet"
 
-#: ../src/guake/main.py:75
+#: ../src/guake/main.py:76
 #, fuzzy
 msgid "Shows Guake main window"
 msgstr "Viser Guake egenskapervinduet"
 
-#: ../src/guake/main.py:79
+#: ../src/guake/main.py:80
 #, fuzzy
 msgid "Hides Guake main window"
 msgstr "Viser Guake egenskapervinduet"
 
-#: ../src/guake/main.py:83
+#: ../src/guake/main.py:84
 msgid "Shows Guake preference window"
 msgstr "Viser Guake egenskapervinduet"
 
-#: ../src/guake/main.py:87
+#: ../src/guake/main.py:88
 msgid "Shows Guake's about info"
 msgstr "Viser Guakes om informasjon"
 
-#: ../src/guake/main.py:91
+#: ../src/guake/main.py:92
 #, fuzzy
 msgid "Add a new tab (with current directory set to NEW_TAB)"
 msgstr "_Åpne ny fane i aktiv sti"
 
-#: ../src/guake/main.py:95
+#: ../src/guake/main.py:96
 msgid "Select a tab (SELECT_TAB is the index of the tab)"
 msgstr ""
 
-#: ../src/guake/main.py:99
+#: ../src/guake/main.py:100
 msgid "Return the selected tab index."
 msgstr "Gå tilbake til den valgte faneindex."
 
-#: ../src/guake/main.py:103
+#: ../src/guake/main.py:104
 msgid "Execute an arbitrary command in the selected tab."
 msgstr "Utføre en vilkårlig kommandoen i den valgte fanen."
 
-#: ../src/guake/main.py:107
+#: ../src/guake/main.py:108
 msgid "Specify the tab to rename. Default is 0."
 msgstr ""
 
-#: ../src/guake/main.py:111
+#: ../src/guake/main.py:112
 msgid "Set the hexadecimal (#rrggbb) background color of the selected tab."
 msgstr ""
 
-#: ../src/guake/main.py:116
+#: ../src/guake/main.py:117
 msgid "Set the hexadecimal (#rrggbb) foreground color of the selected tab."
 msgstr ""
 
-#: ../src/guake/main.py:122
+#: ../src/guake/main.py:123
 msgid ""
 "Rename the specified tab. Reset to default if TITLE is a single dash \"-\"."
 msgstr ""
 
-#: ../src/guake/main.py:128
+#: ../src/guake/main.py:129
 msgid ""
 "Rename the current tab. Reset to default if TITLE is a single dash \"-\"."
 msgstr ""
 
-#: ../src/guake/main.py:133
+#: ../src/guake/main.py:134
 msgid "Says to Guake go away =("
 msgstr "Sier til Guake at den skal gå vekk =("
 
-#: ../src/guake/main.py:137
+#: ../src/guake/main.py:138
 msgid "Do not execute the start up script"
 msgstr ""
 
-#: ../src/guake/main.py:231
+#: ../src/guake/main.py:235
 msgid "Guake can not init!"
 msgstr "Guake kan ikke init!"
 
-#: ../src/guake/main.py:232
+#: ../src/guake/main.py:236
 #, fuzzy
 msgid ""
 "Gconf Error.\n"
@@ -766,32 +773,190 @@ msgstr ""
 msgid "<user shell>"
 msgstr "<bruker skall>"
 
-#: ../src/guake/prefs.py:467
+#: ../src/guake/prefs.py:77
+msgid "Toggle Guake visibility"
+msgstr "Endrer Guakes synslighet"
+
+#: ../src/guake/prefs.py:81
+#, fuzzy
+msgid "Toggle Hide on Lose Focus"
+msgstr "Skjul ved inaktivt vindu"
+
+#: ../src/guake/prefs.py:88
+msgid "Tab management"
+msgstr "Fanebehandler"
+
+#: ../src/guake/prefs.py:90
+#, fuzzy
+msgid "New tab"
+msgstr "Ny fane"
+
+#: ../src/guake/prefs.py:92
+msgid "Close tab"
+msgstr "Lukk fane"
+
+#: ../src/guake/prefs.py:94
+msgid "Rename current tab"
+msgstr "Gi nytt navn til aktiv fane"
+
+#: ../src/guake/prefs.py:97
+msgid "Navigation"
+msgstr "Navigasjon"
+
+#: ../src/guake/prefs.py:99
+msgid "Go to previous tab"
+msgstr "Gå til forrige fane"
+
+#: ../src/guake/prefs.py:101
+msgid "Go to next tab"
+msgstr "Gå til neste fane"
+
+#: ../src/guake/prefs.py:103
+#, fuzzy
+msgid "Move current tab left"
+msgstr "Gi nytt navn til aktiv fane"
+
+#: ../src/guake/prefs.py:105
+#, fuzzy
+msgid "Move current tab right"
+msgstr "Gi nytt navn til aktiv fane"
+
+#: ../src/guake/prefs.py:107
+#, fuzzy
+msgid "Go to first tab"
+msgstr "Gå til neste fane"
+
+#: ../src/guake/prefs.py:109
+#, fuzzy
+msgid "Go to second tab"
+msgstr "Gå til neste fane"
+
+#: ../src/guake/prefs.py:111
+#, fuzzy
+msgid "Go to third tab"
+msgstr "Gå til neste fane"
+
+#: ../src/guake/prefs.py:113
+#, fuzzy
+msgid "Go to fourth tab"
+msgstr "Gå til neste fane"
+
+#: ../src/guake/prefs.py:115
+#, fuzzy
+msgid "Go to fifth tab"
+msgstr "Gå til neste fane"
+
+#: ../src/guake/prefs.py:117
+#, fuzzy
+msgid "Go to sixth tab"
+msgstr "Gå til neste fane"
+
+#: ../src/guake/prefs.py:119
+#, fuzzy
+msgid "Go to seventh tab"
+msgstr "Gå til neste fane"
+
+#: ../src/guake/prefs.py:121
+#, fuzzy
+msgid "Go to eighth tab"
+msgstr "Gå til neste fane"
+
+#: ../src/guake/prefs.py:123
+#, fuzzy
+msgid "Go to ninth tab"
+msgstr "Gå til neste fane"
+
+#: ../src/guake/prefs.py:125
+#, fuzzy
+msgid "Go to tenth tab"
+msgstr "Gå til neste fane"
+
+#: ../src/guake/prefs.py:127
+#, fuzzy
+msgid "Go to last tab"
+msgstr "Gå til neste fane"
+
+#: ../src/guake/prefs.py:132
+msgid "Zoom out"
+msgstr ""
+
+#: ../src/guake/prefs.py:134
+msgid "Zoom in"
+msgstr ""
+
+#: ../src/guake/prefs.py:136
+msgid "Zoom in (alternative)"
+msgstr ""
+
+#: ../src/guake/prefs.py:138
+msgid "Increase height"
+msgstr ""
+
+#: ../src/guake/prefs.py:140
+msgid "Decrease height"
+msgstr ""
+
+#: ../src/guake/prefs.py:142
+#, fuzzy
+msgid "Increase transparency"
+msgstr "Gjennomsiktighet"
+
+#: ../src/guake/prefs.py:144
+#, fuzzy
+msgid "Decrease transparency"
+msgstr "Gjennomsiktighet"
+
+#: ../src/guake/prefs.py:146
+#, fuzzy
+msgid "Toggle transparency"
+msgstr "Gjennomsiktighet"
+
+#: ../src/guake/prefs.py:149
+msgid "Clipboard"
+msgstr "Utklippstavle"
+
+#: ../src/guake/prefs.py:151
+msgid "Copy text to clipboard"
+msgstr "Kopier tekst til utklippstavle"
+
+#: ../src/guake/prefs.py:153
+msgid "Paste text from clipboard"
+msgstr "Lim inn tekst fra utklippstavle"
+
+#: ../src/guake/prefs.py:156
+msgid "Extra features"
+msgstr ""
+
+#: ../src/guake/prefs.py:159
+msgid "Search select text on web"
+msgstr ""
+
+#: ../src/guake/prefs.py:519
 msgid "Action"
 msgstr "Handling"
 
-#: ../src/guake/prefs.py:477
+#: ../src/guake/prefs.py:529
 msgid "Shortcut"
 msgstr "Snarvei"
 
-#: ../src/guake/prefs.py:619 ../src/guake/prefs.py:665
+#: ../src/guake/prefs.py:678 ../src/guake/prefs.py:724
 msgid "Custom"
 msgstr ""
 
-#: ../src/guake/prefs.py:926
+#: ../src/guake/prefs.py:994
 msgid "JSON files"
 msgstr ""
 
-#: ../src/guake/prefs.py:1019
+#: ../src/guake/prefs.py:1088
 #, python-format
 msgid "The shortcut \"%s\" is already in use."
 msgstr "Hurtigtasten \"%s\" er allerede i bruk"
 
-#: ../src/guake/prefs.py:1020
+#: ../src/guake/prefs.py:1089
 msgid "Error setting keybinding."
 msgstr "Kunne ikke lagre hurtigtasten."
 
-#: ../src/guake/prefs.py:1032
+#: ../src/guake/prefs.py:1101
 #, python-format
 msgid ""
 "The shortcut \"%s\" cannot be used because it will become impossible to type "
@@ -831,36 +996,6 @@ msgstr ""
 
 #~ msgid "Rename the selected tab."
 #~ msgstr "Gi nytt navn til aktiv fane."
-
-#~ msgid "Toggle Guake visibility"
-#~ msgstr "Endrer Guakes synslighet"
-
-#~ msgid "Tab management"
-#~ msgstr "Fanebehandler"
-
-#~ msgid "Close tab"
-#~ msgstr "Lukk fane"
-
-#~ msgid "Rename current tab"
-#~ msgstr "Gi nytt navn til aktiv fane"
-
-#~ msgid "Navigation"
-#~ msgstr "Navigasjon"
-
-#~ msgid "Go to previous tab"
-#~ msgstr "Gå til forrige fane"
-
-#~ msgid "Go to next tab"
-#~ msgstr "Gå til neste fane"
-
-#~ msgid "Clipboard"
-#~ msgstr "Utklippstavle"
-
-#~ msgid "Copy text to clipboard"
-#~ msgstr "Kopier tekst til utklippstavle"
-
-#~ msgid "Paste text from clipboard"
-#~ msgstr "Lim inn tekst fra utklippstavle"
 
 #~ msgid "<b>Background</b>"
 #~ msgstr "<b>Bakgrunn</b>"

--- a/po/nl.po
+++ b/po/nl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Guake 0.4.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-12-01 16:49+0100\n"
+"POT-Creation-Date: 2016-08-17 21:41+0000\n"
 "PO-Revision-Date: 2011-03-22 15:26+0000\n"
 "Last-Translator: Robert van Drunen <r.j.m.vandrunen@gmail.com>\n"
 "Language-Team: Dutch (http://www.transifex.com/projects/p/guake/language/"
@@ -103,7 +103,7 @@ msgstr "Kopieren"
 msgid "Paste"
 msgstr "Plakken"
 
-#: ../data/guake.glade.h:3
+#: ../data/guake.glade.h:3 ../src/guake/prefs.py:79
 msgid "Toggle Fullscreen"
 msgstr "Schakel volledig scherm-gebruik aan of uit"
 
@@ -111,7 +111,7 @@ msgstr "Schakel volledig scherm-gebruik aan of uit"
 msgid "Save to File..."
 msgstr ""
 
-#: ../data/guake.glade.h:5
+#: ../data/guake.glade.h:5 ../src/guake/prefs.py:85
 #, fuzzy
 msgid "Reset terminal"
 msgstr "Guake Terminal"
@@ -142,7 +142,7 @@ msgstr ""
 msgid "Search on Web"
 msgstr ""
 
-#: ../data/guake.glade.h:12
+#: ../data/guake.glade.h:12 ../src/guake/prefs.py:83
 msgid "Quit"
 msgstr "Afsluiten"
 
@@ -265,202 +265,206 @@ msgid "Use VTE titles for tab names"
 msgstr ""
 
 #: ../data/prefs.glade.h:33
-msgid "Max tab name length:"
+msgid "Abbreviate directories in tab names"
 msgstr ""
 
 #: ../data/prefs.glade.h:34
+msgid "Max tab name length:"
+msgstr ""
+
+#: ../data/prefs.glade.h:35
 msgid "Hide on lose focus"
 msgstr "Verbergen bij het verliezen van focus"
 
-#: ../data/prefs.glade.h:35
+#: ../data/prefs.glade.h:36
 msgid "Show tab bar"
 msgstr "Toon tabbalk"
 
-#: ../data/prefs.glade.h:36
+#: ../data/prefs.glade.h:37
 #, fuzzy
 msgid "Start fullscreen"
 msgstr "Schakel volledig scherm-gebruik aan of uit"
 
-#: ../data/prefs.glade.h:37
+#: ../data/prefs.glade.h:38
 msgid "<b>Main Window</b>"
 msgstr "<b>Hoofdscherm</b>"
 
-#: ../data/prefs.glade.h:38
+#: ../data/prefs.glade.h:39
 msgid "Left"
 msgstr ""
 
-#: ../data/prefs.glade.h:39
+#: ../data/prefs.glade.h:40
 msgid "Center"
 msgstr ""
 
-#: ../data/prefs.glade.h:40
+#: ../data/prefs.glade.h:41
 msgid "Right"
 msgstr ""
 
-#: ../data/prefs.glade.h:41
+#: ../data/prefs.glade.h:42
 #, fuzzy
 msgid "<b>Main Window Horizontal Alignment</b>"
 msgstr "<b>Hoogte hoofdscherm</b>"
 
-#: ../data/prefs.glade.h:42
+#: ../data/prefs.glade.h:43
 #, fuzzy
 msgid "<b>Main Window Height</b>"
 msgstr "<b>Hoogte hoofdscherm</b>"
 
-#: ../data/prefs.glade.h:43
+#: ../data/prefs.glade.h:44
 #, fuzzy
 msgid "<b>Main Window Width</b>"
 msgstr "<b>Hoogte hoofdscherm</b>"
 
-#: ../data/prefs.glade.h:44
+#: ../data/prefs.glade.h:45
 msgid "Custom command file path: "
 msgstr ""
 
-#: ../data/prefs.glade.h:45
+#: ../data/prefs.glade.h:46
 msgid "Please select a json file"
 msgstr ""
 
-#: ../data/prefs.glade.h:46
+#: ../data/prefs.glade.h:47 ../src/guake/prefs.py:75
 msgid "General"
 msgstr "Algemeen"
 
-#: ../data/prefs.glade.h:47
+#: ../data/prefs.glade.h:48
 msgid "Default interpreter:"
 msgstr "Standaard interpreter:"
 
-#: ../data/prefs.glade.h:48
+#: ../data/prefs.glade.h:49
 msgid "_Run command as a login shell"
 msgstr "_Voer commando uit als login shell"
 
-#: ../data/prefs.glade.h:49
+#: ../data/prefs.glade.h:50
 msgid "_Open new tab in current directory"
 msgstr "_Open nieuwe tab in huidige directory"
 
-#: ../data/prefs.glade.h:50
+#: ../data/prefs.glade.h:51
 msgid "<b>Shell</b>"
 msgstr "<b>Shell</b>"
 
-#: ../data/prefs.glade.h:51
+#: ../data/prefs.glade.h:52
 msgid "Shell"
 msgstr ""
 
-#: ../data/prefs.glade.h:52
+#: ../data/prefs.glade.h:53
 msgid "Show scrollbar"
 msgstr "Toon schuifbalk"
 
-#: ../data/prefs.glade.h:53
+#: ../data/prefs.glade.h:54
 msgid "Scrollback lines:"
 msgstr "Aantal regels:"
 
-#: ../data/prefs.glade.h:54
+#: ../data/prefs.glade.h:55
 msgid "On output"
 msgstr "Bij uitvoer"
 
-#: ../data/prefs.glade.h:55
+#: ../data/prefs.glade.h:56
 msgid "On key stroke"
 msgstr "Na toetsaanslag"
 
-#: ../data/prefs.glade.h:56
+#: ../data/prefs.glade.h:57
 msgid "<b>Scroll</b>"
 msgstr "<b>Meeschuiven</b>"
 
-#: ../data/prefs.glade.h:57
+#: ../data/prefs.glade.h:58
 msgid "Scrolling"
 msgstr "Schuiven"
 
-#: ../data/prefs.glade.h:58
+#: ../data/prefs.glade.h:59
 msgid "Use the system fixed width font"
 msgstr "Gebruik systeemlettertype (fixed width)"
 
-#: ../data/prefs.glade.h:59
+#: ../data/prefs.glade.h:60
 msgid "Font:"
 msgstr "Lettertype:"
 
-#: ../data/prefs.glade.h:60
+#: ../data/prefs.glade.h:61
 msgid "Choose some font"
 msgstr "Kies een lettertype"
 
-#: ../data/prefs.glade.h:61
+#: ../data/prefs.glade.h:62
 msgid "Text color:"
 msgstr "Tekstkleur:"
 
-#: ../data/prefs.glade.h:62
+#: ../data/prefs.glade.h:63
 msgid "Background color:"
 msgstr "Achtergrondkleur:"
 
-#: ../data/prefs.glade.h:63
+#: ../data/prefs.glade.h:64
 msgid "Cursor shape:"
 msgstr ""
 
-#: ../data/prefs.glade.h:64
+#: ../data/prefs.glade.h:65
 msgid ""
 "Block\n"
 "I-Beam\n"
 "Underline"
 msgstr ""
 
-#: ../data/prefs.glade.h:67
+#: ../data/prefs.glade.h:68
 msgid ""
 "Follow GTK+ setting\n"
 "Blink on\n"
 "Blink off"
 msgstr ""
 
-#: ../data/prefs.glade.h:70
+#: ../data/prefs.glade.h:71
 msgid "Cursor blink mode:"
 msgstr ""
 
-#: ../data/prefs.glade.h:71
+#: ../data/prefs.glade.h:72
 msgid "Allow bold font"
 msgstr ""
 
-#: ../data/prefs.glade.h:72
+#: ../data/prefs.glade.h:73
 msgid "<b>Palette</b>"
 msgstr "<b>Palet</b>"
 
-#: ../data/prefs.glade.h:73
+#: ../data/prefs.glade.h:74
 msgid "Built-in schemes:"
 msgstr "Ingebouwde schema's:"
 
-#: ../data/prefs.glade.h:74
+#: ../data/prefs.glade.h:75
 msgid "Color palette:"
 msgstr "Kleurenpalet:"
 
-#: ../data/prefs.glade.h:75
+#: ../data/prefs.glade.h:76
 #, fuzzy
 msgid "Font color"
 msgstr "Tekstkleur:"
 
-#: ../data/prefs.glade.h:76
+#: ../data/prefs.glade.h:77
 #, fuzzy
 msgid "Background color"
 msgstr "Achtergrondkleur:"
 
-#: ../data/prefs.glade.h:77
+#: ../data/prefs.glade.h:78
 msgid "Use font and background color from the palette"
 msgstr ""
 
-#: ../data/prefs.glade.h:78
+#: ../data/prefs.glade.h:79
 msgid "Demo:"
 msgstr ""
 
-#: ../data/prefs.glade.h:79
+#: ../data/prefs.glade.h:80
 msgid "<b>Effects</b>"
 msgstr "<b>Effecten</b>"
 
-#: ../data/prefs.glade.h:80
+#: ../data/prefs.glade.h:81
 msgid "Transparency:"
 msgstr "Transparantie:"
 
-#: ../data/prefs.glade.h:81
+#: ../data/prefs.glade.h:82
 msgid "Background image:"
 msgstr "Achtergrondafbeelding:"
 
-#: ../data/prefs.glade.h:82
+#: ../data/prefs.glade.h:83 ../src/guake/prefs.py:130
 msgid "Appearance"
 msgstr "Uiterlijk"
 
-#: ../data/prefs.glade.h:83
+#: ../data/prefs.glade.h:84
 msgid ""
 "<small>Quick open is a feature allowing you to open a file directly into "
 "your favorite text editor by clicking on its filename when it appears in "
@@ -468,15 +472,15 @@ msgid ""
 "extract filename below.</small>"
 msgstr ""
 
-#: ../data/prefs.glade.h:84
+#: ../data/prefs.glade.h:85
 msgid "Enable Quick Open when Ctrl+clicking on a filename in the terminal"
 msgstr ""
 
-#: ../data/prefs.glade.h:85
+#: ../data/prefs.glade.h:86
 msgid "Editor command line:"
 msgstr ""
 
-#: ../data/prefs.glade.h:87
+#: ../data/prefs.glade.h:88
 #, no-c-format
 msgid ""
 "<small><i>Use the following elements in the open editor command line:\n"
@@ -488,36 +492,36 @@ msgid ""
 "</i></small>"
 msgstr ""
 
-#: ../data/prefs.glade.h:93
+#: ../data/prefs.glade.h:94
 msgid "Quick open in current terminal"
 msgstr ""
 
-#: ../data/prefs.glade.h:94
+#: ../data/prefs.glade.h:95
 msgid ""
 "Here is the list of supported patterns: (to add your own, please contact the "
 "Guake's authors)"
 msgstr ""
 
-#: ../data/prefs.glade.h:95
+#: ../data/prefs.glade.h:96
 #, fuzzy
 msgid "<b>Quick Open</b>"
 msgstr "<b>Palet</b>"
 
-#: ../data/prefs.glade.h:96
+#: ../data/prefs.glade.h:97
 msgid "Quick Open"
 msgstr ""
 
-#: ../data/prefs.glade.h:97
+#: ../data/prefs.glade.h:98
 msgid ""
 "To change a shortcut simply click on its name.\n"
 "To disable a shortcut, press the \"Backspace\" key."
 msgstr ""
 
-#: ../data/prefs.glade.h:99
+#: ../data/prefs.glade.h:100
 msgid "Keyboard shortcuts"
 msgstr "Sneltoetsen"
 
-#: ../data/prefs.glade.h:100
+#: ../data/prefs.glade.h:101
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -529,7 +533,7 @@ msgstr ""
 "en besturingssystemen die ander terminal-gedrag verwachten omzeild kunnen "
 "worden.</i></small>"
 
-#: ../data/prefs.glade.h:101
+#: ../data/prefs.glade.h:102
 msgid ""
 "ASCII DEL\n"
 "Escape sequence\n"
@@ -539,38 +543,37 @@ msgstr ""
 "Escape sequentie\n"
 "Control-H"
 
-#: ../data/prefs.glade.h:104
+#: ../data/prefs.glade.h:105
 msgid "_Backspace key generates:"
 msgstr "Resultaat _terug-toets:"
 
-#: ../data/prefs.glade.h:105
+#: ../data/prefs.glade.h:106
 msgid "_Delete key generates:"
 msgstr "Resultaat _verwijder-toets:"
 
-#: ../data/prefs.glade.h:106
+#: ../data/prefs.glade.h:107
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "_Herstel standaard-instellingen"
 
-#: ../data/prefs.glade.h:107
+#: ../data/prefs.glade.h:108
 msgid "<b>Keyboard compatibility</b>"
 msgstr "<b>Toetsenbord-compatibiliteit</b>"
 
-#: ../data/prefs.glade.h:108
+#: ../data/prefs.glade.h:109
 msgid "Compatibility"
 msgstr "Compatibiliteit"
 
-#: ../src/guake/about.py:47 ../src/guake/gconfhandler.py:427
-#: ../src/guake/guake_app.py:177 ../src/guake/guake_app.py:348
+#: ../src/guake/about.py:47 ../src/guake/gconfhandler.py:435
+#: ../src/guake/guake_app.py:181 ../src/guake/guake_app.py:376
 msgid "Guake Terminal"
 msgstr "Guake Terminal"
 
-#. Adding a new radio button to the tabbar
-#: ../src/guake/gconfhandler.py:365 ../src/guake/guake_app.py:1548
+#: ../src/guake/gconfhandler.py:368 ../src/guake/guake_app.py:1363
 #, fuzzy
 msgid "Terminal"
 msgstr "Terminal %s"
 
-#: ../src/guake/gconfhandler.py:428
+#: ../src/guake/gconfhandler.py:436
 #, python-format
 msgid ""
 "A problem happened when binding <b>%s</b> key.\n"
@@ -580,183 +583,187 @@ msgstr ""
 "Gebruik het Guake Instellingen-dialoogvenster om een andere toets te binden "
 "(Het notificatievak-pictogram was geactiveerd)"
 
-#: ../src/guake/guake_app.py:128
+#: ../src/guake/guake_app.py:132
 #, fuzzy
 msgid "Do you want to close the tab?"
 msgstr "Weet je zeker dat je Guake! wilt afsluiten!?"
 
-#: ../src/guake/guake_app.py:131
+#: ../src/guake/guake_app.py:135
 #, fuzzy
 msgid "Do you really want to quit Guake?"
 msgstr "Weet je zeker dat je Guake! wilt afsluiten!?"
 
-#: ../src/guake/guake_app.py:133
+#: ../src/guake/guake_app.py:137
 #, fuzzy
 msgid " and one tab open"
 msgstr "Voeg een nieuwe tab toe"
 
-#: ../src/guake/guake_app.py:135
+#: ../src/guake/guake_app.py:139
 #, python-brace-format
 msgid " and {0} tabs open"
 msgstr ""
 
-#: ../src/guake/guake_app.py:138
+#: ../src/guake/guake_app.py:142
 #, fuzzy
 msgid "There are no processes running"
 msgstr "<b>Er draait nog steeds een proces.</b>"
 
-#: ../src/guake/guake_app.py:140
+#: ../src/guake/guake_app.py:144
 #, fuzzy
 msgid "There is a process still running"
 msgstr "<b>Er draait nog steeds een proces.</b>"
 
-#: ../src/guake/guake_app.py:142
+#: ../src/guake/guake_app.py:146
 #, fuzzy, python-brace-format
 msgid "There are {0} processes still running"
 msgstr "<b>Er draaien %d processen.</b>"
 
-#: ../src/guake/guake_app.py:182
+#: ../src/guake/guake_app.py:186
 msgid "guake-indicator"
 msgstr ""
 
-#: ../src/guake/guake_app.py:182
+#: ../src/guake/guake_app.py:186
 msgid "guake-tray"
 msgstr ""
 
-#: ../src/guake/guake_app.py:186
+#: ../src/guake/guake_app.py:190
 msgid "Show"
 msgstr ""
 
-#: ../src/guake/guake_app.py:349
+#: ../src/guake/guake_app.py:377
 #, python-format
 msgid ""
 "Guake is now running,\n"
 "press <b>%s</b> to use it."
 msgstr "Guake is beschikbaar onder de <b>%s</b>-toets."
 
-#: ../src/guake/guake_app.py:611
+#: ../src/guake/guake_app.py:665
 #, python-format
 msgid "Search on Web: '%s'"
 msgstr ""
 
-#: ../src/guake/guake_app.py:616
+#: ../src/guake/guake_app.py:670
 msgid "Search on Web (no selection)"
 msgstr ""
 
-#: ../src/guake/guake_app.py:622
+#: ../src/guake/guake_app.py:678
+msgid "Open Link: '{}...'"
+msgstr ""
+
+#: ../src/guake/guake_app.py:680
 msgid "Open Link: {}"
 msgstr ""
 
-#: ../src/guake/guake_app.py:625
+#: ../src/guake/guake_app.py:683
 msgid "Open Link..."
 msgstr ""
 
-#: ../src/guake/guake_app.py:1300
+#: ../src/guake/guake_app.py:1402
 msgid "Rename tab"
 msgstr "Hernoem tab"
 
-#: ../src/guake/guake_app.py:1591
+#: ../src/guake/guake_app.py:1716
 msgid "Save to..."
 msgstr ""
 
-#: ../src/guake/guake_app.py:1598 ../src/guake/prefs.py:930
+#: ../src/guake/guake_app.py:1723 ../src/guake/prefs.py:998
 msgid "All files"
 msgstr ""
 
-#: ../src/guake/guake_app.py:1603
+#: ../src/guake/guake_app.py:1728
 msgid "Text and Logs"
 msgstr ""
 
-#: ../src/guake/guake_app.py:1621
+#: ../src/guake/guake_app.py:1746
 msgid "Find"
 msgstr ""
 
-#: ../src/guake/guake_app.py:1623
+#: ../src/guake/guake_app.py:1748
 msgid "Forward"
 msgstr ""
 
-#: ../src/guake/guake_app.py:1624
+#: ../src/guake/guake_app.py:1749
 msgid "Backward"
 msgstr ""
 
-#: ../src/guake/main.py:67
+#: ../src/guake/main.py:68
 msgid "Put Guake in fullscreen mode"
 msgstr ""
 
-#: ../src/guake/main.py:71
+#: ../src/guake/main.py:72
 msgid "Toggles the visibility of the terminal window"
 msgstr "Schakel zichtbaarheid van terminal-scherm aan of uit"
 
-#: ../src/guake/main.py:75
+#: ../src/guake/main.py:76
 #, fuzzy
 msgid "Shows Guake main window"
 msgstr "Toont Guake instellingen-scherm"
 
-#: ../src/guake/main.py:79
+#: ../src/guake/main.py:80
 #, fuzzy
 msgid "Hides Guake main window"
 msgstr "Toont Guake instellingen-scherm"
 
-#: ../src/guake/main.py:83
+#: ../src/guake/main.py:84
 msgid "Shows Guake preference window"
 msgstr "Toont Guake instellingen-scherm"
 
-#: ../src/guake/main.py:87
+#: ../src/guake/main.py:88
 msgid "Shows Guake's about info"
 msgstr "Toont informatie over Guake"
 
-#: ../src/guake/main.py:91
+#: ../src/guake/main.py:92
 #, fuzzy
 msgid "Add a new tab (with current directory set to NEW_TAB)"
 msgstr "_Open nieuwe tab in huidige directory"
 
-#: ../src/guake/main.py:95
+#: ../src/guake/main.py:96
 msgid "Select a tab (SELECT_TAB is the index of the tab)"
 msgstr ""
 
-#: ../src/guake/main.py:99
+#: ../src/guake/main.py:100
 msgid "Return the selected tab index."
 msgstr "Geef de geselecteerde tabindex"
 
-#: ../src/guake/main.py:103
+#: ../src/guake/main.py:104
 msgid "Execute an arbitrary command in the selected tab."
 msgstr "Voer een willekeurig commando uit in de geselecteerde tab."
 
-#: ../src/guake/main.py:107
+#: ../src/guake/main.py:108
 msgid "Specify the tab to rename. Default is 0."
 msgstr ""
 
-#: ../src/guake/main.py:111
+#: ../src/guake/main.py:112
 msgid "Set the hexadecimal (#rrggbb) background color of the selected tab."
 msgstr ""
 
-#: ../src/guake/main.py:116
+#: ../src/guake/main.py:117
 msgid "Set the hexadecimal (#rrggbb) foreground color of the selected tab."
 msgstr ""
 
-#: ../src/guake/main.py:122
+#: ../src/guake/main.py:123
 msgid ""
 "Rename the specified tab. Reset to default if TITLE is a single dash \"-\"."
 msgstr ""
 
-#: ../src/guake/main.py:128
+#: ../src/guake/main.py:129
 msgid ""
 "Rename the current tab. Reset to default if TITLE is a single dash \"-\"."
 msgstr ""
 
-#: ../src/guake/main.py:133
+#: ../src/guake/main.py:134
 msgid "Says to Guake go away =("
 msgstr "Zegt tegen Guake: Ga weg =("
 
-#: ../src/guake/main.py:137
+#: ../src/guake/main.py:138
 msgid "Do not execute the start up script"
 msgstr ""
 
-#: ../src/guake/main.py:231
+#: ../src/guake/main.py:235
 msgid "Guake can not init!"
 msgstr "Guake kan niet worden geinitialiseerd!"
 
-#: ../src/guake/main.py:232
+#: ../src/guake/main.py:236
 #, fuzzy
 msgid ""
 "Gconf Error.\n"
@@ -770,32 +777,190 @@ msgstr ""
 msgid "<user shell>"
 msgstr "<gebruiker shell>"
 
-#: ../src/guake/prefs.py:467
+#: ../src/guake/prefs.py:77
+msgid "Toggle Guake visibility"
+msgstr "Schakel zichtbaarheid van Guake aan of uit"
+
+#: ../src/guake/prefs.py:81
+#, fuzzy
+msgid "Toggle Hide on Lose Focus"
+msgstr "Verbergen bij het verliezen van focus"
+
+#: ../src/guake/prefs.py:88
+msgid "Tab management"
+msgstr "Tab-beheer"
+
+#: ../src/guake/prefs.py:90
+#, fuzzy
+msgid "New tab"
+msgstr "Nieuwe tab"
+
+#: ../src/guake/prefs.py:92
+msgid "Close tab"
+msgstr "Sluit tab"
+
+#: ../src/guake/prefs.py:94
+msgid "Rename current tab"
+msgstr "Hernoem huidige tab"
+
+#: ../src/guake/prefs.py:97
+msgid "Navigation"
+msgstr "Navigatie"
+
+#: ../src/guake/prefs.py:99
+msgid "Go to previous tab"
+msgstr "Ga naar de vorige tab"
+
+#: ../src/guake/prefs.py:101
+msgid "Go to next tab"
+msgstr "Ga naar de volgende tab"
+
+#: ../src/guake/prefs.py:103
+#, fuzzy
+msgid "Move current tab left"
+msgstr "Hernoem huidige tab"
+
+#: ../src/guake/prefs.py:105
+#, fuzzy
+msgid "Move current tab right"
+msgstr "Hernoem huidige tab"
+
+#: ../src/guake/prefs.py:107
+#, fuzzy
+msgid "Go to first tab"
+msgstr "Ga naar de volgende tab"
+
+#: ../src/guake/prefs.py:109
+#, fuzzy
+msgid "Go to second tab"
+msgstr "Ga naar de volgende tab"
+
+#: ../src/guake/prefs.py:111
+#, fuzzy
+msgid "Go to third tab"
+msgstr "Ga naar de volgende tab"
+
+#: ../src/guake/prefs.py:113
+#, fuzzy
+msgid "Go to fourth tab"
+msgstr "Ga naar de volgende tab"
+
+#: ../src/guake/prefs.py:115
+#, fuzzy
+msgid "Go to fifth tab"
+msgstr "Ga naar de volgende tab"
+
+#: ../src/guake/prefs.py:117
+#, fuzzy
+msgid "Go to sixth tab"
+msgstr "Ga naar de volgende tab"
+
+#: ../src/guake/prefs.py:119
+#, fuzzy
+msgid "Go to seventh tab"
+msgstr "Ga naar de volgende tab"
+
+#: ../src/guake/prefs.py:121
+#, fuzzy
+msgid "Go to eighth tab"
+msgstr "Ga naar de volgende tab"
+
+#: ../src/guake/prefs.py:123
+#, fuzzy
+msgid "Go to ninth tab"
+msgstr "Ga naar de volgende tab"
+
+#: ../src/guake/prefs.py:125
+#, fuzzy
+msgid "Go to tenth tab"
+msgstr "Ga naar de volgende tab"
+
+#: ../src/guake/prefs.py:127
+#, fuzzy
+msgid "Go to last tab"
+msgstr "Ga naar de volgende tab"
+
+#: ../src/guake/prefs.py:132
+msgid "Zoom out"
+msgstr ""
+
+#: ../src/guake/prefs.py:134
+msgid "Zoom in"
+msgstr ""
+
+#: ../src/guake/prefs.py:136
+msgid "Zoom in (alternative)"
+msgstr ""
+
+#: ../src/guake/prefs.py:138
+msgid "Increase height"
+msgstr ""
+
+#: ../src/guake/prefs.py:140
+msgid "Decrease height"
+msgstr ""
+
+#: ../src/guake/prefs.py:142
+#, fuzzy
+msgid "Increase transparency"
+msgstr "Transparantie:"
+
+#: ../src/guake/prefs.py:144
+#, fuzzy
+msgid "Decrease transparency"
+msgstr "Transparantie:"
+
+#: ../src/guake/prefs.py:146
+#, fuzzy
+msgid "Toggle transparency"
+msgstr "Transparantie:"
+
+#: ../src/guake/prefs.py:149
+msgid "Clipboard"
+msgstr "Klembord"
+
+#: ../src/guake/prefs.py:151
+msgid "Copy text to clipboard"
+msgstr "Kopieer tekst naar klembord"
+
+#: ../src/guake/prefs.py:153
+msgid "Paste text from clipboard"
+msgstr "Plak tekst van klembord"
+
+#: ../src/guake/prefs.py:156
+msgid "Extra features"
+msgstr ""
+
+#: ../src/guake/prefs.py:159
+msgid "Search select text on web"
+msgstr ""
+
+#: ../src/guake/prefs.py:519
 msgid "Action"
 msgstr "Actie"
 
-#: ../src/guake/prefs.py:477
+#: ../src/guake/prefs.py:529
 msgid "Shortcut"
 msgstr "Sneltoets"
 
-#: ../src/guake/prefs.py:619 ../src/guake/prefs.py:665
+#: ../src/guake/prefs.py:678 ../src/guake/prefs.py:724
 msgid "Custom"
 msgstr ""
 
-#: ../src/guake/prefs.py:926
+#: ../src/guake/prefs.py:994
 msgid "JSON files"
 msgstr ""
 
-#: ../src/guake/prefs.py:1019
+#: ../src/guake/prefs.py:1088
 #, python-format
 msgid "The shortcut \"%s\" is already in use."
 msgstr "De sneltoets \"%s\" is al in gebruik,"
 
-#: ../src/guake/prefs.py:1020
+#: ../src/guake/prefs.py:1089
 msgid "Error setting keybinding."
 msgstr "Fout bij het instellen van toets-binding."
 
-#: ../src/guake/prefs.py:1032
+#: ../src/guake/prefs.py:1101
 #, python-format
 msgid ""
 "The shortcut \"%s\" cannot be used because it will become impossible to type "
@@ -835,33 +1000,3 @@ msgstr ""
 
 #~ msgid "Rename the selected tab."
 #~ msgstr "Hernoem de geselecteerde tab."
-
-#~ msgid "Toggle Guake visibility"
-#~ msgstr "Schakel zichtbaarheid van Guake aan of uit"
-
-#~ msgid "Tab management"
-#~ msgstr "Tab-beheer"
-
-#~ msgid "Close tab"
-#~ msgstr "Sluit tab"
-
-#~ msgid "Rename current tab"
-#~ msgstr "Hernoem huidige tab"
-
-#~ msgid "Navigation"
-#~ msgstr "Navigatie"
-
-#~ msgid "Go to previous tab"
-#~ msgstr "Ga naar de vorige tab"
-
-#~ msgid "Go to next tab"
-#~ msgstr "Ga naar de volgende tab"
-
-#~ msgid "Clipboard"
-#~ msgstr "Klembord"
-
-#~ msgid "Copy text to clipboard"
-#~ msgstr "Kopieer tekst naar klembord"
-
-#~ msgid "Paste text from clipboard"
-#~ msgstr "Plak tekst van klembord"

--- a/po/pa.po
+++ b/po/pa.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Guake 0.4.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-12-01 16:49+0100\n"
+"POT-Creation-Date: 2016-08-17 21:41+0000\n"
 "PO-Revision-Date: 2010-07-13 08:13+0530\n"
 "Last-Translator: A S Alam <aalam@users.sf.net>\n"
 "Language-Team: Punjabi/Panjabi <punjabi-users@lists.sf.net>\n"
@@ -80,7 +80,7 @@ msgstr "ਕਾਪੀ ਕਰੋ"
 msgid "Paste"
 msgstr "ਚੇਪੋ"
 
-#: ../data/guake.glade.h:3
+#: ../data/guake.glade.h:3 ../src/guake/prefs.py:79
 msgid "Toggle Fullscreen"
 msgstr "ਪੂਰੀ ਸਕਰੀਨ ਬਦਲੋ"
 
@@ -88,7 +88,7 @@ msgstr "ਪੂਰੀ ਸਕਰੀਨ ਬਦਲੋ"
 msgid "Save to File..."
 msgstr ""
 
-#: ../data/guake.glade.h:5
+#: ../data/guake.glade.h:5 ../src/guake/prefs.py:85
 #, fuzzy
 msgid "Reset terminal"
 msgstr "ਗੁਆਕੀ ਟਰਮੀਨਲ"
@@ -119,7 +119,7 @@ msgstr ""
 msgid "Search on Web"
 msgstr ""
 
-#: ../data/guake.glade.h:12
+#: ../data/guake.glade.h:12 ../src/guake/prefs.py:83
 msgid "Quit"
 msgstr "ਬਾਹਰ"
 
@@ -242,202 +242,206 @@ msgid "Use VTE titles for tab names"
 msgstr ""
 
 #: ../data/prefs.glade.h:33
-msgid "Max tab name length:"
+msgid "Abbreviate directories in tab names"
 msgstr ""
 
 #: ../data/prefs.glade.h:34
+msgid "Max tab name length:"
+msgstr ""
+
+#: ../data/prefs.glade.h:35
 msgid "Hide on lose focus"
 msgstr "ਫੋਕਸ ਖਤਮ ਹੋਣ ਉੱਤੇ ਓਹਲੇ ਕਰੋ"
 
-#: ../data/prefs.glade.h:35
+#: ../data/prefs.glade.h:36
 msgid "Show tab bar"
 msgstr "ਟੈਬ ਪੱਟੀ ਵੇਖੋ"
 
-#: ../data/prefs.glade.h:36
+#: ../data/prefs.glade.h:37
 #, fuzzy
 msgid "Start fullscreen"
 msgstr "ਪੂਰੀ ਸਕਰੀਨ ਬਦਲੋ"
 
-#: ../data/prefs.glade.h:37
+#: ../data/prefs.glade.h:38
 msgid "<b>Main Window</b>"
 msgstr "<b>ਮੇਨ ਵਿੰਡੋ</b>"
 
-#: ../data/prefs.glade.h:38
+#: ../data/prefs.glade.h:39
 msgid "Left"
 msgstr ""
 
-#: ../data/prefs.glade.h:39
+#: ../data/prefs.glade.h:40
 msgid "Center"
 msgstr ""
 
-#: ../data/prefs.glade.h:40
+#: ../data/prefs.glade.h:41
 msgid "Right"
 msgstr ""
 
-#: ../data/prefs.glade.h:41
+#: ../data/prefs.glade.h:42
 #, fuzzy
 msgid "<b>Main Window Horizontal Alignment</b>"
 msgstr "<b>ਮੇਨ ਵਿੰਡੋ ਉਚਾਈ</b>"
 
-#: ../data/prefs.glade.h:42
+#: ../data/prefs.glade.h:43
 #, fuzzy
 msgid "<b>Main Window Height</b>"
 msgstr "<b>ਮੇਨ ਵਿੰਡੋ ਉਚਾਈ</b>"
 
-#: ../data/prefs.glade.h:43
+#: ../data/prefs.glade.h:44
 #, fuzzy
 msgid "<b>Main Window Width</b>"
 msgstr "<b>ਮੇਨ ਵਿੰਡੋ ਉਚਾਈ</b>"
 
-#: ../data/prefs.glade.h:44
+#: ../data/prefs.glade.h:45
 msgid "Custom command file path: "
 msgstr ""
 
-#: ../data/prefs.glade.h:45
+#: ../data/prefs.glade.h:46
 msgid "Please select a json file"
 msgstr ""
 
-#: ../data/prefs.glade.h:46
+#: ../data/prefs.glade.h:47 ../src/guake/prefs.py:75
 msgid "General"
 msgstr "ਆਮ"
 
-#: ../data/prefs.glade.h:47
+#: ../data/prefs.glade.h:48
 msgid "Default interpreter:"
 msgstr "ਡਿਫਾਲਟ ਇੰਟਰਪਰੇਟਰ:"
 
-#: ../data/prefs.glade.h:48
+#: ../data/prefs.glade.h:49
 msgid "_Run command as a login shell"
 msgstr "ਕਮਾਂਡ ਲਾਗਇਨ ਸ਼ੈੱਲ ਵਜੋਂ ਚਲਾਓ(_R)"
 
-#: ../data/prefs.glade.h:49
+#: ../data/prefs.glade.h:50
 msgid "_Open new tab in current directory"
 msgstr "ਮੌਜੂਦਾ ਡਾਇਰੈਕਟਰੀ ਵਿੱਚ ਨਵੀਂ ਟੈਬ ਖੋਲ੍ਹੋ(_O)"
 
-#: ../data/prefs.glade.h:50
+#: ../data/prefs.glade.h:51
 msgid "<b>Shell</b>"
 msgstr "<b>ਸ਼ੈੱਲ</b>"
 
-#: ../data/prefs.glade.h:51
+#: ../data/prefs.glade.h:52
 msgid "Shell"
 msgstr ""
 
-#: ../data/prefs.glade.h:52
+#: ../data/prefs.glade.h:53
 msgid "Show scrollbar"
 msgstr "ਸਕਰੋਲਬਾਰ ਵੇਖੋ"
 
-#: ../data/prefs.glade.h:53
+#: ../data/prefs.glade.h:54
 msgid "Scrollback lines:"
 msgstr "ਸਕਰੋਲਬੈਕ ਲਾਈਨਾਂ:"
 
-#: ../data/prefs.glade.h:54
+#: ../data/prefs.glade.h:55
 msgid "On output"
 msgstr "ਆਉਟਪੁੱਟ ਉੱਤੇ"
 
-#: ../data/prefs.glade.h:55
+#: ../data/prefs.glade.h:56
 msgid "On key stroke"
 msgstr "ਕੁੰਜੀ ਦੱਬਣ ਉੱਤੇ"
 
-#: ../data/prefs.glade.h:56
+#: ../data/prefs.glade.h:57
 msgid "<b>Scroll</b>"
 msgstr "<b>ਸਕਰੋਲ</b>"
 
-#: ../data/prefs.glade.h:57
+#: ../data/prefs.glade.h:58
 msgid "Scrolling"
 msgstr "ਸਕਰੋਲਿੰਗ"
 
-#: ../data/prefs.glade.h:58
+#: ../data/prefs.glade.h:59
 msgid "Use the system fixed width font"
 msgstr "ਸਿਸਟਮ ਸਥਿਰ ਚੌੜਾਈ ਫੋਂਟ ਵਰਤੋਂ"
 
-#: ../data/prefs.glade.h:59
+#: ../data/prefs.glade.h:60
 msgid "Font:"
 msgstr "ਫੋਂਟ:"
 
-#: ../data/prefs.glade.h:60
+#: ../data/prefs.glade.h:61
 msgid "Choose some font"
 msgstr "ਕੁਝ ਫੋਟ ਚੁਣੋ"
 
-#: ../data/prefs.glade.h:61
+#: ../data/prefs.glade.h:62
 msgid "Text color:"
 msgstr "ਟੈਕਸਟ ਰੰਗ:"
 
-#: ../data/prefs.glade.h:62
+#: ../data/prefs.glade.h:63
 msgid "Background color:"
 msgstr "ਬੈਕਗਰਾਊਂਡ ਰੰਗ:"
 
-#: ../data/prefs.glade.h:63
+#: ../data/prefs.glade.h:64
 msgid "Cursor shape:"
 msgstr ""
 
-#: ../data/prefs.glade.h:64
+#: ../data/prefs.glade.h:65
 msgid ""
 "Block\n"
 "I-Beam\n"
 "Underline"
 msgstr ""
 
-#: ../data/prefs.glade.h:67
+#: ../data/prefs.glade.h:68
 msgid ""
 "Follow GTK+ setting\n"
 "Blink on\n"
 "Blink off"
 msgstr ""
 
-#: ../data/prefs.glade.h:70
+#: ../data/prefs.glade.h:71
 msgid "Cursor blink mode:"
 msgstr ""
 
-#: ../data/prefs.glade.h:71
+#: ../data/prefs.glade.h:72
 msgid "Allow bold font"
 msgstr ""
 
-#: ../data/prefs.glade.h:72
+#: ../data/prefs.glade.h:73
 msgid "<b>Palette</b>"
 msgstr "<b>ਰੰਗ-ਪੱਟੀ</b>"
 
-#: ../data/prefs.glade.h:73
+#: ../data/prefs.glade.h:74
 msgid "Built-in schemes:"
 msgstr "ਬਿਲਟ-ਇਨ ਸਕੀਮ:"
 
-#: ../data/prefs.glade.h:74
+#: ../data/prefs.glade.h:75
 msgid "Color palette:"
 msgstr "ਰੰਗ ਪਲੇਅਟ:"
 
-#: ../data/prefs.glade.h:75
+#: ../data/prefs.glade.h:76
 #, fuzzy
 msgid "Font color"
 msgstr "ਟੈਕਸਟ ਰੰਗ:"
 
-#: ../data/prefs.glade.h:76
+#: ../data/prefs.glade.h:77
 #, fuzzy
 msgid "Background color"
 msgstr "ਬੈਕਗਰਾਊਂਡ ਰੰਗ:"
 
-#: ../data/prefs.glade.h:77
+#: ../data/prefs.glade.h:78
 msgid "Use font and background color from the palette"
 msgstr ""
 
-#: ../data/prefs.glade.h:78
+#: ../data/prefs.glade.h:79
 msgid "Demo:"
 msgstr ""
 
-#: ../data/prefs.glade.h:79
+#: ../data/prefs.glade.h:80
 msgid "<b>Effects</b>"
 msgstr "<b>ਪਰਭਾਵ</b>"
 
-#: ../data/prefs.glade.h:80
+#: ../data/prefs.glade.h:81
 msgid "Transparency:"
 msgstr "ਟਰਾਂਸਪਰੇਸੀ:"
 
-#: ../data/prefs.glade.h:81
+#: ../data/prefs.glade.h:82
 msgid "Background image:"
 msgstr "ਬੈਕਗਰਾਊਂਡ ਚਿੱਤਰ:"
 
-#: ../data/prefs.glade.h:82
+#: ../data/prefs.glade.h:83 ../src/guake/prefs.py:130
 msgid "Appearance"
 msgstr "ਦਿੱਖ"
 
-#: ../data/prefs.glade.h:83
+#: ../data/prefs.glade.h:84
 msgid ""
 "<small>Quick open is a feature allowing you to open a file directly into "
 "your favorite text editor by clicking on its filename when it appears in "
@@ -445,15 +449,15 @@ msgid ""
 "extract filename below.</small>"
 msgstr ""
 
-#: ../data/prefs.glade.h:84
+#: ../data/prefs.glade.h:85
 msgid "Enable Quick Open when Ctrl+clicking on a filename in the terminal"
 msgstr ""
 
-#: ../data/prefs.glade.h:85
+#: ../data/prefs.glade.h:86
 msgid "Editor command line:"
 msgstr ""
 
-#: ../data/prefs.glade.h:87
+#: ../data/prefs.glade.h:88
 #, no-c-format
 msgid ""
 "<small><i>Use the following elements in the open editor command line:\n"
@@ -465,36 +469,36 @@ msgid ""
 "</i></small>"
 msgstr ""
 
-#: ../data/prefs.glade.h:93
+#: ../data/prefs.glade.h:94
 msgid "Quick open in current terminal"
 msgstr ""
 
-#: ../data/prefs.glade.h:94
+#: ../data/prefs.glade.h:95
 msgid ""
 "Here is the list of supported patterns: (to add your own, please contact the "
 "Guake's authors)"
 msgstr ""
 
-#: ../data/prefs.glade.h:95
+#: ../data/prefs.glade.h:96
 #, fuzzy
 msgid "<b>Quick Open</b>"
 msgstr "<b>ਰੰਗ-ਪੱਟੀ</b>"
 
-#: ../data/prefs.glade.h:96
+#: ../data/prefs.glade.h:97
 msgid "Quick Open"
 msgstr ""
 
-#: ../data/prefs.glade.h:97
+#: ../data/prefs.glade.h:98
 msgid ""
 "To change a shortcut simply click on its name.\n"
 "To disable a shortcut, press the \"Backspace\" key."
 msgstr ""
 
-#: ../data/prefs.glade.h:99
+#: ../data/prefs.glade.h:100
 msgid "Keyboard shortcuts"
 msgstr "ਕੀਬੋਰਡ ਸ਼ਾਰਟਕੱਟ"
 
-#: ../data/prefs.glade.h:100
+#: ../data/prefs.glade.h:101
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -502,7 +506,7 @@ msgid ""
 "i></small>"
 msgstr ""
 
-#: ../data/prefs.glade.h:101
+#: ../data/prefs.glade.h:102
 msgid ""
 "ASCII DEL\n"
 "Escape sequence\n"
@@ -512,92 +516,91 @@ msgstr ""
 "Escape sequence\n"
 "Control-H"
 
-#: ../data/prefs.glade.h:104
+#: ../data/prefs.glade.h:105
 msgid "_Backspace key generates:"
 msgstr "ਬੈਕਸਪੇ ਕੁੰਜੀ ਤਿਆਰ ਕਰੇ(_B):"
 
-#: ../data/prefs.glade.h:105
+#: ../data/prefs.glade.h:106
 msgid "_Delete key generates:"
 msgstr ""
 
-#: ../data/prefs.glade.h:106
+#: ../data/prefs.glade.h:107
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "ਅਨੁਕੂਲਤਾ ਚੋਣਾਂ ਡਿਫਾਲਟ ਲਈ ਮੁੜ-ਸੈੱਟ ਕਰੋ(_R)"
 
-#: ../data/prefs.glade.h:107
+#: ../data/prefs.glade.h:108
 msgid "<b>Keyboard compatibility</b>"
 msgstr "<b>ਕੀਬੋਰਡ ਅਨੁਕੂਲਤਾ</b>"
 
-#: ../data/prefs.glade.h:108
+#: ../data/prefs.glade.h:109
 msgid "Compatibility"
 msgstr "ਅਨੁਕੂਲਤਾ"
 
-#: ../src/guake/about.py:47 ../src/guake/gconfhandler.py:427
-#: ../src/guake/guake_app.py:177 ../src/guake/guake_app.py:348
+#: ../src/guake/about.py:47 ../src/guake/gconfhandler.py:435
+#: ../src/guake/guake_app.py:181 ../src/guake/guake_app.py:376
 msgid "Guake Terminal"
 msgstr "ਗੁਆਕੀ ਟਰਮੀਨਲ"
 
-#. Adding a new radio button to the tabbar
-#: ../src/guake/gconfhandler.py:365 ../src/guake/guake_app.py:1548
+#: ../src/guake/gconfhandler.py:368 ../src/guake/guake_app.py:1363
 #, fuzzy
 msgid "Terminal"
 msgstr "%s ਟਰਮੀਨਲ"
 
-#: ../src/guake/gconfhandler.py:428
+#: ../src/guake/gconfhandler.py:436
 #, python-format
 msgid ""
 "A problem happened when binding <b>%s</b> key.\n"
 "Please use Guake Preferences dialog to choose another key"
 msgstr ""
 
-#: ../src/guake/guake_app.py:128
+#: ../src/guake/guake_app.py:132
 #, fuzzy
 msgid "Do you want to close the tab?"
 msgstr "ਕੀ ਤੁਸੀਂ ਗੁਆਕੀ ਬੰਦ ਕਰਨਾ ਚਾਹੁੰਦੇ ਹੋ?"
 
-#: ../src/guake/guake_app.py:131
+#: ../src/guake/guake_app.py:135
 #, fuzzy
 msgid "Do you really want to quit Guake?"
 msgstr "ਕੀ ਤੁਸੀਂ ਗੁਆਕੀ ਬੰਦ ਕਰਨਾ ਚਾਹੁੰਦੇ ਹੋ?"
 
-#: ../src/guake/guake_app.py:133
+#: ../src/guake/guake_app.py:137
 #, fuzzy
 msgid " and one tab open"
 msgstr "ਨਵੀਂ ਟੈਬ ਸ਼ਾਮਲ"
 
-#: ../src/guake/guake_app.py:135
+#: ../src/guake/guake_app.py:139
 #, python-brace-format
 msgid " and {0} tabs open"
 msgstr ""
 
-#: ../src/guake/guake_app.py:138
+#: ../src/guake/guake_app.py:142
 #, fuzzy
 msgid "There are no processes running"
 msgstr "<b>ਹਾਲੇ ਇੱਕ ਕਾਰਵਾਈ ਚੱਲ ਰਹੀ ਹੈ।</b>"
 
-#: ../src/guake/guake_app.py:140
+#: ../src/guake/guake_app.py:144
 #, fuzzy
 msgid "There is a process still running"
 msgstr "<b>ਹਾਲੇ ਇੱਕ ਕਾਰਵਾਈ ਚੱਲ ਰਹੀ ਹੈ।</b>"
 
-#: ../src/guake/guake_app.py:142
+#: ../src/guake/guake_app.py:146
 #, fuzzy, python-brace-format
 msgid "There are {0} processes still running"
 msgstr "<b>%d ਪਰੋਸੈਸ ਚੱਲ ਰਹੇ ਹਨ।</b>"
 
-#: ../src/guake/guake_app.py:182
+#: ../src/guake/guake_app.py:186
 msgid "guake-indicator"
 msgstr ""
 
-#: ../src/guake/guake_app.py:182
+#: ../src/guake/guake_app.py:186
 msgid "guake-tray"
 msgstr ""
 
-#: ../src/guake/guake_app.py:186
+#: ../src/guake/guake_app.py:190
 msgid "Show"
 msgstr ""
 
-#: ../src/guake/guake_app.py:349
+#: ../src/guake/guake_app.py:377
 #, python-format
 msgid ""
 "Guake is now running,\n"
@@ -606,129 +609,133 @@ msgstr ""
 "ਗੁਆਕੀ ਹੁਣ ਚੱਲ ਰਿਹਾ ਹੈ।\n"
 "ਇਸ ਨੂੰ ਵਰਤਣ ਲਈ <b>%s</b> ਦੱਬੋ।"
 
-#: ../src/guake/guake_app.py:611
+#: ../src/guake/guake_app.py:665
 #, python-format
 msgid "Search on Web: '%s'"
 msgstr ""
 
-#: ../src/guake/guake_app.py:616
+#: ../src/guake/guake_app.py:670
 msgid "Search on Web (no selection)"
 msgstr ""
 
-#: ../src/guake/guake_app.py:622
+#: ../src/guake/guake_app.py:678
+msgid "Open Link: '{}...'"
+msgstr ""
+
+#: ../src/guake/guake_app.py:680
 msgid "Open Link: {}"
 msgstr ""
 
-#: ../src/guake/guake_app.py:625
+#: ../src/guake/guake_app.py:683
 msgid "Open Link..."
 msgstr ""
 
-#: ../src/guake/guake_app.py:1300
+#: ../src/guake/guake_app.py:1402
 msgid "Rename tab"
 msgstr "ਟੈਬ ਨਾਂ ਬਦਲੋ"
 
-#: ../src/guake/guake_app.py:1591
+#: ../src/guake/guake_app.py:1716
 msgid "Save to..."
 msgstr ""
 
-#: ../src/guake/guake_app.py:1598 ../src/guake/prefs.py:930
+#: ../src/guake/guake_app.py:1723 ../src/guake/prefs.py:998
 msgid "All files"
 msgstr ""
 
-#: ../src/guake/guake_app.py:1603
+#: ../src/guake/guake_app.py:1728
 msgid "Text and Logs"
 msgstr ""
 
-#: ../src/guake/guake_app.py:1621
+#: ../src/guake/guake_app.py:1746
 msgid "Find"
 msgstr ""
 
-#: ../src/guake/guake_app.py:1623
+#: ../src/guake/guake_app.py:1748
 msgid "Forward"
 msgstr ""
 
-#: ../src/guake/guake_app.py:1624
+#: ../src/guake/guake_app.py:1749
 msgid "Backward"
 msgstr ""
 
-#: ../src/guake/main.py:67
+#: ../src/guake/main.py:68
 msgid "Put Guake in fullscreen mode"
 msgstr ""
 
-#: ../src/guake/main.py:71
+#: ../src/guake/main.py:72
 msgid "Toggles the visibility of the terminal window"
 msgstr "ਟਰਮੀਨਲ ਵਿੰਡੋ ਦੀ ਦਿੱਖ ਬਦਲੋ"
 
-#: ../src/guake/main.py:75
+#: ../src/guake/main.py:76
 #, fuzzy
 msgid "Shows Guake main window"
 msgstr "ਗੁਆਕੀ ਪਸੰਦ ਵਿੰਡੋ ਵੇਖੋ"
 
-#: ../src/guake/main.py:79
+#: ../src/guake/main.py:80
 #, fuzzy
 msgid "Hides Guake main window"
 msgstr "ਗੁਆਕੀ ਪਸੰਦ ਵਿੰਡੋ ਵੇਖੋ"
 
-#: ../src/guake/main.py:83
+#: ../src/guake/main.py:84
 msgid "Shows Guake preference window"
 msgstr "ਗੁਆਕੀ ਪਸੰਦ ਵਿੰਡੋ ਵੇਖੋ"
 
-#: ../src/guake/main.py:87
+#: ../src/guake/main.py:88
 msgid "Shows Guake's about info"
 msgstr "ਗੁਆਕੀ ਬਾਰੇ ਜਾਣਕਾਰੀ ਵੇਖੋ"
 
-#: ../src/guake/main.py:91
+#: ../src/guake/main.py:92
 #, fuzzy
 msgid "Add a new tab (with current directory set to NEW_TAB)"
 msgstr "ਮੌਜੂਦਾ ਡਾਇਰੈਕਟਰੀ ਵਿੱਚ ਨਵੀਂ ਟੈਬ ਖੋਲ੍ਹੋ(_O)"
 
-#: ../src/guake/main.py:95
+#: ../src/guake/main.py:96
 msgid "Select a tab (SELECT_TAB is the index of the tab)"
 msgstr ""
 
-#: ../src/guake/main.py:99
+#: ../src/guake/main.py:100
 msgid "Return the selected tab index."
 msgstr "ਚੁਣੇ ਟੈਬ ਇੰਡੈਕਸ ਉੱਤੇ ਵਾਪਸ ਜਾਉ।"
 
-#: ../src/guake/main.py:103
+#: ../src/guake/main.py:104
 msgid "Execute an arbitrary command in the selected tab."
 msgstr ""
 
-#: ../src/guake/main.py:107
+#: ../src/guake/main.py:108
 msgid "Specify the tab to rename. Default is 0."
 msgstr ""
 
-#: ../src/guake/main.py:111
+#: ../src/guake/main.py:112
 msgid "Set the hexadecimal (#rrggbb) background color of the selected tab."
 msgstr ""
 
-#: ../src/guake/main.py:116
+#: ../src/guake/main.py:117
 msgid "Set the hexadecimal (#rrggbb) foreground color of the selected tab."
 msgstr ""
 
-#: ../src/guake/main.py:122
+#: ../src/guake/main.py:123
 msgid ""
 "Rename the specified tab. Reset to default if TITLE is a single dash \"-\"."
 msgstr ""
 
-#: ../src/guake/main.py:128
+#: ../src/guake/main.py:129
 msgid ""
 "Rename the current tab. Reset to default if TITLE is a single dash \"-\"."
 msgstr ""
 
-#: ../src/guake/main.py:133
+#: ../src/guake/main.py:134
 msgid "Says to Guake go away =("
 msgstr "ਗੁਆਕੀ ਨੂੰ ਦੂਰ ਜਾਣ ਲਈ ਕਰੋ =("
 
-#: ../src/guake/main.py:137
+#: ../src/guake/main.py:138
 msgid "Do not execute the start up script"
 msgstr ""
 
-#: ../src/guake/main.py:231
+#: ../src/guake/main.py:235
 msgid "Guake can not init!"
 msgstr ""
 
-#: ../src/guake/main.py:232
+#: ../src/guake/main.py:236
 msgid ""
 "Gconf Error.\n"
 "Have you installed <b>guake.schemas</b> properly?"
@@ -739,32 +746,190 @@ msgstr ""
 msgid "<user shell>"
 msgstr "<user shell>"
 
-#: ../src/guake/prefs.py:467
+#: ../src/guake/prefs.py:77
+msgid "Toggle Guake visibility"
+msgstr "ਗੁਆਕੀ ਦਿੱਖ ਬਦਲੋ"
+
+#: ../src/guake/prefs.py:81
+#, fuzzy
+msgid "Toggle Hide on Lose Focus"
+msgstr "ਫੋਕਸ ਖਤਮ ਹੋਣ ਉੱਤੇ ਓਹਲੇ ਕਰੋ"
+
+#: ../src/guake/prefs.py:88
+msgid "Tab management"
+msgstr "ਟੈਬ ਪਰਬੰਧ"
+
+#: ../src/guake/prefs.py:90
+#, fuzzy
+msgid "New tab"
+msgstr "ਨਵੀਂ ਟੈਬ"
+
+#: ../src/guake/prefs.py:92
+msgid "Close tab"
+msgstr "ਟੈਬ ਬੰਦ ਕਰੋ"
+
+#: ../src/guake/prefs.py:94
+msgid "Rename current tab"
+msgstr "ਮੌਜੂਦਾ ਟੈਬ ਦਾ ਨਾਂ ਬਦਲੋ"
+
+#: ../src/guake/prefs.py:97
+msgid "Navigation"
+msgstr "ਨੈਵੀਗੇਸ਼ਨ"
+
+#: ../src/guake/prefs.py:99
+msgid "Go to previous tab"
+msgstr "ਪਿਛਲੀ ਟੈਬ ਉੱਤੇ ਜਾਓ"
+
+#: ../src/guake/prefs.py:101
+msgid "Go to next tab"
+msgstr "ਅਗਲੀ ਟੈਬ ਉੱਤੇ ਜਾਓ"
+
+#: ../src/guake/prefs.py:103
+#, fuzzy
+msgid "Move current tab left"
+msgstr "ਮੌਜੂਦਾ ਟੈਬ ਦਾ ਨਾਂ ਬਦਲੋ"
+
+#: ../src/guake/prefs.py:105
+#, fuzzy
+msgid "Move current tab right"
+msgstr "ਮੌਜੂਦਾ ਟੈਬ ਦਾ ਨਾਂ ਬਦਲੋ"
+
+#: ../src/guake/prefs.py:107
+#, fuzzy
+msgid "Go to first tab"
+msgstr "ਅਗਲੀ ਟੈਬ ਉੱਤੇ ਜਾਓ"
+
+#: ../src/guake/prefs.py:109
+#, fuzzy
+msgid "Go to second tab"
+msgstr "ਅਗਲੀ ਟੈਬ ਉੱਤੇ ਜਾਓ"
+
+#: ../src/guake/prefs.py:111
+#, fuzzy
+msgid "Go to third tab"
+msgstr "ਅਗਲੀ ਟੈਬ ਉੱਤੇ ਜਾਓ"
+
+#: ../src/guake/prefs.py:113
+#, fuzzy
+msgid "Go to fourth tab"
+msgstr "ਅਗਲੀ ਟੈਬ ਉੱਤੇ ਜਾਓ"
+
+#: ../src/guake/prefs.py:115
+#, fuzzy
+msgid "Go to fifth tab"
+msgstr "ਅਗਲੀ ਟੈਬ ਉੱਤੇ ਜਾਓ"
+
+#: ../src/guake/prefs.py:117
+#, fuzzy
+msgid "Go to sixth tab"
+msgstr "ਅਗਲੀ ਟੈਬ ਉੱਤੇ ਜਾਓ"
+
+#: ../src/guake/prefs.py:119
+#, fuzzy
+msgid "Go to seventh tab"
+msgstr "ਅਗਲੀ ਟੈਬ ਉੱਤੇ ਜਾਓ"
+
+#: ../src/guake/prefs.py:121
+#, fuzzy
+msgid "Go to eighth tab"
+msgstr "ਅਗਲੀ ਟੈਬ ਉੱਤੇ ਜਾਓ"
+
+#: ../src/guake/prefs.py:123
+#, fuzzy
+msgid "Go to ninth tab"
+msgstr "ਅਗਲੀ ਟੈਬ ਉੱਤੇ ਜਾਓ"
+
+#: ../src/guake/prefs.py:125
+#, fuzzy
+msgid "Go to tenth tab"
+msgstr "ਅਗਲੀ ਟੈਬ ਉੱਤੇ ਜਾਓ"
+
+#: ../src/guake/prefs.py:127
+#, fuzzy
+msgid "Go to last tab"
+msgstr "ਅਗਲੀ ਟੈਬ ਉੱਤੇ ਜਾਓ"
+
+#: ../src/guake/prefs.py:132
+msgid "Zoom out"
+msgstr ""
+
+#: ../src/guake/prefs.py:134
+msgid "Zoom in"
+msgstr ""
+
+#: ../src/guake/prefs.py:136
+msgid "Zoom in (alternative)"
+msgstr ""
+
+#: ../src/guake/prefs.py:138
+msgid "Increase height"
+msgstr ""
+
+#: ../src/guake/prefs.py:140
+msgid "Decrease height"
+msgstr ""
+
+#: ../src/guake/prefs.py:142
+#, fuzzy
+msgid "Increase transparency"
+msgstr "ਟਰਾਂਸਪਰੇਸੀ:"
+
+#: ../src/guake/prefs.py:144
+#, fuzzy
+msgid "Decrease transparency"
+msgstr "ਟਰਾਂਸਪਰੇਸੀ:"
+
+#: ../src/guake/prefs.py:146
+#, fuzzy
+msgid "Toggle transparency"
+msgstr "ਟਰਾਂਸਪਰੇਸੀ:"
+
+#: ../src/guake/prefs.py:149
+msgid "Clipboard"
+msgstr "ਕਲਿੱਪਬੋਰਡ"
+
+#: ../src/guake/prefs.py:151
+msgid "Copy text to clipboard"
+msgstr "ਟੈਕਸਟ ਕਲਿੱਪਬੋਰਡ 'ਚ ਕਾਪੀ ਕਰੋ"
+
+#: ../src/guake/prefs.py:153
+msgid "Paste text from clipboard"
+msgstr "ਕਲਿੱਪਬੋਰਡ 'ਚ ਟੈਕਸਟ ਚੇਪੋ"
+
+#: ../src/guake/prefs.py:156
+msgid "Extra features"
+msgstr ""
+
+#: ../src/guake/prefs.py:159
+msgid "Search select text on web"
+msgstr ""
+
+#: ../src/guake/prefs.py:519
 msgid "Action"
 msgstr "ਐਕਸ਼ਨ"
 
-#: ../src/guake/prefs.py:477
+#: ../src/guake/prefs.py:529
 msgid "Shortcut"
 msgstr "ਸ਼ਾਰਟਕੱਟ"
 
-#: ../src/guake/prefs.py:619 ../src/guake/prefs.py:665
+#: ../src/guake/prefs.py:678 ../src/guake/prefs.py:724
 msgid "Custom"
 msgstr ""
 
-#: ../src/guake/prefs.py:926
+#: ../src/guake/prefs.py:994
 msgid "JSON files"
 msgstr ""
 
-#: ../src/guake/prefs.py:1019
+#: ../src/guake/prefs.py:1088
 #, python-format
 msgid "The shortcut \"%s\" is already in use."
 msgstr "ਸ਼ਾਰਟਕੱਟ \"%s\" ਪਹਿਲਾਂ ਹੀ ਵਰਤੋਂ ਅਧੀਨ ਹੈ।"
 
-#: ../src/guake/prefs.py:1020
+#: ../src/guake/prefs.py:1089
 msgid "Error setting keybinding."
 msgstr "ਸੈਟਿੰਗ ਕੀ-ਬਾਈਡਿੰਗ ਦੌਰਾਨ ਗਲਤੀ।"
 
-#: ../src/guake/prefs.py:1032
+#: ../src/guake/prefs.py:1101
 #, python-format
 msgid ""
 "The shortcut \"%s\" cannot be used because it will become impossible to type "
@@ -800,33 +965,3 @@ msgstr ""
 
 #~ msgid "Rename the selected tab."
 #~ msgstr "ਚੁਣੀ ਟੈਬ ਦਾ ਨਾਂ ਬਦਲੋ।"
-
-#~ msgid "Toggle Guake visibility"
-#~ msgstr "ਗੁਆਕੀ ਦਿੱਖ ਬਦਲੋ"
-
-#~ msgid "Tab management"
-#~ msgstr "ਟੈਬ ਪਰਬੰਧ"
-
-#~ msgid "Close tab"
-#~ msgstr "ਟੈਬ ਬੰਦ ਕਰੋ"
-
-#~ msgid "Rename current tab"
-#~ msgstr "ਮੌਜੂਦਾ ਟੈਬ ਦਾ ਨਾਂ ਬਦਲੋ"
-
-#~ msgid "Navigation"
-#~ msgstr "ਨੈਵੀਗੇਸ਼ਨ"
-
-#~ msgid "Go to previous tab"
-#~ msgstr "ਪਿਛਲੀ ਟੈਬ ਉੱਤੇ ਜਾਓ"
-
-#~ msgid "Go to next tab"
-#~ msgstr "ਅਗਲੀ ਟੈਬ ਉੱਤੇ ਜਾਓ"
-
-#~ msgid "Clipboard"
-#~ msgstr "ਕਲਿੱਪਬੋਰਡ"
-
-#~ msgid "Copy text to clipboard"
-#~ msgstr "ਟੈਕਸਟ ਕਲਿੱਪਬੋਰਡ 'ਚ ਕਾਪੀ ਕਰੋ"
-
-#~ msgid "Paste text from clipboard"
-#~ msgstr "ਕਲਿੱਪਬੋਰਡ 'ਚ ਟੈਕਸਟ ਚੇਪੋ"

--- a/po/pl.po
+++ b/po/pl.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: guake\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-02-04 10:49+0100\n"
+"POT-Creation-Date: 2016-08-17 21:41+0000\n"
 "PO-Revision-Date: 2016-02-04 10:52+0100\n"
 "Last-Translator: Piotr Drąg <piotrdrag@gmail.com>\n"
 "Language-Team: Polish <trans-pl@lists.fedoraproject.org>\n"
@@ -20,21 +20,22 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
 "|| n%100>=20) ? 1 : 2);\n"
 
-#: data/about.glade:7
+#: ../data/about.glade.h:1
 msgid "About Guake"
 msgstr "O programie Guake"
 
-#: data/about.glade:13
+#: ../data/about.glade.h:2
+#, fuzzy
 msgid ""
 "Copyright 2013-2015 Gaetan Semet\n"
 "Copyright 2007-2010 Lincoln de Sousa\n"
-"Copyright 2007 Gabriel Falcão"
+"Copyright 2007 Gabriel Falc&#xE3;o"
 msgstr ""
 "Copyright 2013-2015 Gaetan Semet\n"
 "Copyright 2007-2010 Lincoln de Sousa\n"
 "Copyright 2007 Gabriel Falcão"
 
-#: data/about.glade:16
+#: ../data/about.glade.h:5
 msgid ""
 "Guake is an easy to access\n"
 "terminal based on FPS games terminal"
@@ -42,7 +43,7 @@ msgstr ""
 "Guake jest łatwo dostępnym\n"
 "terminalem opartym na grach FPS"
 
-#: data/about.glade:20
+#: ../data/about.glade.h:7
 msgid ""
 "Guake is free software; you can redistribute it and/or modify it under the "
 "terms of the GNU General Public License as published by the Free Software "
@@ -74,7 +75,7 @@ msgstr ""
 "napisać do Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, "
 "Boston, MA 02110-1301 USA.\n"
 
-#: data/about.glade:37
+#: ../data/about.glade.h:13
 msgid ""
 "Adolfo González Blázquez <code@infinicode.org> Spanish\n"
 "Lincoln de Sousa <lincoln@guake.org> Brazilian Portuguese\n"
@@ -96,132 +97,87 @@ msgstr ""
 "Sangwoo Joo <sangwoojoo@naver.com> koreański\n"
 "    "
 
-#: data/guake-autoconfigure.desktop.in:3
-msgid "Autoconfigure Guake"
-msgstr "Automatyczna konfiguracja Guake"
-
-#: data/guake-autoconfigure.desktop.in:5
-msgid "Autoconfigure the start of the Guake terminal"
-msgstr "Automatycznie konfiguruje uruchamianie terminala Guake"
-
-#: data/guake-autoconfigure.desktop.in:9 data/guake-autostart.desktop.in:9
-msgid "/usr/share/pixmaps/guake/guake.png"
-msgstr "/usr/share/pixmaps/guake/guake.png"
-
-#: data/guake-autostart.desktop.in:3
-msgid "Autostart Guake Terminal"
-msgstr "Automatyczne uruchamianie terminala Guake"
-
-#: data/guake-autostart.desktop.in:5
-msgid "Automatically start Guake terminal at login"
-msgstr "Automatycznie uruchamia terminal Guake podczas logowania"
-
-#: data/guake.desktop.in:4 src/guake/about.py:47 src/guake/gconfhandler.py:428
-#: src/guake/guake_app.py:180 src/guake/guake_app.py:357
-msgid "Guake Terminal"
-msgstr "Terminal Guake"
-
-#: data/guake.desktop.in:9
-msgid "Use the command line in a Quake-like terminal"
-msgstr "Wiersz poleceń w terminalu w stylu gry Quake"
-
-#: data/guake.desktop.in:16
-msgid "guake"
-msgstr "guake"
-
-#: data/guake.glade:11
+#: ../data/guake.glade.h:1
 msgid "Copy"
 msgstr "Skopiuj"
 
-#: data/guake.glade:29
+#: ../data/guake.glade.h:2
 msgid "Paste"
 msgstr "Wklej"
 
-#: data/guake.glade:53
+#: ../data/guake.glade.h:3 ../src/guake/prefs.py:79
 msgid "Toggle Fullscreen"
 msgstr "Przełącz pełny ekran"
 
-#: data/guake.glade:77
+#: ../data/guake.glade.h:4
 msgid "Save to File..."
 msgstr "Zapisz do pliku…"
 
-#: data/guake.glade:95
+#: ../data/guake.glade.h:5 ../src/guake/prefs.py:85
 msgid "Reset terminal"
 msgstr "Przywróć terminal"
 
-#: data/guake.glade:105
+#: ../data/guake.glade.h:6
 msgid "Find..."
 msgstr "Znajdź…"
 
-#: data/guake.glade:129 data/guake.glade:281
+#: ../data/guake.glade.h:7
 msgid "New Tab"
 msgstr "Nowa karta"
 
-#: data/guake.glade:147
+#: ../data/guake.glade.h:8
 msgid "Rename Tab"
 msgstr "Zmień nazwę karty"
 
-#: data/guake.glade:165
+#: ../data/guake.glade.h:9
 msgid "Close Tab"
 msgstr "Zamknij kartę"
 
-#: data/guake.glade:189
+#: ../data/guake.glade.h:10
 msgid "Open link..."
 msgstr "Otwórz odnośnik…"
 
-#: data/guake.glade:207
+#: ../data/guake.glade.h:11
 msgid "Search on Web"
 msgstr "Znajdź w sieci"
 
-#: data/guake.glade:259 data/guake.glade:367
+#: ../data/guake.glade.h:12 ../src/guake/prefs.py:83
 msgid "Quit"
 msgstr "Zakończ"
 
-#: data/guake.glade:299
+#: ../data/guake.glade.h:13
 msgid "Rename"
 msgstr "Zmień nazwę"
 
-#: data/guake.glade:317
+#: ../data/guake.glade.h:14
 msgid "Close"
 msgstr "Zamknij"
 
-#: data/guake.glade:387
+#: ../data/guake.glade.h:15
 msgid "Guake!"
 msgstr "Guake!"
 
-#: data/guake.glade:470
+#: ../data/guake.glade.h:16
 msgid "Add a new tab"
 msgstr "Dodaje nową kartę"
 
-#: data/guake-prefs.desktop.in:4 data/prefs.glade:7
+#: ../data/prefs.glade.h:1
 msgid "Guake Preferences"
 msgstr "Preferencje programu Guake"
 
-#: data/guake-prefs.desktop.in:7
-msgid "Configure your Guake sessions"
-msgstr "Konfiguruje sesje programu Guake"
-
-#: data/guake-prefs.desktop.in:13
-msgid "guake-prefs"
-msgstr "guake-prefs"
-
-#: data/guake-prefs.desktop.in:19
-msgid "Terminal;Utility;"
-msgstr "Terminal;Konsola;Narzędzie;"
-
-#: data/prefs.glade:53
+#: ../data/prefs.glade.h:2
 msgid "<span size=\"18000\" color=\"black\"><b>Guake properties</b></span>"
 msgstr ""
 "<span size=\"18000\" color=\"black\"><b>Właściwości programu Guake</b></span>"
 
-#: data/prefs.glade:68
+#: ../data/prefs.glade.h:3
 msgid ""
 "<span color=\"black\">Customize behavior and appearance of Guake!</span>"
 msgstr ""
 "<span color=\"black\">Dostosowanie zachowania i wyglądu programu Guake!</"
 "span>"
 
-#: data/prefs.glade:154
+#: ../data/prefs.glade.h:4
 msgid ""
 "Path to a bash script that would be automatically executed when Guake "
 "starts, unless you specify --no-startup-script.\n"
@@ -250,35 +206,35 @@ msgstr ""
 "guake -r \"main\" -e \"cd ~/projekty/mójprojekt/main\"\n"
 "guake -r \"prod\" -e \"cd ~/projekty/mójprojekt/prod\"\n"
 
-#: data/prefs.glade:182
+#: ../data/prefs.glade.h:15
 msgid "Enable popup notifications on startup"
 msgstr "Wyskakujące powiadomienia podczas uruchamiania"
 
-#: data/prefs.glade:197
+#: ../data/prefs.glade.h:16
 msgid "Show tray icon"
 msgstr "Ikona obszaru powiadamiania"
 
-#: data/prefs.glade:208
+#: ../data/prefs.glade.h:17
 msgid "Always prompt on quit"
 msgstr "Potwierdzenie podczas kończenia działania"
 
-#: data/prefs.glade:226
+#: ../data/prefs.glade.h:18
 msgid "_Flash terminal on bell"
 msgstr "_Miganie terminalem jako dzwonek"
 
-#: data/prefs.glade:242
+#: ../data/prefs.glade.h:19
 msgid "_Play system alert sound on bell"
 msgstr "Systemowy _dźwięk alarmu jako dzwonek"
 
-#: data/prefs.glade:262
+#: ../data/prefs.glade.h:20
 msgid "Path to script executed on Guake start:"
 msgstr "Ścieżka do skryptu wykonywanego podczas uruchamiania programu Guake:"
 
-#: data/prefs.glade:281
+#: ../data/prefs.glade.h:21
 msgid "Prompt on close tab:"
 msgstr "Potwierdzenie podczas zamykania karty:"
 
-#: data/prefs.glade:305
+#: ../data/prefs.glade.h:22
 msgid ""
 "Never\n"
 "With process running\n"
@@ -288,163 +244,167 @@ msgstr ""
 "Kiedy jest uruchomiony proces\n"
 "Zawsze"
 
-#: data/prefs.glade:339 data/prefs.glade:1165 data/prefs.glade:1284
+#: ../data/prefs.glade.h:25
 msgid "<b>General</b>"
 msgstr "<b>Ogólne</b>"
 
-#: data/prefs.glade:376
+#: ../data/prefs.glade.h:26
 msgid "Bottom align window instead of top align"
 msgstr "Okno na dole zamiast na górze"
 
-#: data/prefs.glade:391
+#: ../data/prefs.glade.h:27
 msgid "Appear on mouse display"
 msgstr "Wyświetlanie na ekranie z kursorem"
 
-#: data/prefs.glade:416
+#: ../data/prefs.glade.h:28
 msgid "Appear on display:"
 msgstr "Wyświetlanie na ekranie:"
 
-#: data/prefs.glade:448
+#: ../data/prefs.glade.h:29
 msgid "Place tabs on top"
 msgstr "Karty na górze"
 
-#: data/prefs.glade:470
+#: ../data/prefs.glade.h:30
 msgid "<b>Placement</b>"
 msgstr "<b>Umieszczenie</b>"
 
-#: data/prefs.glade:501
+#: ../data/prefs.glade.h:31
 msgid "Stay on top"
 msgstr "Zawsze na wierzchu"
 
-#: data/prefs.glade:519
+#: ../data/prefs.glade.h:32
 msgid "Use VTE titles for tab names"
 msgstr "Tytuły VTE dla nazw kart"
 
-#: data/prefs.glade:544
+#: ../data/prefs.glade.h:33
+msgid "Abbreviate directories in tab names"
+msgstr ""
+
+#: ../data/prefs.glade.h:34
 msgid "Max tab name length:"
 msgstr "Maksymalna długość nazwy karty:"
 
-#: data/prefs.glade:582
+#: ../data/prefs.glade.h:35
 msgid "Hide on lose focus"
 msgstr "Ukrycie po utracie aktywności"
 
-#: data/prefs.glade:599
+#: ../data/prefs.glade.h:36
 msgid "Show tab bar"
 msgstr "Pasek kart"
 
-#: data/prefs.glade:615
+#: ../data/prefs.glade.h:37
 msgid "Start fullscreen"
 msgstr "Uruchamianie w trybie pełnoekranowym"
 
-#: data/prefs.glade:638
+#: ../data/prefs.glade.h:38
 msgid "<b>Main Window</b>"
 msgstr "<b>Główne okno</b>"
 
-#: data/prefs.glade:672
+#: ../data/prefs.glade.h:39
 msgid "Left"
 msgstr "Po lewej"
 
-#: data/prefs.glade:687
+#: ../data/prefs.glade.h:40
 msgid "Center"
 msgstr "Na środku"
 
-#: data/prefs.glade:704
+#: ../data/prefs.glade.h:41
 msgid "Right"
 msgstr "Po prawej"
 
-#: data/prefs.glade:734
+#: ../data/prefs.glade.h:42
 msgid "<b>Main Window Horizontal Alignment</b>"
 msgstr "<b>Pionowe wyrównanie głównego okna</b>"
 
-#: data/prefs.glade:786
+#: ../data/prefs.glade.h:43
 msgid "<b>Main Window Height</b>"
 msgstr "<b>Wysokość głównego okna</b>"
 
-#: data/prefs.glade:830
+#: ../data/prefs.glade.h:44
 msgid "<b>Main Window Width</b>"
 msgstr "<b>Szerokość głównego okna</b>"
 
-#: data/prefs.glade:863
+#: ../data/prefs.glade.h:45
 msgid "Custom command file path: "
 msgstr "Inna ścieżka do pliku polecenia: "
 
-#: data/prefs.glade:875
+#: ../data/prefs.glade.h:46
 msgid "Please select a json file"
 msgstr "Proszę wybrać plik JSON"
 
-#: data/prefs.glade:897
+#: ../data/prefs.glade.h:47 ../src/guake/prefs.py:75
 msgid "General"
 msgstr "Ogólne"
 
-#: data/prefs.glade:936
+#: ../data/prefs.glade.h:48
 msgid "Default interpreter:"
 msgstr "Domyślna powłoka:"
 
-#: data/prefs.glade:983
+#: ../data/prefs.glade.h:49
 msgid "_Run command as a login shell"
 msgstr "U_ruchamianie polecenia jako powłokę logowania"
 
-#: data/prefs.glade:1000
+#: ../data/prefs.glade.h:50
 msgid "_Open new tab in current directory"
 msgstr "_Otwieranie nowych kart w bieżącym katalogu"
 
-#: data/prefs.glade:1031
+#: ../data/prefs.glade.h:51
 msgid "<b>Shell</b>"
 msgstr "<b>Powłoka</b>"
 
-#: data/prefs.glade:1065
+#: ../data/prefs.glade.h:52
 msgid "Shell"
 msgstr "Powłoka"
 
-#: data/prefs.glade:1096
+#: ../data/prefs.glade.h:53
 msgid "Show scrollbar"
 msgstr "Pasek przewijania"
 
-#: data/prefs.glade:1120
+#: ../data/prefs.glade.h:54
 msgid "Scrollback lines:"
 msgstr "Przewijanie:"
 
-#: data/prefs.glade:1198
+#: ../data/prefs.glade.h:55
 msgid "On output"
 msgstr "Na wyjściu"
 
-#: data/prefs.glade:1214
+#: ../data/prefs.glade.h:56
 msgid "On key stroke"
 msgstr "Podczas wciśnięcia klawisza"
 
-#: data/prefs.glade:1237
+#: ../data/prefs.glade.h:57
 msgid "<b>Scroll</b>"
 msgstr "<b>Przewijanie</b>"
 
-#: data/prefs.glade:1260
+#: ../data/prefs.glade.h:58
 msgid "Scrolling"
 msgstr "Przewijanie"
 
-#: data/prefs.glade:1311
+#: ../data/prefs.glade.h:59
 msgid "Use the system fixed width font"
 msgstr "Systemowa czcionka o stałej szerokości"
 
-#: data/prefs.glade:1331
+#: ../data/prefs.glade.h:60
 msgid "Font:"
 msgstr "Czcionka:"
 
-#: data/prefs.glade:1347
+#: ../data/prefs.glade.h:61
 msgid "Choose some font"
 msgstr "Wybór czcionki"
 
-#: data/prefs.glade:1366
+#: ../data/prefs.glade.h:62
 msgid "Text color:"
 msgstr "Kolor tekstu:"
 
-#: data/prefs.glade:1381
+#: ../data/prefs.glade.h:63
 msgid "Background color:"
 msgstr "Kolor tła:"
 
-#: data/prefs.glade:1456
+#: ../data/prefs.glade.h:64
 msgid "Cursor shape:"
 msgstr "Kształt kursora:"
 
-#: data/prefs.glade:1470
+#: ../data/prefs.glade.h:65
 msgid ""
 "Block\n"
 "I-Beam\n"
@@ -454,7 +414,7 @@ msgstr ""
 "Linia pionowa\n"
 "Podkreślenie"
 
-#: data/prefs.glade:1487
+#: ../data/prefs.glade.h:68
 msgid ""
 "Follow GTK+ setting\n"
 "Blink on\n"
@@ -464,59 +424,59 @@ msgstr ""
 "Miganie\n"
 "Bez migania"
 
-#: data/prefs.glade:1505
+#: ../data/prefs.glade.h:71
 msgid "Cursor blink mode:"
 msgstr "Tryb migania kursora:"
 
-#: data/prefs.glade:1519
+#: ../data/prefs.glade.h:72
 msgid "Allow bold font"
 msgstr "Zezwolenie na pogrubioną czcionkę"
 
-#: data/prefs.glade:1572
+#: ../data/prefs.glade.h:73
 msgid "<b>Palette</b>"
 msgstr "<b>Paleta</b>"
 
-#: data/prefs.glade:1602
+#: ../data/prefs.glade.h:74
 msgid "Built-in schemes:"
 msgstr "Wbudowane schematy:"
 
-#: data/prefs.glade:1616
+#: ../data/prefs.glade.h:75
 msgid "Color palette:"
 msgstr "Paleta kolorów:"
 
-#: data/prefs.glade:1889
+#: ../data/prefs.glade.h:76
 msgid "Font color"
 msgstr "Kolor czcionki"
 
-#: data/prefs.glade:1904
+#: ../data/prefs.glade.h:77
 msgid "Background color"
 msgstr "Kolor tła"
 
-#: data/prefs.glade:1948
+#: ../data/prefs.glade.h:78
 msgid "Use font and background color from the palette"
 msgstr "Kolor czcionki i tła z palety"
 
-#: data/prefs.glade:1971
+#: ../data/prefs.glade.h:79
 msgid "Demo:"
 msgstr "Demo:"
 
-#: data/prefs.glade:2023
+#: ../data/prefs.glade.h:80
 msgid "<b>Effects</b>"
 msgstr "<b>Efekty</b>"
 
-#: data/prefs.glade:2050
+#: ../data/prefs.glade.h:81
 msgid "Transparency:"
 msgstr "Przezroczystość:"
 
-#: data/prefs.glade:2078
+#: ../data/prefs.glade.h:82
 msgid "Background image:"
 msgstr "Obraz tła:"
 
-#: data/prefs.glade:2171
+#: ../data/prefs.glade.h:83 ../src/guake/prefs.py:130
 msgid "Appearance"
 msgstr "Wygląd"
 
-#: data/prefs.glade:2219
+#: ../data/prefs.glade.h:84
 msgid ""
 "<small>Quick open is a feature allowing you to open a file directly into "
 "your favorite text editor by clicking on its filename when it appears in "
@@ -528,17 +488,18 @@ msgstr ""
 "terminalu. Poniżej znajduje się lista obecnie obsługiwanych wzorców "
 "używanych do wyodrębniania nazw plików.</small>"
 
-#: data/prefs.glade:2270
+#: ../data/prefs.glade.h:85
 msgid "Enable Quick Open when Ctrl+clicking on a filename in the terminal"
 msgstr ""
 "Szybkie otwieranie po kliknięciu na nazwie pliku w terminalu przytrzymując "
 "klawisz Ctrl"
 
-#: data/prefs.glade:2294
+#: ../data/prefs.glade.h:86
 msgid "Editor command line:"
 msgstr "Polecenie edytora:"
 
-#: data/prefs.glade:2347
+#: ../data/prefs.glade.h:88
+#, no-c-format
 msgid ""
 "<small><i>Use the following elements in the open editor command line:\n"
 " - <b>%(file_path)s</b>: path to the file that has been clicked\n"
@@ -558,11 +519,11 @@ msgstr ""
 "%(line_number)s</b>\n"
 "</i></small>"
 
-#: data/prefs.glade:2364
+#: ../data/prefs.glade.h:94
 msgid "Quick open in current terminal"
 msgstr "Szybkie otwieranie w bieżącym terminalu"
 
-#: data/prefs.glade:2405
+#: ../data/prefs.glade.h:95
 msgid ""
 "Here is the list of supported patterns: (to add your own, please contact the "
 "Guake's authors)"
@@ -570,15 +531,15 @@ msgstr ""
 "Lista obsługiwanych wzorców (aby dodać własne, prosimy skontaktować się z "
 "autorami programu Guake):"
 
-#: data/prefs.glade:2427
+#: ../data/prefs.glade.h:96
 msgid "<b>Quick Open</b>"
 msgstr "<b>Szybkie otwieranie</b>"
 
-#: data/prefs.glade:2457
+#: ../data/prefs.glade.h:97
 msgid "Quick Open"
 msgstr "Szybkie otwieranie"
 
-#: data/prefs.glade:2476
+#: ../data/prefs.glade.h:98
 msgid ""
 "To change a shortcut simply click on its name.\n"
 "To disable a shortcut, press the \"Backspace\" key."
@@ -586,11 +547,11 @@ msgstr ""
 "Klikając nazwę skrótu można go zmienić.\n"
 "Naciśnięcie klawisza „Backspace” wyłącza skrót."
 
-#: data/prefs.glade:2515
+#: ../data/prefs.glade.h:100
 msgid "Keyboard shortcuts"
 msgstr "Skróty klawiszowe"
 
-#: data/prefs.glade:2546
+#: ../data/prefs.glade.h:101
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -602,7 +563,7 @@ msgstr ""
 "określonymi programami i systemami operacyjnymi, które oczekują innego "
 "zachowania terminala.</i></small>"
 
-#: data/prefs.glade:2568 data/prefs.glade:2585
+#: ../data/prefs.glade.h:102
 msgid ""
 "ASCII DEL\n"
 "Escape sequence\n"
@@ -612,32 +573,36 @@ msgstr ""
 "Sekwencja Escape\n"
 "Control-H"
 
-#: data/prefs.glade:2601
+#: ../data/prefs.glade.h:105
 msgid "_Backspace key generates:"
 msgstr "Klawisz _Backspace generuje:"
 
-#: data/prefs.glade:2616
+#: ../data/prefs.glade.h:106
 msgid "_Delete key generates:"
 msgstr "Klawisz _Delete generuje:"
 
-#: data/prefs.glade:2644
+#: ../data/prefs.glade.h:107
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "P_rzywróć domyślne opcje zgodności"
 
-#: data/prefs.glade:2669
+#: ../data/prefs.glade.h:108
 msgid "<b>Keyboard compatibility</b>"
 msgstr "<b>Zgodność klawiatury</b>"
 
-#: data/prefs.glade:2685
+#: ../data/prefs.glade.h:109
 msgid "Compatibility"
 msgstr "Zgodność"
 
-#. Adding a new radio button to the tabbar
-#: src/guake/gconfhandler.py:366 src/guake/guake_app.py:1569
+#: ../src/guake/about.py:47 ../src/guake/gconfhandler.py:435
+#: ../src/guake/guake_app.py:181 ../src/guake/guake_app.py:376
+msgid "Guake Terminal"
+msgstr "Terminal Guake"
+
+#: ../src/guake/gconfhandler.py:368 ../src/guake/guake_app.py:1363
 msgid "Terminal"
 msgstr "Terminal"
 
-#: src/guake/gconfhandler.py:429
+#: ../src/guake/gconfhandler.py:436
 #, python-format
 msgid ""
 "A problem happened when binding <b>%s</b> key.\n"
@@ -647,49 +612,49 @@ msgstr ""
 "Proszę użyć okna dialogowego preferencji programu Guake, aby wybrać inny "
 "klawisz"
 
-#: src/guake/guake_app.py:131
+#: ../src/guake/guake_app.py:132
 msgid "Do you want to close the tab?"
 msgstr "Zamknąć kartę?"
 
-#: src/guake/guake_app.py:134
+#: ../src/guake/guake_app.py:135
 msgid "Do you really want to quit Guake?"
 msgstr "Na pewno zakończyć program Guake?"
 
-#: src/guake/guake_app.py:136
+#: ../src/guake/guake_app.py:137
 msgid " and one tab open"
 msgstr " i jest jedna otwarta karta"
 
-#: src/guake/guake_app.py:138
+#: ../src/guake/guake_app.py:139
 #, python-brace-format
 msgid " and {0} tabs open"
 msgstr " i więcej kart jest otwartych: {0}"
 
-#: src/guake/guake_app.py:141
+#: ../src/guake/guake_app.py:142
 msgid "There are no processes running"
 msgstr "Żaden proces nie jest uruchomiony"
 
-#: src/guake/guake_app.py:143
+#: ../src/guake/guake_app.py:144
 msgid "There is a process still running"
 msgstr "Jeden proces jest ciągle uruchomiony"
 
-#: src/guake/guake_app.py:145
+#: ../src/guake/guake_app.py:146
 #, python-brace-format
 msgid "There are {0} processes still running"
 msgstr "Nadal uruchomione procesy: {0}"
 
-#: src/guake/guake_app.py:185
+#: ../src/guake/guake_app.py:186
 msgid "guake-indicator"
 msgstr "guake-indicator"
 
-#: src/guake/guake_app.py:185
+#: ../src/guake/guake_app.py:186
 msgid "guake-tray"
 msgstr "guake-tray"
 
-#: src/guake/guake_app.py:189
+#: ../src/guake/guake_app.py:190
 msgid "Show"
 msgstr "Wyświetl"
 
-#: src/guake/guake_app.py:358
+#: ../src/guake/guake_app.py:377
 #, python-format
 msgid ""
 "Guake is now running,\n"
@@ -698,130 +663,135 @@ msgstr ""
 "Program Guake jest teraz uruchomiony,\n"
 "należy nacisnąć <b>%s</b>, aby go użyć."
 
-#: src/guake/guake_app.py:620
+#: ../src/guake/guake_app.py:665
 #, python-format
 msgid "Search on Web: '%s'"
 msgstr "Wyszukiwanie w sieci: „%s”"
 
-#: src/guake/guake_app.py:625
+#: ../src/guake/guake_app.py:670
 msgid "Search on Web (no selection)"
 msgstr "Wyszukiwanie w sieci (bez zaznaczenia)"
 
-#: src/guake/guake_app.py:631
+#: ../src/guake/guake_app.py:678
+#, fuzzy
+msgid "Open Link: '{}...'"
+msgstr "Otwórz odnośnik: {}"
+
+#: ../src/guake/guake_app.py:680
 msgid "Open Link: {}"
 msgstr "Otwórz odnośnik: {}"
 
-#: src/guake/guake_app.py:634
+#: ../src/guake/guake_app.py:683
 msgid "Open Link..."
 msgstr "Otwórz odnośnik…"
 
-#: src/guake/guake_app.py:1321
+#: ../src/guake/guake_app.py:1402
 msgid "Rename tab"
 msgstr "Zmiana nazwy karty"
 
-#: src/guake/guake_app.py:1612
+#: ../src/guake/guake_app.py:1716
 msgid "Save to..."
 msgstr "Zapisanie do…"
 
-#: src/guake/guake_app.py:1619 src/guake/prefs.py:936
+#: ../src/guake/guake_app.py:1723 ../src/guake/prefs.py:998
 msgid "All files"
 msgstr "Wszystkie pliki"
 
-#: src/guake/guake_app.py:1624
+#: ../src/guake/guake_app.py:1728
 msgid "Text and Logs"
 msgstr "Pliki tekstowe i dzienniki"
 
-#: src/guake/guake_app.py:1642
+#: ../src/guake/guake_app.py:1746
 msgid "Find"
 msgstr "Znajdź"
 
-#: src/guake/guake_app.py:1644
+#: ../src/guake/guake_app.py:1748
 msgid "Forward"
 msgstr "Dalej"
 
-#: src/guake/guake_app.py:1645
+#: ../src/guake/guake_app.py:1749
 msgid "Backward"
 msgstr "Wstecz"
 
-#: src/guake/main.py:67
+#: ../src/guake/main.py:68
 msgid "Put Guake in fullscreen mode"
 msgstr "Umieszcza program Guake w trybie pełnoekranowym"
 
-#: src/guake/main.py:71
+#: ../src/guake/main.py:72
 msgid "Toggles the visibility of the terminal window"
 msgstr "Przełącza widoczność okna terminala"
 
-#: src/guake/main.py:75
+#: ../src/guake/main.py:76
 msgid "Shows Guake main window"
 msgstr "Wyświetla główne okno programu Guake"
 
-#: src/guake/main.py:79
+#: ../src/guake/main.py:80
 msgid "Hides Guake main window"
 msgstr "Ukrywa główne okno programu Guake"
 
-#: src/guake/main.py:83
+#: ../src/guake/main.py:84
 msgid "Shows Guake preference window"
 msgstr "Wyświetla okno preferencji programu Guake"
 
-#: src/guake/main.py:87
+#: ../src/guake/main.py:88
 msgid "Shows Guake's about info"
 msgstr "Wyświetla informacje o programie Guake"
 
-#: src/guake/main.py:91
+#: ../src/guake/main.py:92
 msgid "Add a new tab (with current directory set to NEW_TAB)"
 msgstr "Dodaje nową kartę (z bieżącym katalogiem ustawionym na NEW_TAB)"
 
-#: src/guake/main.py:95
+#: ../src/guake/main.py:96
 msgid "Select a tab (SELECT_TAB is the index of the tab)"
 msgstr "Wybiera kartę (SELECT_TAB jest indeksem kart)"
 
-#: src/guake/main.py:99
+#: ../src/guake/main.py:100
 msgid "Return the selected tab index."
 msgstr "Wyświetla wybrany indeks kart."
 
-#: src/guake/main.py:103
+#: ../src/guake/main.py:104
 msgid "Execute an arbitrary command in the selected tab."
 msgstr "Wykonuje podane polecenie w wybranej karcie."
 
-#: src/guake/main.py:107
+#: ../src/guake/main.py:108
 msgid "Specify the tab to rename. Default is 0."
 msgstr "Podaje kartę do zmiany nazwy. Domyślnie 0."
 
-#: src/guake/main.py:111
+#: ../src/guake/main.py:112
 msgid "Set the hexadecimal (#rrggbb) background color of the selected tab."
 msgstr "Ustawia szesnastkowy (#rrggbb) kolor tła wybranej karty."
 
-#: src/guake/main.py:116
+#: ../src/guake/main.py:117
 msgid "Set the hexadecimal (#rrggbb) foreground color of the selected tab."
 msgstr "Ustawia szesnastkowy (#rrggbb) kolor tekstu wybranej karty."
 
-#: src/guake/main.py:122
+#: ../src/guake/main.py:123
 msgid ""
 "Rename the specified tab. Reset to default if TITLE is a single dash \"-\"."
 msgstr ""
 "Zmienia nazwę podanej karty. Przywraca domyślą, jeśli TITLE jest pojedynczym "
 "myślnikiem „-”."
 
-#: src/guake/main.py:128
+#: ../src/guake/main.py:129
 msgid ""
 "Rename the current tab. Reset to default if TITLE is a single dash \"-\"."
 msgstr ""
 "Zmienia nazwę bieżącej karty. Przywraca domyślą, jeśli TITLE jest "
 "pojedynczym myślnikiem „-”."
 
-#: src/guake/main.py:133
+#: ../src/guake/main.py:134
 msgid "Says to Guake go away =("
 msgstr "Mówi programowi Guake, aby sobie poszedł =("
 
-#: src/guake/main.py:137
+#: ../src/guake/main.py:138
 msgid "Do not execute the start up script"
 msgstr "Bez wykonywania skryptu startowego"
 
-#: src/guake/main.py:231
+#: ../src/guake/main.py:235
 msgid "Guake can not init!"
 msgstr "Nie można zainicjować programu Guake."
 
-#: src/guake/main.py:232
+#: ../src/guake/main.py:236
 msgid ""
 "Gconf Error.\n"
 "Have you installed <b>guake.schemas</b> properly?"
@@ -830,36 +800,184 @@ msgstr ""
 "Na pewno poprawnie zainstalowano <b>guake.schemas</b>?"
 
 #. string to show in prefereces dialog for user shell option
-#: src/guake/prefs.py:67
+#: ../src/guake/prefs.py:67
 msgid "<user shell>"
 msgstr "<powłoka użytkownika>"
 
-#: src/guake/prefs.py:469
+#: ../src/guake/prefs.py:77
+msgid "Toggle Guake visibility"
+msgstr ""
+
+#: ../src/guake/prefs.py:81
+#, fuzzy
+msgid "Toggle Hide on Lose Focus"
+msgstr "Ukrycie po utracie aktywności"
+
+#: ../src/guake/prefs.py:88
+msgid "Tab management"
+msgstr ""
+
+#: ../src/guake/prefs.py:90
+#, fuzzy
+msgid "New tab"
+msgstr "Nowa karta"
+
+#: ../src/guake/prefs.py:92
+#, fuzzy
+msgid "Close tab"
+msgstr "Zamknij kartę"
+
+#: ../src/guake/prefs.py:94
+#, fuzzy
+msgid "Rename current tab"
+msgstr "Zmiana nazwy karty"
+
+#: ../src/guake/prefs.py:97
+msgid "Navigation"
+msgstr ""
+
+#: ../src/guake/prefs.py:99
+msgid "Go to previous tab"
+msgstr ""
+
+#: ../src/guake/prefs.py:101
+msgid "Go to next tab"
+msgstr ""
+
+#: ../src/guake/prefs.py:103
+msgid "Move current tab left"
+msgstr ""
+
+#: ../src/guake/prefs.py:105
+msgid "Move current tab right"
+msgstr ""
+
+#: ../src/guake/prefs.py:107
+msgid "Go to first tab"
+msgstr ""
+
+#: ../src/guake/prefs.py:109
+msgid "Go to second tab"
+msgstr ""
+
+#: ../src/guake/prefs.py:111
+msgid "Go to third tab"
+msgstr ""
+
+#: ../src/guake/prefs.py:113
+msgid "Go to fourth tab"
+msgstr ""
+
+#: ../src/guake/prefs.py:115
+msgid "Go to fifth tab"
+msgstr ""
+
+#: ../src/guake/prefs.py:117
+msgid "Go to sixth tab"
+msgstr ""
+
+#: ../src/guake/prefs.py:119
+msgid "Go to seventh tab"
+msgstr ""
+
+#: ../src/guake/prefs.py:121
+msgid "Go to eighth tab"
+msgstr ""
+
+#: ../src/guake/prefs.py:123
+msgid "Go to ninth tab"
+msgstr ""
+
+#: ../src/guake/prefs.py:125
+msgid "Go to tenth tab"
+msgstr ""
+
+#: ../src/guake/prefs.py:127
+msgid "Go to last tab"
+msgstr ""
+
+#: ../src/guake/prefs.py:132
+msgid "Zoom out"
+msgstr ""
+
+#: ../src/guake/prefs.py:134
+msgid "Zoom in"
+msgstr ""
+
+#: ../src/guake/prefs.py:136
+msgid "Zoom in (alternative)"
+msgstr ""
+
+#: ../src/guake/prefs.py:138
+msgid "Increase height"
+msgstr ""
+
+#: ../src/guake/prefs.py:140
+msgid "Decrease height"
+msgstr ""
+
+#: ../src/guake/prefs.py:142
+#, fuzzy
+msgid "Increase transparency"
+msgstr "Przezroczystość:"
+
+#: ../src/guake/prefs.py:144
+#, fuzzy
+msgid "Decrease transparency"
+msgstr "Przezroczystość:"
+
+#: ../src/guake/prefs.py:146
+#, fuzzy
+msgid "Toggle transparency"
+msgstr "Przezroczystość:"
+
+#: ../src/guake/prefs.py:149
+msgid "Clipboard"
+msgstr ""
+
+#: ../src/guake/prefs.py:151
+msgid "Copy text to clipboard"
+msgstr ""
+
+#: ../src/guake/prefs.py:153
+msgid "Paste text from clipboard"
+msgstr ""
+
+#: ../src/guake/prefs.py:156
+msgid "Extra features"
+msgstr ""
+
+#: ../src/guake/prefs.py:159
+#, fuzzy
+msgid "Search select text on web"
+msgstr "Znajdź w sieci"
+
+#: ../src/guake/prefs.py:519
 msgid "Action"
 msgstr "Działanie"
 
-#: src/guake/prefs.py:479
+#: ../src/guake/prefs.py:529
 msgid "Shortcut"
 msgstr "Skrót"
 
-#: src/guake/prefs.py:621 src/guake/prefs.py:667
+#: ../src/guake/prefs.py:678 ../src/guake/prefs.py:724
 msgid "Custom"
 msgstr "Inne"
 
-#: src/guake/prefs.py:932
+#: ../src/guake/prefs.py:994
 msgid "JSON files"
 msgstr "Pliki JSON"
 
-#: src/guake/prefs.py:1026
+#: ../src/guake/prefs.py:1088
 #, python-format
 msgid "The shortcut \"%s\" is already in use."
 msgstr "Skrót „%s” jest już używany."
 
-#: src/guake/prefs.py:1027
+#: ../src/guake/prefs.py:1089
 msgid "Error setting keybinding."
 msgstr "Błąd podczas ustawiania dowiązania klawiszy."
 
-#: src/guake/prefs.py:1039
+#: ../src/guake/prefs.py:1101
 #, python-format
 msgid ""
 "The shortcut \"%s\" cannot be used because it will become impossible to type "
@@ -872,3 +990,33 @@ msgstr ""
 "\n"
 "Proszę spróbować z klawiszem takim jak Ctrl, Alt lub Shift w tym samym "
 "czasie.\n"
+
+#~ msgid "Autoconfigure Guake"
+#~ msgstr "Automatyczna konfiguracja Guake"
+
+#~ msgid "Autoconfigure the start of the Guake terminal"
+#~ msgstr "Automatycznie konfiguruje uruchamianie terminala Guake"
+
+#~ msgid "/usr/share/pixmaps/guake/guake.png"
+#~ msgstr "/usr/share/pixmaps/guake/guake.png"
+
+#~ msgid "Autostart Guake Terminal"
+#~ msgstr "Automatyczne uruchamianie terminala Guake"
+
+#~ msgid "Automatically start Guake terminal at login"
+#~ msgstr "Automatycznie uruchamia terminal Guake podczas logowania"
+
+#~ msgid "Use the command line in a Quake-like terminal"
+#~ msgstr "Wiersz poleceń w terminalu w stylu gry Quake"
+
+#~ msgid "guake"
+#~ msgstr "guake"
+
+#~ msgid "Configure your Guake sessions"
+#~ msgstr "Konfiguruje sesje programu Guake"
+
+#~ msgid "guake-prefs"
+#~ msgstr "guake-prefs"
+
+#~ msgid "Terminal;Utility;"
+#~ msgstr "Terminal;Konsola;Narzędzie;"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Guake 0.4.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-01-07 19:17-0200\n"
+"POT-Creation-Date: 2016-08-17 21:41+0000\n"
 "PO-Revision-Date: 2009-11-14 09:48-0300\n"
 "Last-Translator: Matheus Manoel <matheus.manoel@usp.br>\n"
 "Language-Team: Portuguese/Brazil <gnome-l10n-br@listas.cipsga.org.br>\n"
@@ -102,7 +102,7 @@ msgstr "Copiar"
 msgid "Paste"
 msgstr "Colar"
 
-#: ../data/guake.glade.h:3
+#: ../data/guake.glade.h:3 ../src/guake/prefs.py:79
 msgid "Toggle Fullscreen"
 msgstr "Alternar tela cheia"
 
@@ -110,7 +110,7 @@ msgstr "Alternar tela cheia"
 msgid "Save to File..."
 msgstr "Salvar no Arquivo..."
 
-#: ../data/guake.glade.h:5
+#: ../data/guake.glade.h:5 ../src/guake/prefs.py:85
 msgid "Reset terminal"
 msgstr "Resetar terminal"
 
@@ -138,7 +138,7 @@ msgstr "Abrir link..."
 msgid "Search on Web"
 msgstr "Procurar na Web"
 
-#: ../data/guake.glade.h:12
+#: ../data/guake.glade.h:12 ../src/guake/prefs.py:83
 msgid "Quit"
 msgstr "Sair"
 
@@ -276,137 +276,141 @@ msgid "Use VTE titles for tab names"
 msgstr "Usar títulos VTE para os nomes das abas"
 
 #: ../data/prefs.glade.h:33
+msgid "Abbreviate directories in tab names"
+msgstr ""
+
+#: ../data/prefs.glade.h:34
 msgid "Max tab name length:"
 msgstr "Tamanho máximo para nome da aba:"
 
-#: ../data/prefs.glade.h:34
+#: ../data/prefs.glade.h:35
 msgid "Hide on lose focus"
 msgstr "Esconder ao perder o foco"
 
-#: ../data/prefs.glade.h:35
+#: ../data/prefs.glade.h:36
 msgid "Show tab bar"
 msgstr "Mostrar barra de abas"
 
-#: ../data/prefs.glade.h:36
+#: ../data/prefs.glade.h:37
 msgid "Start fullscreen"
 msgstr "Iniciar com tela cheia"
 
-#: ../data/prefs.glade.h:37
+#: ../data/prefs.glade.h:38
 msgid "<b>Main Window</b>"
 msgstr "<b>Janela principal</b>"
 
-#: ../data/prefs.glade.h:38
+#: ../data/prefs.glade.h:39
 msgid "Left"
 msgstr "Esquerda"
 
-#: ../data/prefs.glade.h:39
+#: ../data/prefs.glade.h:40
 msgid "Center"
 msgstr "Centro"
 
-#: ../data/prefs.glade.h:40
+#: ../data/prefs.glade.h:41
 msgid "Right"
 msgstr "Direita"
 
-#: ../data/prefs.glade.h:41
+#: ../data/prefs.glade.h:42
 msgid "<b>Main Window Horizontal Alignment</b>"
 msgstr "<b>Alinhamento horizontal da janela principal</b>"
 
-#: ../data/prefs.glade.h:42
+#: ../data/prefs.glade.h:43
 msgid "<b>Main Window Height</b>"
 msgstr "<b>Altura da janela principal</b>"
 
-#: ../data/prefs.glade.h:43
+#: ../data/prefs.glade.h:44
 msgid "<b>Main Window Width</b>"
 msgstr "<b>Largura da janela principal</b>"
 
-#: ../data/prefs.glade.h:44
+#: ../data/prefs.glade.h:45
 msgid "Custom command file path: "
 msgstr "Caminho do arquivo de comandos personalizados: "
 
-#: ../data/prefs.glade.h:45
+#: ../data/prefs.glade.h:46
 msgid "Please select a json file"
 msgstr "Por favor selecione um arquivo json"
 
-#: ../data/prefs.glade.h:46
+#: ../data/prefs.glade.h:47 ../src/guake/prefs.py:75
 msgid "General"
 msgstr "Geral"
 
-#: ../data/prefs.glade.h:47
+#: ../data/prefs.glade.h:48
 msgid "Default interpreter:"
 msgstr "Interpretador padrão:"
 
-#: ../data/prefs.glade.h:48
+#: ../data/prefs.glade.h:49
 msgid "_Run command as a login shell"
 msgstr "_Executar comando como shell de login"
 
-#: ../data/prefs.glade.h:49
+#: ../data/prefs.glade.h:50
 msgid "_Open new tab in current directory"
 msgstr "_Abrir nova aba no diretório atual"
 
-#: ../data/prefs.glade.h:50
+#: ../data/prefs.glade.h:51
 msgid "<b>Shell</b>"
 msgstr "<b>Shell</b>"
 
-#: ../data/prefs.glade.h:51
+#: ../data/prefs.glade.h:52
 msgid "Shell"
 msgstr "Shell"
 
-#: ../data/prefs.glade.h:52
+#: ../data/prefs.glade.h:53
 msgid "Show scrollbar"
 msgstr "Mostrar barra de rolagem"
 
-#: ../data/prefs.glade.h:53
+#: ../data/prefs.glade.h:54
 msgid "Scrollback lines:"
 msgstr "Linhas de rolagem:"
 
-#: ../data/prefs.glade.h:54
+#: ../data/prefs.glade.h:55
 msgid "On output"
 msgstr "Com a saída"
 
-#: ../data/prefs.glade.h:55
+#: ../data/prefs.glade.h:56
 msgid "On key stroke"
 msgstr "Ao pressionar tecla"
 
-#: ../data/prefs.glade.h:56
+#: ../data/prefs.glade.h:57
 msgid "<b>Scroll</b>"
 msgstr "<b>Rolagem</b>"
 
-#: ../data/prefs.glade.h:57
+#: ../data/prefs.glade.h:58
 msgid "Scrolling"
 msgstr "Rolagem"
 
-#: ../data/prefs.glade.h:58
+#: ../data/prefs.glade.h:59
 msgid "Use the system fixed width font"
 msgstr "Usar a largura da fonte fixada pelo sistema:"
 
-#: ../data/prefs.glade.h:59
+#: ../data/prefs.glade.h:60
 msgid "Font:"
 msgstr "Fonte:"
 
-#: ../data/prefs.glade.h:60
+#: ../data/prefs.glade.h:61
 msgid "Choose some font"
 msgstr "Escolha uma fonte"
 
-#: ../data/prefs.glade.h:61
+#: ../data/prefs.glade.h:62
 msgid "Text color:"
 msgstr "Cor do texto:"
 
-#: ../data/prefs.glade.h:62
+#: ../data/prefs.glade.h:63
 msgid "Background color:"
 msgstr "Cor de fundo:"
 
-#: ../data/prefs.glade.h:63
+#: ../data/prefs.glade.h:64
 msgid "Cursor shape:"
 msgstr "Forma do cursor:"
 
-#: ../data/prefs.glade.h:64
+#: ../data/prefs.glade.h:65
 msgid ""
 "Block\n"
 "I-Beam\n"
 "Underline"
 msgstr ""
 
-#: ../data/prefs.glade.h:67
+#: ../data/prefs.glade.h:68
 msgid ""
 "Follow GTK+ setting\n"
 "Blink on\n"
@@ -416,59 +420,59 @@ msgstr ""
 "Blink(piscar) ligado\n"
 "Blink(piscar) desligado"
 
-#: ../data/prefs.glade.h:70
+#: ../data/prefs.glade.h:71
 msgid "Cursor blink mode:"
 msgstr "Modo de cursor piscante:"
 
-#: ../data/prefs.glade.h:71
+#: ../data/prefs.glade.h:72
 msgid "Allow bold font"
 msgstr "Permitir negrito"
 
-#: ../data/prefs.glade.h:72
+#: ../data/prefs.glade.h:73
 msgid "<b>Palette</b>"
 msgstr "<b>Paleta</b>"
 
-#: ../data/prefs.glade.h:73
+#: ../data/prefs.glade.h:74
 msgid "Built-in schemes:"
 msgstr "Esquemas embutidos:"
 
-#: ../data/prefs.glade.h:74
+#: ../data/prefs.glade.h:75
 msgid "Color palette:"
 msgstr "Paleta de cor:"
 
-#: ../data/prefs.glade.h:75
+#: ../data/prefs.glade.h:76
 msgid "Font color"
 msgstr "Cor do texto:"
 
-#: ../data/prefs.glade.h:76
+#: ../data/prefs.glade.h:77
 msgid "Background color"
 msgstr "Cor de fundo:"
 
-#: ../data/prefs.glade.h:77
+#: ../data/prefs.glade.h:78
 msgid "Use font and background color from the palette"
 msgstr "Usar fonte e cor de background da paleta"
 
-#: ../data/prefs.glade.h:78
+#: ../data/prefs.glade.h:79
 msgid "Demo:"
 msgstr "Demosntração:"
 
-#: ../data/prefs.glade.h:79
+#: ../data/prefs.glade.h:80
 msgid "<b>Effects</b>"
 msgstr "<b>Efeitos</b>"
 
-#: ../data/prefs.glade.h:80
+#: ../data/prefs.glade.h:81
 msgid "Transparency:"
 msgstr "Transparência:"
 
-#: ../data/prefs.glade.h:81
+#: ../data/prefs.glade.h:82
 msgid "Background image:"
 msgstr "Imagem de fundo:"
 
-#: ../data/prefs.glade.h:82
+#: ../data/prefs.glade.h:83 ../src/guake/prefs.py:130
 msgid "Appearance"
 msgstr "Aparência"
 
-#: ../data/prefs.glade.h:83
+#: ../data/prefs.glade.h:84
 msgid ""
 "<small>Quick open is a feature allowing you to open a file directly into "
 "your favorite text editor by clicking on its filename when it appears in "
@@ -480,15 +484,15 @@ msgstr ""
 "aparece no seu terminal. Veja a lista de padrões de texto atualmente usados "
 "para extrair nomes de arquivo abaixo.</small>"
 
-#: ../data/prefs.glade.h:84
+#: ../data/prefs.glade.h:85
 msgid "Enable Quick Open when Ctrl+clicking on a filename in the terminal"
 msgstr "Habilitar Quick Open quando Ctrl+click num nome de arquivo no terminal"
 
-#: ../data/prefs.glade.h:85
+#: ../data/prefs.glade.h:86
 msgid "Editor command line:"
 msgstr "Editor de linha de comando:"
 
-#: ../data/prefs.glade.h:87
+#: ../data/prefs.glade.h:88
 #, no-c-format
 msgid ""
 "<small><i>Use the following elements in the open editor command line:\n"
@@ -508,11 +512,11 @@ msgstr ""
 "%(numero_linha)s</b>\n"
 "</i></small>"
 
-#: ../data/prefs.glade.h:93
+#: ../data/prefs.glade.h:94
 msgid "Quick open in current terminal"
 msgstr "Quick open no terminal atual"
 
-#: ../data/prefs.glade.h:94
+#: ../data/prefs.glade.h:95
 msgid ""
 "Here is the list of supported patterns: (to add your own, please contact the "
 "Guake's authors)"
@@ -520,16 +524,16 @@ msgstr ""
 "Aqui está uam lista de padrões suportados: (para adicionar o seu, por favor "
 "faça contato com os autores do Guake)"
 
-#: ../data/prefs.glade.h:95
+#: ../data/prefs.glade.h:96
 #, fuzzy
 msgid "<b>Quick Open</b>"
 msgstr "<b>Quick Open</b>"
 
-#: ../data/prefs.glade.h:96
+#: ../data/prefs.glade.h:97
 msgid "Quick Open"
 msgstr "Quick Open"
 
-#: ../data/prefs.glade.h:97
+#: ../data/prefs.glade.h:98
 msgid ""
 "To change a shortcut simply click on its name.\n"
 "To disable a shortcut, press the \"Backspace\" key."
@@ -537,11 +541,11 @@ msgstr ""
 "Para mudar um atalho simplesmente clique em seu nome.\n"
 "Para desabilitar um atalho, aperte a tecla \"Backspace\""
 
-#: ../data/prefs.glade.h:99
+#: ../data/prefs.glade.h:100
 msgid "Keyboard shortcuts"
 msgstr "Atalhos de teclado"
 
-#: ../data/prefs.glade.h:100
+#: ../data/prefs.glade.h:101
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -553,7 +557,7 @@ msgstr ""
 "contorne certos aplicativos e sistemas operacionais que esperam um "
 "comportamento diferente do terminal.</i></small>"
 
-#: ../data/prefs.glade.h:101
+#: ../data/prefs.glade.h:102
 msgid ""
 "ASCII DEL\n"
 "Escape sequence\n"
@@ -563,37 +567,36 @@ msgstr ""
 "Escape sequence\n"
 "Control-H"
 
-#: ../data/prefs.glade.h:104
+#: ../data/prefs.glade.h:105
 msgid "_Backspace key generates:"
 msgstr "Tecla _backspace gera:"
 
-#: ../data/prefs.glade.h:105
+#: ../data/prefs.glade.h:106
 msgid "_Delete key generates:"
 msgstr "Tecla _delete gera:"
 
-#: ../data/prefs.glade.h:106
+#: ../data/prefs.glade.h:107
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "_Restaurar as opções de compatibilidade padrão"
 
-#: ../data/prefs.glade.h:107
+#: ../data/prefs.glade.h:108
 msgid "<b>Keyboard compatibility</b>"
 msgstr "<b>Compatibilidade do teclado</b>"
 
-#: ../data/prefs.glade.h:108
+#: ../data/prefs.glade.h:109
 msgid "Compatibility"
 msgstr "Compatibilidade"
 
-#: ../src/guake/about.py:47 ../src/guake/gconfhandler.py:427
-#: ../src/guake/guake_app.py:180 ../src/guake/guake_app.py:357
+#: ../src/guake/about.py:47 ../src/guake/gconfhandler.py:435
+#: ../src/guake/guake_app.py:181 ../src/guake/guake_app.py:376
 msgid "Guake Terminal"
 msgstr "Terminal Guake"
 
-#. Adding a new radio button to the tabbar
-#: ../src/guake/gconfhandler.py:365 ../src/guake/guake_app.py:1569
+#: ../src/guake/gconfhandler.py:368 ../src/guake/guake_app.py:1363
 msgid "Terminal"
 msgstr "Terminal"
 
-#: ../src/guake/gconfhandler.py:428
+#: ../src/guake/gconfhandler.py:436
 #, python-format
 msgid ""
 "A problem happened when binding <b>%s</b> key.\n"
@@ -602,49 +605,49 @@ msgstr ""
 "Um problema aconteceu ao tentar associar a tecla <b>%s</b>.\n"
 "Por favor use a janela de preferências do Guake para escolher outra tecla."
 
-#: ../src/guake/guake_app.py:131
+#: ../src/guake/guake_app.py:132
 msgid "Do you want to close the tab?"
 msgstr "Você deseja fechar a aba?"
 
-#: ../src/guake/guake_app.py:134
+#: ../src/guake/guake_app.py:135
 msgid "Do you really want to quit Guake?"
 msgstr "Você realmente deseja sair do Guake?"
 
-#: ../src/guake/guake_app.py:136
+#: ../src/guake/guake_app.py:137
 msgid " and one tab open"
 msgstr " e uma aba aberta"
 
-#: ../src/guake/guake_app.py:138
+#: ../src/guake/guake_app.py:139
 #, python-brace-format
 msgid " and {0} tabs open"
 msgstr " and {0} abas abertas"
 
-#: ../src/guake/guake_app.py:141
+#: ../src/guake/guake_app.py:142
 msgid "There are no processes running"
 msgstr "Não há nenhum processo sendo executado."
 
-#: ../src/guake/guake_app.py:143
+#: ../src/guake/guake_app.py:144
 msgid "There is a process still running"
 msgstr "Há um processo sendo executado."
 
-#: ../src/guake/guake_app.py:145
+#: ../src/guake/guake_app.py:146
 #, fuzzy, python-brace-format
 msgid "There are {0} processes still running"
 msgstr "<b>Há %d processos sendo executados.</b>"
 
-#: ../src/guake/guake_app.py:185
+#: ../src/guake/guake_app.py:186
 msgid "guake-indicator"
 msgstr ""
 
-#: ../src/guake/guake_app.py:185
+#: ../src/guake/guake_app.py:186
 msgid "guake-tray"
 msgstr ""
 
-#: ../src/guake/guake_app.py:189
+#: ../src/guake/guake_app.py:190
 msgid "Show"
 msgstr "Mostrar"
 
-#: ../src/guake/guake_app.py:358
+#: ../src/guake/guake_app.py:377
 #, python-format
 msgid ""
 "Guake is now running,\n"
@@ -653,131 +656,136 @@ msgstr ""
 "O Guake está em execução,\n"
 "aperte <b>%s</b> para usá-lo."
 
-#: ../src/guake/guake_app.py:620
+#: ../src/guake/guake_app.py:665
 #, python-format
 msgid "Search on Web: '%s'"
 msgstr "Procurar na Web: '%s'"
 
-#: ../src/guake/guake_app.py:625
+#: ../src/guake/guake_app.py:670
 msgid "Search on Web (no selection)"
 msgstr "Procurar na Web (sem seleção)"
 
-#: ../src/guake/guake_app.py:631
+#: ../src/guake/guake_app.py:678
+#, fuzzy
+msgid "Open Link: '{}...'"
+msgstr "Abrir Link: {}"
+
+#: ../src/guake/guake_app.py:680
 msgid "Open Link: {}"
 msgstr "Abrir Link: {}"
 
-#: ../src/guake/guake_app.py:634
+#: ../src/guake/guake_app.py:683
 msgid "Open Link..."
 msgstr "Abrir Link..."
 
-#: ../src/guake/guake_app.py:1321
+#: ../src/guake/guake_app.py:1402
 msgid "Rename tab"
 msgstr "Renomear aba"
 
-#: ../src/guake/guake_app.py:1612
+#: ../src/guake/guake_app.py:1716
 msgid "Save to..."
 msgstr "Salvar em..."
 
-#: ../src/guake/guake_app.py:1619 ../src/guake/prefs.py:936
+#: ../src/guake/guake_app.py:1723 ../src/guake/prefs.py:998
 msgid "All files"
 msgstr "Todos arquivos"
 
-#: ../src/guake/guake_app.py:1624
+#: ../src/guake/guake_app.py:1728
 msgid "Text and Logs"
 msgstr "Texto e Logs"
 
-#: ../src/guake/guake_app.py:1642
+#: ../src/guake/guake_app.py:1746
 msgid "Find"
 msgstr "Encontrar"
 
-#: ../src/guake/guake_app.py:1644
+#: ../src/guake/guake_app.py:1748
 msgid "Forward"
 msgstr "Avançar"
 
-#: ../src/guake/guake_app.py:1645
+#: ../src/guake/guake_app.py:1749
 msgid "Backward"
 msgstr "Voltar"
 
-#: ../src/guake/main.py:67
+#: ../src/guake/main.py:68
 msgid "Put Guake in fullscreen mode"
 msgstr "Colocar Guake em modo de tela cheia"
 
-#: ../src/guake/main.py:71
+#: ../src/guake/main.py:72
 msgid "Toggles the visibility of the terminal window"
 msgstr "Alterna a visibilidade da janela do terminal"
 
-#: ../src/guake/main.py:75
+#: ../src/guake/main.py:76
 msgid "Shows Guake main window"
 msgstr "Exibe a janela principal do Guake"
 
-#: ../src/guake/main.py:79
+#: ../src/guake/main.py:80
 msgid "Hides Guake main window"
 msgstr "Exibe a janela principal do Guake"
 
-#: ../src/guake/main.py:83
+#: ../src/guake/main.py:84
 msgid "Shows Guake preference window"
 msgstr "Exibe a janela de preferências do Guake"
 
-#: ../src/guake/main.py:87
+#: ../src/guake/main.py:88
 msgid "Shows Guake's about info"
 msgstr "Mostra a janela \"Sobre o Guake\""
 
-#: ../src/guake/main.py:91
+#: ../src/guake/main.py:92
 #, fuzzy
 msgid "Add a new tab (with current directory set to NEW_TAB)"
 msgstr "Abrir nova aba no diretório atual"
 
-#: ../src/guake/main.py:95
+#: ../src/guake/main.py:96
 msgid "Select a tab (SELECT_TAB is the index of the tab)"
 msgstr "Selecione uma aba (SELECT_TAB é a posição da aba)"
 
-#: ../src/guake/main.py:99
+#: ../src/guake/main.py:100
 msgid "Return the selected tab index."
 msgstr "Retornar a posição da tabela selecionada."
 
-#: ../src/guake/main.py:103
+#: ../src/guake/main.py:104
 msgid "Execute an arbitrary command in the selected tab."
 msgstr "Executar um comando arbitrário na aba selecionada."
 
-#: ../src/guake/main.py:107
+#: ../src/guake/main.py:108
 msgid "Specify the tab to rename. Default is 0."
 msgstr "Especifique a aba para renomear. O padrão é 0."
 
-#: ../src/guake/main.py:111
+#: ../src/guake/main.py:112
 msgid "Set the hexadecimal (#rrggbb) background color of the selected tab."
 msgstr "Escolha a cor hexadecimal (#rrggbb) do fundo da aba selecionada."
 
-#: ../src/guake/main.py:116
+#: ../src/guake/main.py:117
 msgid "Set the hexadecimal (#rrggbb) foreground color of the selected tab."
 msgstr ""
 "Escolha a cor hexadecimal (#rrggbb) do primeiro plano da aba selecionada."
 
-#: ../src/guake/main.py:122
+#: ../src/guake/main.py:123
 msgid ""
 "Rename the specified tab. Reset to default if TITLE is a single dash \"-\"."
 msgstr ""
 "Renomeia a aba especificada. Reseta para o padrão se o TÍTULO for um hífen "
 "\"-\"."
 
-#: ../src/guake/main.py:128
+#: ../src/guake/main.py:129
 msgid ""
 "Rename the current tab. Reset to default if TITLE is a single dash \"-\"."
 msgstr ""
 "Renomeia a aba atual. Reseta para o padrão se o TÍTULO for um hífen \"-\"."
 
-#: ../src/guake/main.py:133
+#: ../src/guake/main.py:134
 msgid "Says to Guake go away =("
 msgstr "Diz ao Guake para ir embora =("
 
-#: ../src/guake/main.py:137
+#: ../src/guake/main.py:138
 msgid "Do not execute the start up script"
 msgstr "Não execute o script de inicialização"
 
-#: ../src/guake/main.py:231
+#: ../src/guake/main.py:235
 msgid "Guake can not init!"
 msgstr "Guake não pode iniciar!"
 
-#: ../src/guake/main.py:232
+#: ../src/guake/main.py:236
 msgid ""
 "Gconf Error.\n"
 "Have you installed <b>guake.schemas</b> properly?"
@@ -790,32 +798,191 @@ msgstr ""
 msgid "<user shell>"
 msgstr "<user shell>"
 
-#: ../src/guake/prefs.py:469
+#: ../src/guake/prefs.py:77
+msgid "Toggle Guake visibility"
+msgstr "Alternar a visibilidade do Guake"
+
+#: ../src/guake/prefs.py:81
+#, fuzzy
+msgid "Toggle Hide on Lose Focus"
+msgstr "Esconder ao perder o foco"
+
+#: ../src/guake/prefs.py:88
+msgid "Tab management"
+msgstr "Gerenciamento das abas"
+
+#: ../src/guake/prefs.py:90
+#, fuzzy
+msgid "New tab"
+msgstr "Nova aba"
+
+#: ../src/guake/prefs.py:92
+msgid "Close tab"
+msgstr "Fechar aba"
+
+#: ../src/guake/prefs.py:94
+msgid "Rename current tab"
+msgstr "Renomear aba atual"
+
+#: ../src/guake/prefs.py:97
+msgid "Navigation"
+msgstr "Navegação"
+
+#: ../src/guake/prefs.py:99
+msgid "Go to previous tab"
+msgstr "Ir para a aba anterior"
+
+#: ../src/guake/prefs.py:101
+msgid "Go to next tab"
+msgstr "Ir para a próxima aba"
+
+#: ../src/guake/prefs.py:103
+#, fuzzy
+msgid "Move current tab left"
+msgstr "Renomear aba atual"
+
+#: ../src/guake/prefs.py:105
+#, fuzzy
+msgid "Move current tab right"
+msgstr "Renomear aba atual"
+
+#: ../src/guake/prefs.py:107
+#, fuzzy
+msgid "Go to first tab"
+msgstr "Ir para a próxima aba"
+
+#: ../src/guake/prefs.py:109
+#, fuzzy
+msgid "Go to second tab"
+msgstr "Ir para a próxima aba"
+
+#: ../src/guake/prefs.py:111
+#, fuzzy
+msgid "Go to third tab"
+msgstr "Ir para a próxima aba"
+
+#: ../src/guake/prefs.py:113
+#, fuzzy
+msgid "Go to fourth tab"
+msgstr "Ir para a próxima aba"
+
+#: ../src/guake/prefs.py:115
+#, fuzzy
+msgid "Go to fifth tab"
+msgstr "Ir para a próxima aba"
+
+#: ../src/guake/prefs.py:117
+#, fuzzy
+msgid "Go to sixth tab"
+msgstr "Ir para a próxima aba"
+
+#: ../src/guake/prefs.py:119
+#, fuzzy
+msgid "Go to seventh tab"
+msgstr "Ir para a próxima aba"
+
+#: ../src/guake/prefs.py:121
+#, fuzzy
+msgid "Go to eighth tab"
+msgstr "Ir para a próxima aba"
+
+#: ../src/guake/prefs.py:123
+#, fuzzy
+msgid "Go to ninth tab"
+msgstr "Ir para a próxima aba"
+
+#: ../src/guake/prefs.py:125
+#, fuzzy
+msgid "Go to tenth tab"
+msgstr "Ir para a próxima aba"
+
+#: ../src/guake/prefs.py:127
+#, fuzzy
+msgid "Go to last tab"
+msgstr "Ir para a próxima aba"
+
+#: ../src/guake/prefs.py:132
+msgid "Zoom out"
+msgstr ""
+
+#: ../src/guake/prefs.py:134
+msgid "Zoom in"
+msgstr ""
+
+#: ../src/guake/prefs.py:136
+msgid "Zoom in (alternative)"
+msgstr ""
+
+#: ../src/guake/prefs.py:138
+msgid "Increase height"
+msgstr ""
+
+#: ../src/guake/prefs.py:140
+msgid "Decrease height"
+msgstr ""
+
+#: ../src/guake/prefs.py:142
+#, fuzzy
+msgid "Increase transparency"
+msgstr "Transparência:"
+
+#: ../src/guake/prefs.py:144
+#, fuzzy
+msgid "Decrease transparency"
+msgstr "Transparência:"
+
+#: ../src/guake/prefs.py:146
+#, fuzzy
+msgid "Toggle transparency"
+msgstr "Transparência:"
+
+#: ../src/guake/prefs.py:149
+msgid "Clipboard"
+msgstr "Área de transferência"
+
+#: ../src/guake/prefs.py:151
+msgid "Copy text to clipboard"
+msgstr "Copiar texto para a área de transferência"
+
+#: ../src/guake/prefs.py:153
+msgid "Paste text from clipboard"
+msgstr "Colar texto da área de transferência"
+
+#: ../src/guake/prefs.py:156
+msgid "Extra features"
+msgstr ""
+
+#: ../src/guake/prefs.py:159
+#, fuzzy
+msgid "Search select text on web"
+msgstr "Procurar na Web"
+
+#: ../src/guake/prefs.py:519
 msgid "Action"
 msgstr "Ação"
 
-#: ../src/guake/prefs.py:479
+#: ../src/guake/prefs.py:529
 msgid "Shortcut"
 msgstr "Atalho"
 
-#: ../src/guake/prefs.py:621 ../src/guake/prefs.py:667
+#: ../src/guake/prefs.py:678 ../src/guake/prefs.py:724
 msgid "Custom"
 msgstr "Personalizado"
 
-#: ../src/guake/prefs.py:932
+#: ../src/guake/prefs.py:994
 msgid "JSON files"
 msgstr "Arquivos JSON"
 
-#: ../src/guake/prefs.py:1026
+#: ../src/guake/prefs.py:1088
 #, python-format
 msgid "The shortcut \"%s\" is already in use."
 msgstr "O atalho \"%s\" já esta sendo usado."
 
-#: ../src/guake/prefs.py:1027
+#: ../src/guake/prefs.py:1089
 msgid "Error setting keybinding."
 msgstr "Erro ao configurar atalho."
 
-#: ../src/guake/prefs.py:1039
+#: ../src/guake/prefs.py:1101
 #, python-format
 msgid ""
 "The shortcut \"%s\" cannot be used because it will become impossible to type "
@@ -856,36 +1023,6 @@ msgstr ""
 
 #~ msgid "Rename the selected tab."
 #~ msgstr "Renomear aba selecionada."
-
-#~ msgid "Toggle Guake visibility"
-#~ msgstr "Alternar a visibilidade do Guake"
-
-#~ msgid "Tab management"
-#~ msgstr "Gerenciamento das abas"
-
-#~ msgid "Close tab"
-#~ msgstr "Fechar aba"
-
-#~ msgid "Rename current tab"
-#~ msgstr "Renomear aba atual"
-
-#~ msgid "Navigation"
-#~ msgstr "Navegação"
-
-#~ msgid "Go to previous tab"
-#~ msgstr "Ir para a aba anterior"
-
-#~ msgid "Go to next tab"
-#~ msgstr "Ir para a próxima aba"
-
-#~ msgid "Clipboard"
-#~ msgstr "Área de transferência"
-
-#~ msgid "Copy text to clipboard"
-#~ msgstr "Copiar texto para a área de transferência"
-
-#~ msgid "Paste text from clipboard"
-#~ msgstr "Colar texto da área de transferência"
 
 #~ msgid "<b>Background</b>"
 #~ msgstr "<b>Plano de fundo</b>"

--- a/po/ru.po
+++ b/po/ru.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Guake 0.4.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-08-05 15:10+0300\n"
+"POT-Creation-Date: 2016-08-17 21:41+0000\n"
 "PO-Revision-Date: 2016-08-05 15:34+0300\n"
 "Last-Translator: Ivan Komaritsyn <vantu5z@mail.ru>\n"
 "Language: \n"
@@ -259,130 +259,134 @@ msgid "Use VTE titles for tab names"
 msgstr "Использовать заголовки VTE для названий вкладок"
 
 #: ../data/prefs.glade.h:33
-msgid "Max tab name length:"
-msgstr "Макс. ширина вкладки"
+msgid "Abbreviate directories in tab names"
+msgstr "Сокращать пути в названиях вкладок"
 
 #: ../data/prefs.glade.h:34
+msgid "Max tab name length:"
+msgstr "Макс. ширина вкладки:"
+
+#: ../data/prefs.glade.h:35
 msgid "Hide on lose focus"
 msgstr "Прятать при потере фокуса"
 
-#: ../data/prefs.glade.h:35
+#: ../data/prefs.glade.h:36
 msgid "Show tab bar"
 msgstr "Показывать панель вкладок"
 
-#: ../data/prefs.glade.h:36
+#: ../data/prefs.glade.h:37
 msgid "Start fullscreen"
 msgstr "Запускать в полноэкранном режиме"
 
-#: ../data/prefs.glade.h:37
+#: ../data/prefs.glade.h:38
 msgid "<b>Main Window</b>"
 msgstr "<b>Основное окно</b>"
 
-#: ../data/prefs.glade.h:38
+#: ../data/prefs.glade.h:39
 msgid "Left"
 msgstr "Слева"
 
-#: ../data/prefs.glade.h:39
+#: ../data/prefs.glade.h:40
 msgid "Center"
 msgstr "По центру"
 
-#: ../data/prefs.glade.h:40
+#: ../data/prefs.glade.h:41
 msgid "Right"
 msgstr "Справа"
 
-#: ../data/prefs.glade.h:41
+#: ../data/prefs.glade.h:42
 msgid "<b>Main Window Horizontal Alignment</b>"
 msgstr "<b>Выравнивание по горизонтали</b>"
 
-#: ../data/prefs.glade.h:42
+#: ../data/prefs.glade.h:43
 msgid "<b>Main Window Height</b>"
 msgstr "<b>Высота основного окна</b>"
 
-#: ../data/prefs.glade.h:43
+#: ../data/prefs.glade.h:44
 msgid "<b>Main Window Width</b>"
 msgstr "<b>Ширина основного окна</b>"
 
-#: ../data/prefs.glade.h:44
+#: ../data/prefs.glade.h:45
 msgid "Custom command file path: "
 msgstr "Путь к пользовательской команде"
 
-#: ../data/prefs.glade.h:45
+#: ../data/prefs.glade.h:46
 msgid "Please select a json file"
 msgstr "Выберите файл json"
 
-#: ../data/prefs.glade.h:46 ../src/guake/prefs.py:75
+#: ../data/prefs.glade.h:47 ../src/guake/prefs.py:75
 msgid "General"
 msgstr "Общие"
 
-#: ../data/prefs.glade.h:47
+#: ../data/prefs.glade.h:48
 msgid "Default interpreter:"
 msgstr "Интерпретатор по умолчанию:"
 
-#: ../data/prefs.glade.h:48
+#: ../data/prefs.glade.h:49
 msgid "_Run command as a login shell"
 msgstr "_Запустить команду как шелл входа"
 
-#: ../data/prefs.glade.h:49
+#: ../data/prefs.glade.h:50
 msgid "_Open new tab in current directory"
 msgstr "_Открыть новую вкладку в текущей директории"
 
-#: ../data/prefs.glade.h:50
+#: ../data/prefs.glade.h:51
 msgid "<b>Shell</b>"
 msgstr "<b>Шелл</b>"
 
-#: ../data/prefs.glade.h:51
+#: ../data/prefs.glade.h:52
 msgid "Shell"
 msgstr "Шелл"
 
-#: ../data/prefs.glade.h:52
+#: ../data/prefs.glade.h:53
 msgid "Show scrollbar"
 msgstr "Показывать полосу прокрутки"
 
-#: ../data/prefs.glade.h:53
+#: ../data/prefs.glade.h:54
 msgid "Scrollback lines:"
 msgstr "Строк прокрутки:"
 
-#: ../data/prefs.glade.h:54
+#: ../data/prefs.glade.h:55
 msgid "On output"
 msgstr "На вывод"
 
-#: ../data/prefs.glade.h:55
+#: ../data/prefs.glade.h:56
 msgid "On key stroke"
 msgstr "На нажатие клавиши"
 
-#: ../data/prefs.glade.h:56
+#: ../data/prefs.glade.h:57
 msgid "<b>Scroll</b>"
 msgstr "<b>Прокрутка</b>"
 
-#: ../data/prefs.glade.h:57
+#: ../data/prefs.glade.h:58
 msgid "Scrolling"
 msgstr "Прокрутка"
 
-#: ../data/prefs.glade.h:58
+#: ../data/prefs.glade.h:59
 msgid "Use the system fixed width font"
 msgstr "Использовать системный шрифт фиксированного размера"
 
-#: ../data/prefs.glade.h:59
+#: ../data/prefs.glade.h:60
 msgid "Font:"
 msgstr "Шрифт:"
 
-#: ../data/prefs.glade.h:60
+#: ../data/prefs.glade.h:61
 msgid "Choose some font"
 msgstr "Выберите шрифт"
 
-#: ../data/prefs.glade.h:61
+#: ../data/prefs.glade.h:62
 msgid "Text color:"
 msgstr "Цвет текста:"
 
-#: ../data/prefs.glade.h:62
+#: ../data/prefs.glade.h:63
 msgid "Background color:"
 msgstr "Цвет фона:"
 
-#: ../data/prefs.glade.h:63
+#: ../data/prefs.glade.h:64
 msgid "Cursor shape:"
 msgstr "Вид курсора:"
 
-#: ../data/prefs.glade.h:64
+#: ../data/prefs.glade.h:65
 msgid ""
 "Block\n"
 "I-Beam\n"
@@ -392,7 +396,7 @@ msgstr ""
 "I-Вид\n"
 "Подчёркивание"
 
-#: ../data/prefs.glade.h:67
+#: ../data/prefs.glade.h:68
 msgid ""
 "Follow GTK+ setting\n"
 "Blink on\n"
@@ -402,59 +406,59 @@ msgstr ""
 "Моргать\n"
 "Не моргать"
 
-#: ../data/prefs.glade.h:70
+#: ../data/prefs.glade.h:71
 msgid "Cursor blink mode:"
 msgstr "Режим отображения курсора:"
 
-#: ../data/prefs.glade.h:71
+#: ../data/prefs.glade.h:72
 msgid "Allow bold font"
 msgstr "Разрешить жирный шрифт"
 
-#: ../data/prefs.glade.h:72
+#: ../data/prefs.glade.h:73
 msgid "<b>Palette</b>"
 msgstr "<b>Палитра</b>"
 
-#: ../data/prefs.glade.h:73
+#: ../data/prefs.glade.h:74
 msgid "Built-in schemes:"
 msgstr "Встроенные схемы:"
 
-#: ../data/prefs.glade.h:74
+#: ../data/prefs.glade.h:75
 msgid "Color palette:"
 msgstr "Цветовая палитра:"
 
-#: ../data/prefs.glade.h:75
+#: ../data/prefs.glade.h:76
 msgid "Font color"
 msgstr "Цвет текста"
 
-#: ../data/prefs.glade.h:76
+#: ../data/prefs.glade.h:77
 msgid "Background color"
 msgstr "Цвет фона"
 
-#: ../data/prefs.glade.h:77
+#: ../data/prefs.glade.h:78
 msgid "Use font and background color from the palette"
 msgstr "Использовать цвет текста и фона из палитры"
 
-#: ../data/prefs.glade.h:78
+#: ../data/prefs.glade.h:79
 msgid "Demo:"
 msgstr "Пример:"
 
-#: ../data/prefs.glade.h:79
+#: ../data/prefs.glade.h:80
 msgid "<b>Effects</b>"
 msgstr "<b>Воздействие</b>"
 
-#: ../data/prefs.glade.h:80
+#: ../data/prefs.glade.h:81
 msgid "Transparency:"
 msgstr "Прозрачность:"
 
-#: ../data/prefs.glade.h:81
+#: ../data/prefs.glade.h:82
 msgid "Background image:"
 msgstr "Фоновое изображение:"
 
-#: ../data/prefs.glade.h:82 ../src/guake/prefs.py:130
+#: ../data/prefs.glade.h:83 ../src/guake/prefs.py:130
 msgid "Appearance"
 msgstr "Оформление"
 
-#: ../data/prefs.glade.h:83
+#: ../data/prefs.glade.h:84
 msgid ""
 "<small>Quick open is a feature allowing you to open a file directly into "
 "your favorite text editor by clicking on its filename when it appears in "
@@ -465,16 +469,16 @@ msgstr ""
 "редакторе с помощью нажатия на его имени в терминале. Список поддерживаемых "
 "на данный момент конструкций имён файлов смотри ниже.</small>"
 
-#: ../data/prefs.glade.h:84
+#: ../data/prefs.glade.h:85
 msgid "Enable Quick Open when Ctrl+clicking on a filename in the terminal"
 msgstr ""
 "Разрешить \"Быстрое открытие\" по Ctrl+click на имени файла в терминале"
 
-#: ../data/prefs.glade.h:85
+#: ../data/prefs.glade.h:86
 msgid "Editor command line:"
 msgstr "Команда для Редактора"
 
-#: ../data/prefs.glade.h:87
+#: ../data/prefs.glade.h:88
 #, no-c-format
 msgid ""
 "<small><i>Use the following elements in the open editor command line:\n"
@@ -494,11 +498,11 @@ msgstr ""
 "b>\n"
 "</i></small>"
 
-#: ../data/prefs.glade.h:93
+#: ../data/prefs.glade.h:94
 msgid "Quick open in current terminal"
 msgstr "Быстрое открытие в текущем терминале"
 
-#: ../data/prefs.glade.h:94
+#: ../data/prefs.glade.h:95
 msgid ""
 "Here is the list of supported patterns: (to add your own, please contact the "
 "Guake's authors)"
@@ -506,15 +510,15 @@ msgstr ""
 "Здесь указан список поддерживаемых конструкций: (чтобы добавить свою, "
 "пожалуйста свяжитесь с разработчиками Guake)"
 
-#: ../data/prefs.glade.h:95
+#: ../data/prefs.glade.h:96
 msgid "<b>Quick Open</b>"
 msgstr "<b>Быстрое открытие</b>"
 
-#: ../data/prefs.glade.h:96
+#: ../data/prefs.glade.h:97
 msgid "Quick Open"
 msgstr "Быстрое открытие"
 
-#: ../data/prefs.glade.h:97
+#: ../data/prefs.glade.h:98
 msgid ""
 "To change a shortcut simply click on its name.\n"
 "To disable a shortcut, press the \"Backspace\" key."
@@ -522,11 +526,11 @@ msgstr ""
 "Чтобы изменить горячую клавишу, нажмите на её имени.\n"
 "Чтобы отключить горячую клавишу, нажмите \"Backspace\"."
 
-#: ../data/prefs.glade.h:99
+#: ../data/prefs.glade.h:100
 msgid "Keyboard shortcuts"
 msgstr "Горячие клавиши"
 
-#: ../data/prefs.glade.h:100
+#: ../data/prefs.glade.h:101
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -540,7 +544,7 @@ msgstr ""
 "Замечание переводчика: смотри http://trac.guake-terminal.org/trac.cgi/"
 "ticket/41</small>"
 
-#: ../data/prefs.glade.h:101
+#: ../data/prefs.glade.h:102
 msgid ""
 "ASCII DEL\n"
 "Escape sequence\n"
@@ -550,37 +554,36 @@ msgstr ""
 "Escape sequence\n"
 "Control-H"
 
-#: ../data/prefs.glade.h:104
+#: ../data/prefs.glade.h:105
 msgid "_Backspace key generates:"
 msgstr "Клавиша _Backspace генерирует:"
 
-#: ../data/prefs.glade.h:105
+#: ../data/prefs.glade.h:106
 msgid "_Delete key generates:"
 msgstr "Клавиша _Delete генерирует:"
 
-#: ../data/prefs.glade.h:106
+#: ../data/prefs.glade.h:107
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "_Сбросить опции совместимости в значения по умолчанию"
 
-#: ../data/prefs.glade.h:107
+#: ../data/prefs.glade.h:108
 msgid "<b>Keyboard compatibility</b>"
 msgstr "<b>Клавиатурная совместимость</b>"
 
-#: ../data/prefs.glade.h:108
+#: ../data/prefs.glade.h:109
 msgid "Compatibility"
 msgstr "Совместимость"
 
-#: ../src/guake/about.py:47 ../src/guake/gconfhandler.py:429
-#: ../src/guake/guake_app.py:181 ../src/guake/guake_app.py:358
+#: ../src/guake/about.py:47 ../src/guake/gconfhandler.py:435
+#: ../src/guake/guake_app.py:181 ../src/guake/guake_app.py:376
 msgid "Guake Terminal"
 msgstr "Терминал Guake"
 
-#. Adding a new radio button to the tabbar
-#: ../src/guake/gconfhandler.py:367 ../src/guake/guake_app.py:1629
+#: ../src/guake/gconfhandler.py:368 ../src/guake/guake_app.py:1363
 msgid "Terminal"
 msgstr "Терминал"
 
-#: ../src/guake/gconfhandler.py:430
+#: ../src/guake/gconfhandler.py:436
 #, python-format
 msgid ""
 "A problem happened when binding <b>%s</b> key.\n"
@@ -632,7 +635,7 @@ msgstr ""
 msgid "Show"
 msgstr "Показать"
 
-#: ../src/guake/guake_app.py:359
+#: ../src/guake/guake_app.py:377
 #, python-format
 msgid ""
 "Guake is now running,\n"
@@ -641,52 +644,52 @@ msgstr ""
 "Guake запущен,\n"
 "нажмите <b>%s</b> чтобы работать с ним."
 
-#: ../src/guake/guake_app.py:647
+#: ../src/guake/guake_app.py:665
 #, python-format
 msgid "Search on Web: '%s'"
 msgstr "Поиск в Интернете: '%s'"
 
-#: ../src/guake/guake_app.py:652
+#: ../src/guake/guake_app.py:670
 msgid "Search on Web (no selection)"
 msgstr "Поиск в Интернете (без выборки)"
 
-#: ../src/guake/guake_app.py:660
+#: ../src/guake/guake_app.py:678
 msgid "Open Link: '{}...'"
 msgstr "Открыть ссылку: '{}...'"
 
-#: ../src/guake/guake_app.py:662
+#: ../src/guake/guake_app.py:680
 msgid "Open Link: {}"
 msgstr "Открыть ссылку: {}"
 
-#: ../src/guake/guake_app.py:665
+#: ../src/guake/guake_app.py:683
 msgid "Open Link..."
 msgstr "Открыть ссылку..."
 
-#: ../src/guake/guake_app.py:1360
+#: ../src/guake/guake_app.py:1402
 msgid "Rename tab"
 msgstr "Переименовать вкладку"
 
-#: ../src/guake/guake_app.py:1674
+#: ../src/guake/guake_app.py:1716
 msgid "Save to..."
 msgstr "Сохранить как..."
 
-#: ../src/guake/guake_app.py:1681 ../src/guake/prefs.py:945
+#: ../src/guake/guake_app.py:1723 ../src/guake/prefs.py:998
 msgid "All files"
 msgstr "Все файлы"
 
-#: ../src/guake/guake_app.py:1686
+#: ../src/guake/guake_app.py:1728
 msgid "Text and Logs"
 msgstr "Текст и Логи"
 
-#: ../src/guake/guake_app.py:1704
+#: ../src/guake/guake_app.py:1746
 msgid "Find"
 msgstr "Найти"
 
-#: ../src/guake/guake_app.py:1706
+#: ../src/guake/guake_app.py:1748
 msgid "Forward"
 msgstr "Вперёд"
 
-#: ../src/guake/guake_app.py:1707
+#: ../src/guake/guake_app.py:1749
 msgid "Backward"
 msgstr "Назад"
 
@@ -922,32 +925,32 @@ msgstr "Допольнительные функции"
 msgid "Search select text on web"
 msgstr "Искать выделенный текст в Интернете"
 
-#: ../src/guake/prefs.py:474
+#: ../src/guake/prefs.py:519
 msgid "Action"
 msgstr "Действие"
 
-#: ../src/guake/prefs.py:484
+#: ../src/guake/prefs.py:529
 msgid "Shortcut"
 msgstr "Горячая клавиша"
 
-#: ../src/guake/prefs.py:630 ../src/guake/prefs.py:676
+#: ../src/guake/prefs.py:678 ../src/guake/prefs.py:724
 msgid "Custom"
 msgstr "Дополнительно"
 
-#: ../src/guake/prefs.py:941
+#: ../src/guake/prefs.py:994
 msgid "JSON files"
 msgstr "JSON файлы"
 
-#: ../src/guake/prefs.py:1035
+#: ../src/guake/prefs.py:1088
 #, python-format
 msgid "The shortcut \"%s\" is already in use."
 msgstr "Сокращение \"%s\" уже используется."
 
-#: ../src/guake/prefs.py:1036
+#: ../src/guake/prefs.py:1089
 msgid "Error setting keybinding."
 msgstr "Ошибка назначения клавиш."
 
-#: ../src/guake/prefs.py:1048
+#: ../src/guake/prefs.py:1101
 #, python-format
 msgid ""
 "The shortcut \"%s\" cannot be used because it will become impossible to type "

--- a/po/sv.po
+++ b/po/sv.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Guake 0.4.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-12-01 16:49+0100\n"
+"POT-Creation-Date: 2016-08-17 21:41+0000\n"
 "PO-Revision-Date: 2011-10-08 05:54+0000\n"
 "Last-Translator: Daniel Nylander <po@danielnylander.se>\n"
 "Language-Team: Swedish (http://www.transifex.com/projects/p/guake/language/"
@@ -100,7 +100,7 @@ msgstr "Kopiera"
 msgid "Paste"
 msgstr "Klistra in"
 
-#: ../data/guake.glade.h:3
+#: ../data/guake.glade.h:3 ../src/guake/prefs.py:79
 msgid "Toggle Fullscreen"
 msgstr "Växla helskärm"
 
@@ -108,7 +108,7 @@ msgstr "Växla helskärm"
 msgid "Save to File..."
 msgstr ""
 
-#: ../data/guake.glade.h:5
+#: ../data/guake.glade.h:5 ../src/guake/prefs.py:85
 #, fuzzy
 msgid "Reset terminal"
 msgstr "Guake Terminal"
@@ -139,7 +139,7 @@ msgstr ""
 msgid "Search on Web"
 msgstr ""
 
-#: ../data/guake.glade.h:12
+#: ../data/guake.glade.h:12 ../src/guake/prefs.py:83
 msgid "Quit"
 msgstr "Avsluta"
 
@@ -264,202 +264,206 @@ msgid "Use VTE titles for tab names"
 msgstr ""
 
 #: ../data/prefs.glade.h:33
-msgid "Max tab name length:"
+msgid "Abbreviate directories in tab names"
 msgstr ""
 
 #: ../data/prefs.glade.h:34
+msgid "Max tab name length:"
+msgstr ""
+
+#: ../data/prefs.glade.h:35
 msgid "Hide on lose focus"
 msgstr "Dölj när fokus tappas"
 
-#: ../data/prefs.glade.h:35
+#: ../data/prefs.glade.h:36
 msgid "Show tab bar"
 msgstr "Visa flikrad"
 
-#: ../data/prefs.glade.h:36
+#: ../data/prefs.glade.h:37
 #, fuzzy
 msgid "Start fullscreen"
 msgstr "Växla helskärm"
 
-#: ../data/prefs.glade.h:37
+#: ../data/prefs.glade.h:38
 msgid "<b>Main Window</b>"
 msgstr "<b>Huvudfönster</b>"
 
-#: ../data/prefs.glade.h:38
+#: ../data/prefs.glade.h:39
 msgid "Left"
 msgstr ""
 
-#: ../data/prefs.glade.h:39
+#: ../data/prefs.glade.h:40
 msgid "Center"
 msgstr ""
 
-#: ../data/prefs.glade.h:40
+#: ../data/prefs.glade.h:41
 msgid "Right"
 msgstr ""
 
-#: ../data/prefs.glade.h:41
+#: ../data/prefs.glade.h:42
 #, fuzzy
 msgid "<b>Main Window Horizontal Alignment</b>"
 msgstr "<b>Höjd för huvudfönster</b>"
 
-#: ../data/prefs.glade.h:42
+#: ../data/prefs.glade.h:43
 #, fuzzy
 msgid "<b>Main Window Height</b>"
 msgstr "<b>Höjd för huvudfönster</b>"
 
-#: ../data/prefs.glade.h:43
+#: ../data/prefs.glade.h:44
 #, fuzzy
 msgid "<b>Main Window Width</b>"
 msgstr "<b>Höjd för huvudfönster</b>"
 
-#: ../data/prefs.glade.h:44
+#: ../data/prefs.glade.h:45
 msgid "Custom command file path: "
 msgstr ""
 
-#: ../data/prefs.glade.h:45
+#: ../data/prefs.glade.h:46
 msgid "Please select a json file"
 msgstr ""
 
-#: ../data/prefs.glade.h:46
+#: ../data/prefs.glade.h:47 ../src/guake/prefs.py:75
 msgid "General"
 msgstr "Allmänt"
 
-#: ../data/prefs.glade.h:47
+#: ../data/prefs.glade.h:48
 msgid "Default interpreter:"
 msgstr "Standardtolk:"
 
-#: ../data/prefs.glade.h:48
+#: ../data/prefs.glade.h:49
 msgid "_Run command as a login shell"
 msgstr "_Kör kommando som ett inloggningsskal"
 
-#: ../data/prefs.glade.h:49
+#: ../data/prefs.glade.h:50
 msgid "_Open new tab in current directory"
 msgstr "_Öppna ny flik i aktuell katalog"
 
-#: ../data/prefs.glade.h:50
+#: ../data/prefs.glade.h:51
 msgid "<b>Shell</b>"
 msgstr "<b>Skal</b>"
 
-#: ../data/prefs.glade.h:51
+#: ../data/prefs.glade.h:52
 msgid "Shell"
 msgstr ""
 
-#: ../data/prefs.glade.h:52
+#: ../data/prefs.glade.h:53
 msgid "Show scrollbar"
 msgstr "Visa rullningslist"
 
-#: ../data/prefs.glade.h:53
+#: ../data/prefs.glade.h:54
 msgid "Scrollback lines:"
 msgstr "Rader i rullningshistorik:"
 
-#: ../data/prefs.glade.h:54
+#: ../data/prefs.glade.h:55
 msgid "On output"
 msgstr "Vid utdata"
 
-#: ../data/prefs.glade.h:55
+#: ../data/prefs.glade.h:56
 msgid "On key stroke"
 msgstr "Vid tangenttryckning"
 
-#: ../data/prefs.glade.h:56
+#: ../data/prefs.glade.h:57
 msgid "<b>Scroll</b>"
 msgstr "<b>Rullning</b>"
 
-#: ../data/prefs.glade.h:57
+#: ../data/prefs.glade.h:58
 msgid "Scrolling"
 msgstr "Rullning"
 
-#: ../data/prefs.glade.h:58
+#: ../data/prefs.glade.h:59
 msgid "Use the system fixed width font"
 msgstr "Använd systemets typsnitt med fast bredd"
 
-#: ../data/prefs.glade.h:59
+#: ../data/prefs.glade.h:60
 msgid "Font:"
 msgstr "Typsnitt:"
 
-#: ../data/prefs.glade.h:60
+#: ../data/prefs.glade.h:61
 msgid "Choose some font"
 msgstr "Välj ett typsnitt"
 
-#: ../data/prefs.glade.h:61
+#: ../data/prefs.glade.h:62
 msgid "Text color:"
 msgstr "Textfärg:"
 
-#: ../data/prefs.glade.h:62
+#: ../data/prefs.glade.h:63
 msgid "Background color:"
 msgstr "Bakgrundsfärg:"
 
-#: ../data/prefs.glade.h:63
+#: ../data/prefs.glade.h:64
 msgid "Cursor shape:"
 msgstr ""
 
-#: ../data/prefs.glade.h:64
+#: ../data/prefs.glade.h:65
 msgid ""
 "Block\n"
 "I-Beam\n"
 "Underline"
 msgstr ""
 
-#: ../data/prefs.glade.h:67
+#: ../data/prefs.glade.h:68
 msgid ""
 "Follow GTK+ setting\n"
 "Blink on\n"
 "Blink off"
 msgstr ""
 
-#: ../data/prefs.glade.h:70
+#: ../data/prefs.glade.h:71
 msgid "Cursor blink mode:"
 msgstr ""
 
-#: ../data/prefs.glade.h:71
+#: ../data/prefs.glade.h:72
 msgid "Allow bold font"
 msgstr ""
 
-#: ../data/prefs.glade.h:72
+#: ../data/prefs.glade.h:73
 msgid "<b>Palette</b>"
 msgstr "<b>Palett</b>"
 
-#: ../data/prefs.glade.h:73
+#: ../data/prefs.glade.h:74
 msgid "Built-in schemes:"
 msgstr "Inbyggda scheman:"
 
-#: ../data/prefs.glade.h:74
+#: ../data/prefs.glade.h:75
 msgid "Color palette:"
 msgstr "Färgpalett:"
 
-#: ../data/prefs.glade.h:75
+#: ../data/prefs.glade.h:76
 #, fuzzy
 msgid "Font color"
 msgstr "Textfärg:"
 
-#: ../data/prefs.glade.h:76
+#: ../data/prefs.glade.h:77
 #, fuzzy
 msgid "Background color"
 msgstr "Bakgrundsfärg:"
 
-#: ../data/prefs.glade.h:77
+#: ../data/prefs.glade.h:78
 msgid "Use font and background color from the palette"
 msgstr ""
 
-#: ../data/prefs.glade.h:78
+#: ../data/prefs.glade.h:79
 msgid "Demo:"
 msgstr ""
 
-#: ../data/prefs.glade.h:79
+#: ../data/prefs.glade.h:80
 msgid "<b>Effects</b>"
 msgstr "<b>Effekter</b>"
 
-#: ../data/prefs.glade.h:80
+#: ../data/prefs.glade.h:81
 msgid "Transparency:"
 msgstr "Genomskinlighet:"
 
-#: ../data/prefs.glade.h:81
+#: ../data/prefs.glade.h:82
 msgid "Background image:"
 msgstr "Bakgrundsbild:"
 
-#: ../data/prefs.glade.h:82
+#: ../data/prefs.glade.h:83 ../src/guake/prefs.py:130
 msgid "Appearance"
 msgstr "Utseende"
 
-#: ../data/prefs.glade.h:83
+#: ../data/prefs.glade.h:84
 msgid ""
 "<small>Quick open is a feature allowing you to open a file directly into "
 "your favorite text editor by clicking on its filename when it appears in "
@@ -467,15 +471,15 @@ msgid ""
 "extract filename below.</small>"
 msgstr ""
 
-#: ../data/prefs.glade.h:84
+#: ../data/prefs.glade.h:85
 msgid "Enable Quick Open when Ctrl+clicking on a filename in the terminal"
 msgstr ""
 
-#: ../data/prefs.glade.h:85
+#: ../data/prefs.glade.h:86
 msgid "Editor command line:"
 msgstr ""
 
-#: ../data/prefs.glade.h:87
+#: ../data/prefs.glade.h:88
 #, no-c-format
 msgid ""
 "<small><i>Use the following elements in the open editor command line:\n"
@@ -487,36 +491,36 @@ msgid ""
 "</i></small>"
 msgstr ""
 
-#: ../data/prefs.glade.h:93
+#: ../data/prefs.glade.h:94
 msgid "Quick open in current terminal"
 msgstr ""
 
-#: ../data/prefs.glade.h:94
+#: ../data/prefs.glade.h:95
 msgid ""
 "Here is the list of supported patterns: (to add your own, please contact the "
 "Guake's authors)"
 msgstr ""
 
-#: ../data/prefs.glade.h:95
+#: ../data/prefs.glade.h:96
 #, fuzzy
 msgid "<b>Quick Open</b>"
 msgstr "<b>Palett</b>"
 
-#: ../data/prefs.glade.h:96
+#: ../data/prefs.glade.h:97
 msgid "Quick Open"
 msgstr ""
 
-#: ../data/prefs.glade.h:97
+#: ../data/prefs.glade.h:98
 msgid ""
 "To change a shortcut simply click on its name.\n"
 "To disable a shortcut, press the \"Backspace\" key."
 msgstr ""
 
-#: ../data/prefs.glade.h:99
+#: ../data/prefs.glade.h:100
 msgid "Keyboard shortcuts"
 msgstr "Tangentbordsgenvägar"
 
-#: ../data/prefs.glade.h:100
+#: ../data/prefs.glade.h:101
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -528,7 +532,7 @@ msgstr ""
 "temporära lösningar för vissa program och operativsystem som förväntar ett "
 "annat terminalbeteende.</i></small>"
 
-#: ../data/prefs.glade.h:101
+#: ../data/prefs.glade.h:102
 msgid ""
 "ASCII DEL\n"
 "Escape sequence\n"
@@ -538,38 +542,37 @@ msgstr ""
 "Escape-sekvens\n"
 "Control-H"
 
-#: ../data/prefs.glade.h:104
+#: ../data/prefs.glade.h:105
 msgid "_Backspace key generates:"
 msgstr "_Backspace-tangenten genererar:"
 
-#: ../data/prefs.glade.h:105
+#: ../data/prefs.glade.h:106
 msgid "_Delete key generates:"
 msgstr "_Delete-tangenten genererar:"
 
-#: ../data/prefs.glade.h:106
+#: ../data/prefs.glade.h:107
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "Åt_erställ kompatibilitetsalternativ till standardvärden"
 
-#: ../data/prefs.glade.h:107
+#: ../data/prefs.glade.h:108
 msgid "<b>Keyboard compatibility</b>"
 msgstr "<b>Tangentbordskompatibilitet</b>"
 
-#: ../data/prefs.glade.h:108
+#: ../data/prefs.glade.h:109
 msgid "Compatibility"
 msgstr "Kompatibilitet"
 
-#: ../src/guake/about.py:47 ../src/guake/gconfhandler.py:427
-#: ../src/guake/guake_app.py:177 ../src/guake/guake_app.py:348
+#: ../src/guake/about.py:47 ../src/guake/gconfhandler.py:435
+#: ../src/guake/guake_app.py:181 ../src/guake/guake_app.py:376
 msgid "Guake Terminal"
 msgstr "Guake Terminal"
 
-#. Adding a new radio button to the tabbar
-#: ../src/guake/gconfhandler.py:365 ../src/guake/guake_app.py:1548
+#: ../src/guake/gconfhandler.py:368 ../src/guake/guake_app.py:1363
 #, fuzzy
 msgid "Terminal"
 msgstr "Terminal %s"
 
-#: ../src/guake/gconfhandler.py:428
+#: ../src/guake/gconfhandler.py:436
 #, python-format
 msgid ""
 "A problem happened when binding <b>%s</b> key.\n"
@@ -579,54 +582,54 @@ msgstr ""
 "Använd inställningsdialogen i Guake för att välja en annan tangent "
 "(Aktivitetsikonen var aktiverad)"
 
-#: ../src/guake/guake_app.py:128
+#: ../src/guake/guake_app.py:132
 #, fuzzy
 msgid "Do you want to close the tab?"
 msgstr "Vill du verkligen avsluta Guake!?"
 
-#: ../src/guake/guake_app.py:131
+#: ../src/guake/guake_app.py:135
 #, fuzzy
 msgid "Do you really want to quit Guake?"
 msgstr "Vill du verkligen avsluta Guake!?"
 
-#: ../src/guake/guake_app.py:133
+#: ../src/guake/guake_app.py:137
 #, fuzzy
 msgid " and one tab open"
 msgstr "Lägg till ny flik"
 
-#: ../src/guake/guake_app.py:135
+#: ../src/guake/guake_app.py:139
 #, python-brace-format
 msgid " and {0} tabs open"
 msgstr ""
 
-#: ../src/guake/guake_app.py:138
+#: ../src/guake/guake_app.py:142
 #, fuzzy
 msgid "There are no processes running"
 msgstr "<b>Det finns fortfarande en process igång.</b>"
 
-#: ../src/guake/guake_app.py:140
+#: ../src/guake/guake_app.py:144
 #, fuzzy
 msgid "There is a process still running"
 msgstr "<b>Det finns fortfarande en process igång.</b>"
 
-#: ../src/guake/guake_app.py:142
+#: ../src/guake/guake_app.py:146
 #, fuzzy, python-brace-format
 msgid "There are {0} processes still running"
 msgstr "<b>Det finns %d processer igång.</b>"
 
-#: ../src/guake/guake_app.py:182
+#: ../src/guake/guake_app.py:186
 msgid "guake-indicator"
 msgstr ""
 
-#: ../src/guake/guake_app.py:182
+#: ../src/guake/guake_app.py:186
 msgid "guake-tray"
 msgstr ""
 
-#: ../src/guake/guake_app.py:186
+#: ../src/guake/guake_app.py:190
 msgid "Show"
 msgstr ""
 
-#: ../src/guake/guake_app.py:349
+#: ../src/guake/guake_app.py:377
 #, python-format
 msgid ""
 "Guake is now running,\n"
@@ -635,129 +638,133 @@ msgstr ""
 "Guake är nu igång, tryck\n"
 "<b>%s</b> för att använda den."
 
-#: ../src/guake/guake_app.py:611
+#: ../src/guake/guake_app.py:665
 #, python-format
 msgid "Search on Web: '%s'"
 msgstr ""
 
-#: ../src/guake/guake_app.py:616
+#: ../src/guake/guake_app.py:670
 msgid "Search on Web (no selection)"
 msgstr ""
 
-#: ../src/guake/guake_app.py:622
+#: ../src/guake/guake_app.py:678
+msgid "Open Link: '{}...'"
+msgstr ""
+
+#: ../src/guake/guake_app.py:680
 msgid "Open Link: {}"
 msgstr ""
 
-#: ../src/guake/guake_app.py:625
+#: ../src/guake/guake_app.py:683
 msgid "Open Link..."
 msgstr ""
 
-#: ../src/guake/guake_app.py:1300
+#: ../src/guake/guake_app.py:1402
 msgid "Rename tab"
 msgstr "Byt namn på flik"
 
-#: ../src/guake/guake_app.py:1591
+#: ../src/guake/guake_app.py:1716
 msgid "Save to..."
 msgstr ""
 
-#: ../src/guake/guake_app.py:1598 ../src/guake/prefs.py:930
+#: ../src/guake/guake_app.py:1723 ../src/guake/prefs.py:998
 msgid "All files"
 msgstr ""
 
-#: ../src/guake/guake_app.py:1603
+#: ../src/guake/guake_app.py:1728
 msgid "Text and Logs"
 msgstr ""
 
-#: ../src/guake/guake_app.py:1621
+#: ../src/guake/guake_app.py:1746
 msgid "Find"
 msgstr ""
 
-#: ../src/guake/guake_app.py:1623
+#: ../src/guake/guake_app.py:1748
 msgid "Forward"
 msgstr ""
 
-#: ../src/guake/guake_app.py:1624
+#: ../src/guake/guake_app.py:1749
 msgid "Backward"
 msgstr ""
 
-#: ../src/guake/main.py:67
+#: ../src/guake/main.py:68
 msgid "Put Guake in fullscreen mode"
 msgstr ""
 
-#: ../src/guake/main.py:71
+#: ../src/guake/main.py:72
 msgid "Toggles the visibility of the terminal window"
 msgstr "Växlar synligheten för terminalfönstret"
 
-#: ../src/guake/main.py:75
+#: ../src/guake/main.py:76
 #, fuzzy
 msgid "Shows Guake main window"
 msgstr "Visar Guakes inställningsfönster"
 
-#: ../src/guake/main.py:79
+#: ../src/guake/main.py:80
 #, fuzzy
 msgid "Hides Guake main window"
 msgstr "Visar Guakes inställningsfönster"
 
-#: ../src/guake/main.py:83
+#: ../src/guake/main.py:84
 msgid "Shows Guake preference window"
 msgstr "Visar Guakes inställningsfönster"
 
-#: ../src/guake/main.py:87
+#: ../src/guake/main.py:88
 msgid "Shows Guake's about info"
 msgstr "Visar information om Guake"
 
-#: ../src/guake/main.py:91
+#: ../src/guake/main.py:92
 #, fuzzy
 msgid "Add a new tab (with current directory set to NEW_TAB)"
 msgstr "_Öppna ny flik i aktuell katalog"
 
-#: ../src/guake/main.py:95
+#: ../src/guake/main.py:96
 msgid "Select a tab (SELECT_TAB is the index of the tab)"
 msgstr ""
 
-#: ../src/guake/main.py:99
+#: ../src/guake/main.py:100
 msgid "Return the selected tab index."
 msgstr "Returnerar valt flikindex"
 
-#: ../src/guake/main.py:103
+#: ../src/guake/main.py:104
 msgid "Execute an arbitrary command in the selected tab."
 msgstr "Kör ett godtyckligt kommando i markerad flik."
 
-#: ../src/guake/main.py:107
+#: ../src/guake/main.py:108
 msgid "Specify the tab to rename. Default is 0."
 msgstr ""
 
-#: ../src/guake/main.py:111
+#: ../src/guake/main.py:112
 msgid "Set the hexadecimal (#rrggbb) background color of the selected tab."
 msgstr ""
 
-#: ../src/guake/main.py:116
+#: ../src/guake/main.py:117
 msgid "Set the hexadecimal (#rrggbb) foreground color of the selected tab."
 msgstr ""
 
-#: ../src/guake/main.py:122
+#: ../src/guake/main.py:123
 msgid ""
 "Rename the specified tab. Reset to default if TITLE is a single dash \"-\"."
 msgstr ""
 
-#: ../src/guake/main.py:128
+#: ../src/guake/main.py:129
 msgid ""
 "Rename the current tab. Reset to default if TITLE is a single dash \"-\"."
 msgstr ""
 
-#: ../src/guake/main.py:133
+#: ../src/guake/main.py:134
 msgid "Says to Guake go away =("
 msgstr "Säger till Guake att försvinna =("
 
-#: ../src/guake/main.py:137
+#: ../src/guake/main.py:138
 msgid "Do not execute the start up script"
 msgstr ""
 
-#: ../src/guake/main.py:231
+#: ../src/guake/main.py:235
 msgid "Guake can not init!"
 msgstr "Guake kan inte initiera!"
 
-#: ../src/guake/main.py:232
+#: ../src/guake/main.py:236
 #, fuzzy
 msgid ""
 "Gconf Error.\n"
@@ -771,32 +778,190 @@ msgstr ""
 msgid "<user shell>"
 msgstr "<användarskal>"
 
-#: ../src/guake/prefs.py:467
+#: ../src/guake/prefs.py:77
+msgid "Toggle Guake visibility"
+msgstr "Växla synlighet för Guake"
+
+#: ../src/guake/prefs.py:81
+#, fuzzy
+msgid "Toggle Hide on Lose Focus"
+msgstr "Dölj när fokus tappas"
+
+#: ../src/guake/prefs.py:88
+msgid "Tab management"
+msgstr "Flikhantering"
+
+#: ../src/guake/prefs.py:90
+#, fuzzy
+msgid "New tab"
+msgstr "Ny flik"
+
+#: ../src/guake/prefs.py:92
+msgid "Close tab"
+msgstr "Stäng flik"
+
+#: ../src/guake/prefs.py:94
+msgid "Rename current tab"
+msgstr "Byt namn på aktuell flik"
+
+#: ../src/guake/prefs.py:97
+msgid "Navigation"
+msgstr "Navigering"
+
+#: ../src/guake/prefs.py:99
+msgid "Go to previous tab"
+msgstr "Gå till föregående flik"
+
+#: ../src/guake/prefs.py:101
+msgid "Go to next tab"
+msgstr "Gå till nästa flik"
+
+#: ../src/guake/prefs.py:103
+#, fuzzy
+msgid "Move current tab left"
+msgstr "Byt namn på aktuell flik"
+
+#: ../src/guake/prefs.py:105
+#, fuzzy
+msgid "Move current tab right"
+msgstr "Byt namn på aktuell flik"
+
+#: ../src/guake/prefs.py:107
+#, fuzzy
+msgid "Go to first tab"
+msgstr "Gå till nästa flik"
+
+#: ../src/guake/prefs.py:109
+#, fuzzy
+msgid "Go to second tab"
+msgstr "Gå till nästa flik"
+
+#: ../src/guake/prefs.py:111
+#, fuzzy
+msgid "Go to third tab"
+msgstr "Gå till nästa flik"
+
+#: ../src/guake/prefs.py:113
+#, fuzzy
+msgid "Go to fourth tab"
+msgstr "Gå till nästa flik"
+
+#: ../src/guake/prefs.py:115
+#, fuzzy
+msgid "Go to fifth tab"
+msgstr "Gå till nästa flik"
+
+#: ../src/guake/prefs.py:117
+#, fuzzy
+msgid "Go to sixth tab"
+msgstr "Gå till nästa flik"
+
+#: ../src/guake/prefs.py:119
+#, fuzzy
+msgid "Go to seventh tab"
+msgstr "Gå till nästa flik"
+
+#: ../src/guake/prefs.py:121
+#, fuzzy
+msgid "Go to eighth tab"
+msgstr "Gå till nästa flik"
+
+#: ../src/guake/prefs.py:123
+#, fuzzy
+msgid "Go to ninth tab"
+msgstr "Gå till nästa flik"
+
+#: ../src/guake/prefs.py:125
+#, fuzzy
+msgid "Go to tenth tab"
+msgstr "Gå till nästa flik"
+
+#: ../src/guake/prefs.py:127
+#, fuzzy
+msgid "Go to last tab"
+msgstr "Gå till nästa flik"
+
+#: ../src/guake/prefs.py:132
+msgid "Zoom out"
+msgstr ""
+
+#: ../src/guake/prefs.py:134
+msgid "Zoom in"
+msgstr ""
+
+#: ../src/guake/prefs.py:136
+msgid "Zoom in (alternative)"
+msgstr ""
+
+#: ../src/guake/prefs.py:138
+msgid "Increase height"
+msgstr ""
+
+#: ../src/guake/prefs.py:140
+msgid "Decrease height"
+msgstr ""
+
+#: ../src/guake/prefs.py:142
+#, fuzzy
+msgid "Increase transparency"
+msgstr "Genomskinlighet:"
+
+#: ../src/guake/prefs.py:144
+#, fuzzy
+msgid "Decrease transparency"
+msgstr "Genomskinlighet:"
+
+#: ../src/guake/prefs.py:146
+#, fuzzy
+msgid "Toggle transparency"
+msgstr "Genomskinlighet:"
+
+#: ../src/guake/prefs.py:149
+msgid "Clipboard"
+msgstr "Urklipp"
+
+#: ../src/guake/prefs.py:151
+msgid "Copy text to clipboard"
+msgstr "Kopiera text till urklipp"
+
+#: ../src/guake/prefs.py:153
+msgid "Paste text from clipboard"
+msgstr "Klistra in text från urklipp"
+
+#: ../src/guake/prefs.py:156
+msgid "Extra features"
+msgstr ""
+
+#: ../src/guake/prefs.py:159
+msgid "Search select text on web"
+msgstr ""
+
+#: ../src/guake/prefs.py:519
 msgid "Action"
 msgstr "Åtgärd"
 
-#: ../src/guake/prefs.py:477
+#: ../src/guake/prefs.py:529
 msgid "Shortcut"
 msgstr "Genväg"
 
-#: ../src/guake/prefs.py:619 ../src/guake/prefs.py:665
+#: ../src/guake/prefs.py:678 ../src/guake/prefs.py:724
 msgid "Custom"
 msgstr ""
 
-#: ../src/guake/prefs.py:926
+#: ../src/guake/prefs.py:994
 msgid "JSON files"
 msgstr ""
 
-#: ../src/guake/prefs.py:1019
+#: ../src/guake/prefs.py:1088
 #, python-format
 msgid "The shortcut \"%s\" is already in use."
 msgstr "Genvägen \"%s\" används redan."
 
-#: ../src/guake/prefs.py:1020
+#: ../src/guake/prefs.py:1089
 msgid "Error setting keybinding."
 msgstr "Fel vid inställning av tangentbindning."
 
-#: ../src/guake/prefs.py:1032
+#: ../src/guake/prefs.py:1101
 #, python-format
 msgid ""
 "The shortcut \"%s\" cannot be used because it will become impossible to type "
@@ -836,33 +1001,3 @@ msgstr ""
 
 #~ msgid "Rename the selected tab."
 #~ msgstr "Byt namn på markerad flik."
-
-#~ msgid "Toggle Guake visibility"
-#~ msgstr "Växla synlighet för Guake"
-
-#~ msgid "Tab management"
-#~ msgstr "Flikhantering"
-
-#~ msgid "Close tab"
-#~ msgstr "Stäng flik"
-
-#~ msgid "Rename current tab"
-#~ msgstr "Byt namn på aktuell flik"
-
-#~ msgid "Navigation"
-#~ msgstr "Navigering"
-
-#~ msgid "Go to previous tab"
-#~ msgstr "Gå till föregående flik"
-
-#~ msgid "Go to next tab"
-#~ msgstr "Gå till nästa flik"
-
-#~ msgid "Clipboard"
-#~ msgstr "Urklipp"
-
-#~ msgid "Copy text to clipboard"
-#~ msgstr "Kopiera text till urklipp"
-
-#~ msgid "Paste text from clipboard"
-#~ msgstr "Klistra in text från urklipp"

--- a/po/tr.po
+++ b/po/tr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Guake 0.4.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-12-01 16:49+0100\n"
+"POT-Creation-Date: 2016-08-17 21:41+0000\n"
 "PO-Revision-Date: 2012-07-30 08:02+0000\n"
 "Last-Translator: Berk Demirkır <bdemirkir@gmail.com>\n"
 "Language-Team: Turkish (http://www.transifex.com/projects/p/guake/language/"
@@ -100,7 +100,7 @@ msgstr "Kopyala"
 msgid "Paste"
 msgstr "Yapıştır"
 
-#: ../data/guake.glade.h:3
+#: ../data/guake.glade.h:3 ../src/guake/prefs.py:79
 msgid "Toggle Fullscreen"
 msgstr "Tam ekran moduna gir veya çık"
 
@@ -108,7 +108,7 @@ msgstr "Tam ekran moduna gir veya çık"
 msgid "Save to File..."
 msgstr ""
 
-#: ../data/guake.glade.h:5
+#: ../data/guake.glade.h:5 ../src/guake/prefs.py:85
 #, fuzzy
 msgid "Reset terminal"
 msgstr "Guake Uçbirim"
@@ -139,7 +139,7 @@ msgstr ""
 msgid "Search on Web"
 msgstr ""
 
-#: ../data/guake.glade.h:12
+#: ../data/guake.glade.h:12 ../src/guake/prefs.py:83
 msgid "Quit"
 msgstr "Çıkış"
 
@@ -264,202 +264,206 @@ msgid "Use VTE titles for tab names"
 msgstr ""
 
 #: ../data/prefs.glade.h:33
-msgid "Max tab name length:"
+msgid "Abbreviate directories in tab names"
 msgstr ""
 
 #: ../data/prefs.glade.h:34
+msgid "Max tab name length:"
+msgstr ""
+
+#: ../data/prefs.glade.h:35
 msgid "Hide on lose focus"
 msgstr "Focus kaybedildiğinde gizle"
 
-#: ../data/prefs.glade.h:35
+#: ../data/prefs.glade.h:36
 msgid "Show tab bar"
 msgstr "Sekme çubuğunu görüntüle"
 
-#: ../data/prefs.glade.h:36
+#: ../data/prefs.glade.h:37
 #, fuzzy
 msgid "Start fullscreen"
 msgstr "Tam ekran moduna gir veya çık"
 
-#: ../data/prefs.glade.h:37
+#: ../data/prefs.glade.h:38
 msgid "<b>Main Window</b>"
 msgstr "<b>Uçbirim Penceresi</b>"
 
-#: ../data/prefs.glade.h:38
+#: ../data/prefs.glade.h:39
 msgid "Left"
 msgstr ""
 
-#: ../data/prefs.glade.h:39
+#: ../data/prefs.glade.h:40
 msgid "Center"
 msgstr ""
 
-#: ../data/prefs.glade.h:40
+#: ../data/prefs.glade.h:41
 msgid "Right"
 msgstr ""
 
-#: ../data/prefs.glade.h:41
+#: ../data/prefs.glade.h:42
 #, fuzzy
 msgid "<b>Main Window Horizontal Alignment</b>"
 msgstr "<b>Uçbirim Pencere yüksekliği</b>"
 
-#: ../data/prefs.glade.h:42
+#: ../data/prefs.glade.h:43
 #, fuzzy
 msgid "<b>Main Window Height</b>"
 msgstr "<b>Uçbirim Pencere yüksekliği</b>"
 
-#: ../data/prefs.glade.h:43
+#: ../data/prefs.glade.h:44
 #, fuzzy
 msgid "<b>Main Window Width</b>"
 msgstr "<b>Uçbirim Pencere yüksekliği</b>"
 
-#: ../data/prefs.glade.h:44
+#: ../data/prefs.glade.h:45
 msgid "Custom command file path: "
 msgstr ""
 
-#: ../data/prefs.glade.h:45
+#: ../data/prefs.glade.h:46
 msgid "Please select a json file"
 msgstr ""
 
-#: ../data/prefs.glade.h:46
+#: ../data/prefs.glade.h:47 ../src/guake/prefs.py:75
 msgid "General"
 msgstr "Genel"
 
-#: ../data/prefs.glade.h:47
+#: ../data/prefs.glade.h:48
 msgid "Default interpreter:"
 msgstr "Varsayılan yorumlayıcı:"
 
-#: ../data/prefs.glade.h:48
+#: ../data/prefs.glade.h:49
 msgid "_Run command as a login shell"
 msgstr "Komutu gi_riş kabuğu olarak çalıştır."
 
-#: ../data/prefs.glade.h:49
+#: ../data/prefs.glade.h:50
 msgid "_Open new tab in current directory"
 msgstr "_Yeni sekmeyi klasörde aç"
 
-#: ../data/prefs.glade.h:50
+#: ../data/prefs.glade.h:51
 msgid "<b>Shell</b>"
 msgstr "<b>Kabuk</b>"
 
-#: ../data/prefs.glade.h:51
+#: ../data/prefs.glade.h:52
 msgid "Shell"
 msgstr ""
 
-#: ../data/prefs.glade.h:52
+#: ../data/prefs.glade.h:53
 msgid "Show scrollbar"
 msgstr "Kaydırma çubuğunu görüntüle"
 
-#: ../data/prefs.glade.h:53
+#: ../data/prefs.glade.h:54
 msgid "Scrollback lines:"
 msgstr "Satır hafızası:"
 
-#: ../data/prefs.glade.h:54
+#: ../data/prefs.glade.h:55
 msgid "On output"
 msgstr "Çıktı üretildiğinde"
 
-#: ../data/prefs.glade.h:55
+#: ../data/prefs.glade.h:56
 msgid "On key stroke"
 msgstr "Tuşa basıldığında"
 
-#: ../data/prefs.glade.h:56
+#: ../data/prefs.glade.h:57
 msgid "<b>Scroll</b>"
 msgstr "<b>Ekran Kaydırma</b>"
 
-#: ../data/prefs.glade.h:57
+#: ../data/prefs.glade.h:58
 msgid "Scrolling"
 msgstr "Kaydırma"
 
-#: ../data/prefs.glade.h:58
+#: ../data/prefs.glade.h:59
 msgid "Use the system fixed width font"
 msgstr "Sistemin sabit genişlikli yazıtipini kullan"
 
-#: ../data/prefs.glade.h:59
+#: ../data/prefs.glade.h:60
 msgid "Font:"
 msgstr "Yazıtipi:"
 
-#: ../data/prefs.glade.h:60
+#: ../data/prefs.glade.h:61
 msgid "Choose some font"
 msgstr "Font seçin"
 
-#: ../data/prefs.glade.h:61
+#: ../data/prefs.glade.h:62
 msgid "Text color:"
 msgstr "Metin rengi:"
 
-#: ../data/prefs.glade.h:62
+#: ../data/prefs.glade.h:63
 msgid "Background color:"
 msgstr "Arkaplan rengi:"
 
-#: ../data/prefs.glade.h:63
+#: ../data/prefs.glade.h:64
 msgid "Cursor shape:"
 msgstr ""
 
-#: ../data/prefs.glade.h:64
+#: ../data/prefs.glade.h:65
 msgid ""
 "Block\n"
 "I-Beam\n"
 "Underline"
 msgstr ""
 
-#: ../data/prefs.glade.h:67
+#: ../data/prefs.glade.h:68
 msgid ""
 "Follow GTK+ setting\n"
 "Blink on\n"
 "Blink off"
 msgstr ""
 
-#: ../data/prefs.glade.h:70
+#: ../data/prefs.glade.h:71
 msgid "Cursor blink mode:"
 msgstr ""
 
-#: ../data/prefs.glade.h:71
+#: ../data/prefs.glade.h:72
 msgid "Allow bold font"
 msgstr ""
 
-#: ../data/prefs.glade.h:72
+#: ../data/prefs.glade.h:73
 msgid "<b>Palette</b>"
 msgstr "<b>Palet</b>"
 
-#: ../data/prefs.glade.h:73
+#: ../data/prefs.glade.h:74
 msgid "Built-in schemes:"
 msgstr "Varsayılan düzenler:"
 
-#: ../data/prefs.glade.h:74
+#: ../data/prefs.glade.h:75
 msgid "Color palette:"
 msgstr "Renk Paleti:"
 
-#: ../data/prefs.glade.h:75
+#: ../data/prefs.glade.h:76
 #, fuzzy
 msgid "Font color"
 msgstr "Metin rengi:"
 
-#: ../data/prefs.glade.h:76
+#: ../data/prefs.glade.h:77
 #, fuzzy
 msgid "Background color"
 msgstr "Arkaplan rengi:"
 
-#: ../data/prefs.glade.h:77
+#: ../data/prefs.glade.h:78
 msgid "Use font and background color from the palette"
 msgstr ""
 
-#: ../data/prefs.glade.h:78
+#: ../data/prefs.glade.h:79
 msgid "Demo:"
 msgstr ""
 
-#: ../data/prefs.glade.h:79
+#: ../data/prefs.glade.h:80
 msgid "<b>Effects</b>"
 msgstr "<b>Efektler</b>"
 
-#: ../data/prefs.glade.h:80
+#: ../data/prefs.glade.h:81
 msgid "Transparency:"
 msgstr "Şeffaflık:"
 
-#: ../data/prefs.glade.h:81
+#: ../data/prefs.glade.h:82
 msgid "Background image:"
 msgstr "Arkaplan resmi:"
 
-#: ../data/prefs.glade.h:82
+#: ../data/prefs.glade.h:83 ../src/guake/prefs.py:130
 msgid "Appearance"
 msgstr "Görünüm"
 
-#: ../data/prefs.glade.h:83
+#: ../data/prefs.glade.h:84
 msgid ""
 "<small>Quick open is a feature allowing you to open a file directly into "
 "your favorite text editor by clicking on its filename when it appears in "
@@ -467,15 +471,15 @@ msgid ""
 "extract filename below.</small>"
 msgstr ""
 
-#: ../data/prefs.glade.h:84
+#: ../data/prefs.glade.h:85
 msgid "Enable Quick Open when Ctrl+clicking on a filename in the terminal"
 msgstr ""
 
-#: ../data/prefs.glade.h:85
+#: ../data/prefs.glade.h:86
 msgid "Editor command line:"
 msgstr ""
 
-#: ../data/prefs.glade.h:87
+#: ../data/prefs.glade.h:88
 #, no-c-format
 msgid ""
 "<small><i>Use the following elements in the open editor command line:\n"
@@ -487,36 +491,36 @@ msgid ""
 "</i></small>"
 msgstr ""
 
-#: ../data/prefs.glade.h:93
+#: ../data/prefs.glade.h:94
 msgid "Quick open in current terminal"
 msgstr ""
 
-#: ../data/prefs.glade.h:94
+#: ../data/prefs.glade.h:95
 msgid ""
 "Here is the list of supported patterns: (to add your own, please contact the "
 "Guake's authors)"
 msgstr ""
 
-#: ../data/prefs.glade.h:95
+#: ../data/prefs.glade.h:96
 #, fuzzy
 msgid "<b>Quick Open</b>"
 msgstr "<b>Palet</b>"
 
-#: ../data/prefs.glade.h:96
+#: ../data/prefs.glade.h:97
 msgid "Quick Open"
 msgstr ""
 
-#: ../data/prefs.glade.h:97
+#: ../data/prefs.glade.h:98
 msgid ""
 "To change a shortcut simply click on its name.\n"
 "To disable a shortcut, press the \"Backspace\" key."
 msgstr ""
 
-#: ../data/prefs.glade.h:99
+#: ../data/prefs.glade.h:100
 msgid "Keyboard shortcuts"
 msgstr "Klavye kısayolları"
 
-#: ../data/prefs.glade.h:100
+#: ../data/prefs.glade.h:101
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -527,7 +531,7 @@ msgstr ""
 "sebep olabilir. Bu ayarlar sadece farklı uçbirim davranışları bekleyen "
 "programlar ve işletim sistemleri için vardır.</i></small>"
 
-#: ../data/prefs.glade.h:101
+#: ../data/prefs.glade.h:102
 msgid ""
 "ASCII DEL\n"
 "Escape sequence\n"
@@ -537,38 +541,37 @@ msgstr ""
 "Esc dizisi\n"
 "Ctrl-H"
 
-#: ../data/prefs.glade.h:104
+#: ../data/prefs.glade.h:105
 msgid "_Backspace key generates:"
 msgstr "_Backspace tuşu yerine:"
 
-#: ../data/prefs.glade.h:105
+#: ../data/prefs.glade.h:106
 msgid "_Delete key generates:"
 msgstr "_Delete tuşu yerine:"
 
-#: ../data/prefs.glade.h:106
+#: ../data/prefs.glade.h:107
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "Uyumluluk aya_rlarını varsayılan hale getir"
 
-#: ../data/prefs.glade.h:107
+#: ../data/prefs.glade.h:108
 msgid "<b>Keyboard compatibility</b>"
 msgstr "<b>Klavye uyumluluğu</b>"
 
-#: ../data/prefs.glade.h:108
+#: ../data/prefs.glade.h:109
 msgid "Compatibility"
 msgstr "Uyumluluk"
 
-#: ../src/guake/about.py:47 ../src/guake/gconfhandler.py:427
-#: ../src/guake/guake_app.py:177 ../src/guake/guake_app.py:348
+#: ../src/guake/about.py:47 ../src/guake/gconfhandler.py:435
+#: ../src/guake/guake_app.py:181 ../src/guake/guake_app.py:376
 msgid "Guake Terminal"
 msgstr "Guake Uçbirim"
 
-#. Adding a new radio button to the tabbar
-#: ../src/guake/gconfhandler.py:365 ../src/guake/guake_app.py:1548
+#: ../src/guake/gconfhandler.py:368 ../src/guake/guake_app.py:1363
 #, fuzzy
 msgid "Terminal"
 msgstr "Uçbirim %s"
 
-#: ../src/guake/gconfhandler.py:428
+#: ../src/guake/gconfhandler.py:436
 #, python-format
 msgid ""
 "A problem happened when binding <b>%s</b> key.\n"
@@ -578,54 +581,54 @@ msgstr ""
 "Lütfen Guake Seçenekler penceresini kullanarak yeni bir kısayol seçin. "
 "(Simge sistem çekmecesindedir)"
 
-#: ../src/guake/guake_app.py:128
+#: ../src/guake/guake_app.py:132
 #, fuzzy
 msgid "Do you want to close the tab?"
 msgstr "Guake'den çıkmak istediğinize emin misiniz?"
 
-#: ../src/guake/guake_app.py:131
+#: ../src/guake/guake_app.py:135
 #, fuzzy
 msgid "Do you really want to quit Guake?"
 msgstr "Guake'den çıkmak istediğinize emin misiniz?"
 
-#: ../src/guake/guake_app.py:133
+#: ../src/guake/guake_app.py:137
 #, fuzzy
 msgid " and one tab open"
 msgstr "Yeni sekme ekle"
 
-#: ../src/guake/guake_app.py:135
+#: ../src/guake/guake_app.py:139
 #, python-brace-format
 msgid " and {0} tabs open"
 msgstr ""
 
-#: ../src/guake/guake_app.py:138
+#: ../src/guake/guake_app.py:142
 #, fuzzy
 msgid "There are no processes running"
 msgstr "<b>Halen çalışan bir işlem var.</b>"
 
-#: ../src/guake/guake_app.py:140
+#: ../src/guake/guake_app.py:144
 #, fuzzy
 msgid "There is a process still running"
 msgstr "<b>Halen çalışan bir işlem var.</b>"
 
-#: ../src/guake/guake_app.py:142
+#: ../src/guake/guake_app.py:146
 #, fuzzy, python-brace-format
 msgid "There are {0} processes still running"
 msgstr "<b>Çalışan %d işlem var.</b>"
 
-#: ../src/guake/guake_app.py:182
+#: ../src/guake/guake_app.py:186
 msgid "guake-indicator"
 msgstr ""
 
-#: ../src/guake/guake_app.py:182
+#: ../src/guake/guake_app.py:186
 msgid "guake-tray"
 msgstr ""
 
-#: ../src/guake/guake_app.py:186
+#: ../src/guake/guake_app.py:190
 msgid "Show"
 msgstr ""
 
-#: ../src/guake/guake_app.py:349
+#: ../src/guake/guake_app.py:377
 #, python-format
 msgid ""
 "Guake is now running,\n"
@@ -634,129 +637,133 @@ msgstr ""
 "Guake çalışıyor.\n"
 "<b>%s</b> tuşu ile kullanmaya başlayın."
 
-#: ../src/guake/guake_app.py:611
+#: ../src/guake/guake_app.py:665
 #, python-format
 msgid "Search on Web: '%s'"
 msgstr ""
 
-#: ../src/guake/guake_app.py:616
+#: ../src/guake/guake_app.py:670
 msgid "Search on Web (no selection)"
 msgstr ""
 
-#: ../src/guake/guake_app.py:622
+#: ../src/guake/guake_app.py:678
+msgid "Open Link: '{}...'"
+msgstr ""
+
+#: ../src/guake/guake_app.py:680
 msgid "Open Link: {}"
 msgstr ""
 
-#: ../src/guake/guake_app.py:625
+#: ../src/guake/guake_app.py:683
 msgid "Open Link..."
 msgstr ""
 
-#: ../src/guake/guake_app.py:1300
+#: ../src/guake/guake_app.py:1402
 msgid "Rename tab"
 msgstr "Sekmeyi yeniden adlandır"
 
-#: ../src/guake/guake_app.py:1591
+#: ../src/guake/guake_app.py:1716
 msgid "Save to..."
 msgstr ""
 
-#: ../src/guake/guake_app.py:1598 ../src/guake/prefs.py:930
+#: ../src/guake/guake_app.py:1723 ../src/guake/prefs.py:998
 msgid "All files"
 msgstr ""
 
-#: ../src/guake/guake_app.py:1603
+#: ../src/guake/guake_app.py:1728
 msgid "Text and Logs"
 msgstr ""
 
-#: ../src/guake/guake_app.py:1621
+#: ../src/guake/guake_app.py:1746
 msgid "Find"
 msgstr ""
 
-#: ../src/guake/guake_app.py:1623
+#: ../src/guake/guake_app.py:1748
 msgid "Forward"
 msgstr ""
 
-#: ../src/guake/guake_app.py:1624
+#: ../src/guake/guake_app.py:1749
 msgid "Backward"
 msgstr ""
 
-#: ../src/guake/main.py:67
+#: ../src/guake/main.py:68
 msgid "Put Guake in fullscreen mode"
 msgstr ""
 
-#: ../src/guake/main.py:71
+#: ../src/guake/main.py:72
 msgid "Toggles the visibility of the terminal window"
 msgstr "Uçbirim penceresinin görüntüler veya gizler"
 
-#: ../src/guake/main.py:75
+#: ../src/guake/main.py:76
 #, fuzzy
 msgid "Shows Guake main window"
 msgstr "Guake seçenekler penceresini gösterir"
 
-#: ../src/guake/main.py:79
+#: ../src/guake/main.py:80
 #, fuzzy
 msgid "Hides Guake main window"
 msgstr "Guake seçenekler penceresini gösterir"
 
-#: ../src/guake/main.py:83
+#: ../src/guake/main.py:84
 msgid "Shows Guake preference window"
 msgstr "Guake seçenekler penceresini gösterir"
 
-#: ../src/guake/main.py:87
+#: ../src/guake/main.py:88
 msgid "Shows Guake's about info"
 msgstr "Guake'nin hakkında bilgisini gösterir"
 
-#: ../src/guake/main.py:91
+#: ../src/guake/main.py:92
 #, fuzzy
 msgid "Add a new tab (with current directory set to NEW_TAB)"
 msgstr "_Yeni sekmeyi klasörde aç"
 
-#: ../src/guake/main.py:95
+#: ../src/guake/main.py:96
 msgid "Select a tab (SELECT_TAB is the index of the tab)"
 msgstr ""
 
-#: ../src/guake/main.py:99
+#: ../src/guake/main.py:100
 msgid "Return the selected tab index."
 msgstr "Seçilmiş sekme sıra numarasını döndürür."
 
-#: ../src/guake/main.py:103
+#: ../src/guake/main.py:104
 msgid "Execute an arbitrary command in the selected tab."
 msgstr "Seçili sekmede sınırsız komut çalıştırır."
 
-#: ../src/guake/main.py:107
+#: ../src/guake/main.py:108
 msgid "Specify the tab to rename. Default is 0."
 msgstr ""
 
-#: ../src/guake/main.py:111
+#: ../src/guake/main.py:112
 msgid "Set the hexadecimal (#rrggbb) background color of the selected tab."
 msgstr ""
 
-#: ../src/guake/main.py:116
+#: ../src/guake/main.py:117
 msgid "Set the hexadecimal (#rrggbb) foreground color of the selected tab."
 msgstr ""
 
-#: ../src/guake/main.py:122
+#: ../src/guake/main.py:123
 msgid ""
 "Rename the specified tab. Reset to default if TITLE is a single dash \"-\"."
 msgstr ""
 
-#: ../src/guake/main.py:128
+#: ../src/guake/main.py:129
 msgid ""
 "Rename the current tab. Reset to default if TITLE is a single dash \"-\"."
 msgstr ""
 
-#: ../src/guake/main.py:133
+#: ../src/guake/main.py:134
 msgid "Says to Guake go away =("
 msgstr "Guake'e güle güle der =("
 
-#: ../src/guake/main.py:137
+#: ../src/guake/main.py:138
 msgid "Do not execute the start up script"
 msgstr ""
 
-#: ../src/guake/main.py:231
+#: ../src/guake/main.py:235
 msgid "Guake can not init!"
 msgstr "Guake başlatılamadı!"
 
-#: ../src/guake/main.py:232
+#: ../src/guake/main.py:236
 #, fuzzy
 msgid ""
 "Gconf Error.\n"
@@ -770,32 +777,190 @@ msgstr ""
 msgid "<user shell>"
 msgstr "<kullanıcı kabuğu>"
 
-#: ../src/guake/prefs.py:467
+#: ../src/guake/prefs.py:77
+msgid "Toggle Guake visibility"
+msgstr "Guake'i görüntüle veya gizle"
+
+#: ../src/guake/prefs.py:81
+#, fuzzy
+msgid "Toggle Hide on Lose Focus"
+msgstr "Focus kaybedildiğinde gizle"
+
+#: ../src/guake/prefs.py:88
+msgid "Tab management"
+msgstr "Sekme yönetimi"
+
+#: ../src/guake/prefs.py:90
+#, fuzzy
+msgid "New tab"
+msgstr "Yeni sekme"
+
+#: ../src/guake/prefs.py:92
+msgid "Close tab"
+msgstr "Sekmeyi kapat"
+
+#: ../src/guake/prefs.py:94
+msgid "Rename current tab"
+msgstr "Geçerli sekmeyi yeniden adlandır"
+
+#: ../src/guake/prefs.py:97
+msgid "Navigation"
+msgstr "Gezinti"
+
+#: ../src/guake/prefs.py:99
+msgid "Go to previous tab"
+msgstr "Önceki sekmeye geç"
+
+#: ../src/guake/prefs.py:101
+msgid "Go to next tab"
+msgstr "Sonraki sekmeye geç"
+
+#: ../src/guake/prefs.py:103
+#, fuzzy
+msgid "Move current tab left"
+msgstr "Geçerli sekmeyi yeniden adlandır"
+
+#: ../src/guake/prefs.py:105
+#, fuzzy
+msgid "Move current tab right"
+msgstr "Geçerli sekmeyi yeniden adlandır"
+
+#: ../src/guake/prefs.py:107
+#, fuzzy
+msgid "Go to first tab"
+msgstr "Sonraki sekmeye geç"
+
+#: ../src/guake/prefs.py:109
+#, fuzzy
+msgid "Go to second tab"
+msgstr "Sonraki sekmeye geç"
+
+#: ../src/guake/prefs.py:111
+#, fuzzy
+msgid "Go to third tab"
+msgstr "Sonraki sekmeye geç"
+
+#: ../src/guake/prefs.py:113
+#, fuzzy
+msgid "Go to fourth tab"
+msgstr "Sonraki sekmeye geç"
+
+#: ../src/guake/prefs.py:115
+#, fuzzy
+msgid "Go to fifth tab"
+msgstr "Sonraki sekmeye geç"
+
+#: ../src/guake/prefs.py:117
+#, fuzzy
+msgid "Go to sixth tab"
+msgstr "Sonraki sekmeye geç"
+
+#: ../src/guake/prefs.py:119
+#, fuzzy
+msgid "Go to seventh tab"
+msgstr "Sonraki sekmeye geç"
+
+#: ../src/guake/prefs.py:121
+#, fuzzy
+msgid "Go to eighth tab"
+msgstr "Sonraki sekmeye geç"
+
+#: ../src/guake/prefs.py:123
+#, fuzzy
+msgid "Go to ninth tab"
+msgstr "Sonraki sekmeye geç"
+
+#: ../src/guake/prefs.py:125
+#, fuzzy
+msgid "Go to tenth tab"
+msgstr "Sonraki sekmeye geç"
+
+#: ../src/guake/prefs.py:127
+#, fuzzy
+msgid "Go to last tab"
+msgstr "Sonraki sekmeye geç"
+
+#: ../src/guake/prefs.py:132
+msgid "Zoom out"
+msgstr ""
+
+#: ../src/guake/prefs.py:134
+msgid "Zoom in"
+msgstr ""
+
+#: ../src/guake/prefs.py:136
+msgid "Zoom in (alternative)"
+msgstr ""
+
+#: ../src/guake/prefs.py:138
+msgid "Increase height"
+msgstr ""
+
+#: ../src/guake/prefs.py:140
+msgid "Decrease height"
+msgstr ""
+
+#: ../src/guake/prefs.py:142
+#, fuzzy
+msgid "Increase transparency"
+msgstr "Şeffaflık:"
+
+#: ../src/guake/prefs.py:144
+#, fuzzy
+msgid "Decrease transparency"
+msgstr "Şeffaflık:"
+
+#: ../src/guake/prefs.py:146
+#, fuzzy
+msgid "Toggle transparency"
+msgstr "Şeffaflık:"
+
+#: ../src/guake/prefs.py:149
+msgid "Clipboard"
+msgstr "Pano"
+
+#: ../src/guake/prefs.py:151
+msgid "Copy text to clipboard"
+msgstr "Metni panoya kopyala"
+
+#: ../src/guake/prefs.py:153
+msgid "Paste text from clipboard"
+msgstr "Panodan metni yapıştır"
+
+#: ../src/guake/prefs.py:156
+msgid "Extra features"
+msgstr ""
+
+#: ../src/guake/prefs.py:159
+msgid "Search select text on web"
+msgstr ""
+
+#: ../src/guake/prefs.py:519
 msgid "Action"
 msgstr "İşlev"
 
-#: ../src/guake/prefs.py:477
+#: ../src/guake/prefs.py:529
 msgid "Shortcut"
 msgstr "Kısayol"
 
-#: ../src/guake/prefs.py:619 ../src/guake/prefs.py:665
+#: ../src/guake/prefs.py:678 ../src/guake/prefs.py:724
 msgid "Custom"
 msgstr ""
 
-#: ../src/guake/prefs.py:926
+#: ../src/guake/prefs.py:994
 msgid "JSON files"
 msgstr ""
 
-#: ../src/guake/prefs.py:1019
+#: ../src/guake/prefs.py:1088
 #, python-format
 msgid "The shortcut \"%s\" is already in use."
 msgstr "\"%s\" kısayolu zaten kullanılıyor."
 
-#: ../src/guake/prefs.py:1020
+#: ../src/guake/prefs.py:1089
 msgid "Error setting keybinding."
 msgstr "Kısayol atamasında hata."
 
-#: ../src/guake/prefs.py:1032
+#: ../src/guake/prefs.py:1101
 #, python-format
 msgid ""
 "The shortcut \"%s\" cannot be used because it will become impossible to type "
@@ -835,33 +1000,3 @@ msgstr ""
 
 #~ msgid "Rename the selected tab."
 #~ msgstr "Seçilen sekmeyi yeniden adlandırır."
-
-#~ msgid "Toggle Guake visibility"
-#~ msgstr "Guake'i görüntüle veya gizle"
-
-#~ msgid "Tab management"
-#~ msgstr "Sekme yönetimi"
-
-#~ msgid "Close tab"
-#~ msgstr "Sekmeyi kapat"
-
-#~ msgid "Rename current tab"
-#~ msgstr "Geçerli sekmeyi yeniden adlandır"
-
-#~ msgid "Navigation"
-#~ msgstr "Gezinti"
-
-#~ msgid "Go to previous tab"
-#~ msgstr "Önceki sekmeye geç"
-
-#~ msgid "Go to next tab"
-#~ msgstr "Sonraki sekmeye geç"
-
-#~ msgid "Clipboard"
-#~ msgstr "Pano"
-
-#~ msgid "Copy text to clipboard"
-#~ msgstr "Metni panoya kopyala"
-
-#~ msgid "Paste text from clipboard"
-#~ msgstr "Panodan metni yapıştır"

--- a/po/uk.po
+++ b/po/uk.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Guake 0.4.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-12-01 16:49+0100\n"
+"POT-Creation-Date: 2016-08-17 21:41+0000\n"
 "PO-Revision-Date: 2011-09-22 10:04+0000\n"
 "Last-Translator: Сергій Дубик <dubyk@ukr.net>\n"
 "Language-Team: Ukrainian (Ukraine) (http://www.transifex.com/projects/p/"
@@ -106,7 +106,7 @@ msgstr "Копіювати"
 msgid "Paste"
 msgstr "Вставити"
 
-#: ../data/guake.glade.h:3
+#: ../data/guake.glade.h:3 ../src/guake/prefs.py:79
 msgid "Toggle Fullscreen"
 msgstr "Перемикання повноекранного режиму"
 
@@ -114,7 +114,7 @@ msgstr "Перемикання повноекранного режиму"
 msgid "Save to File..."
 msgstr ""
 
-#: ../data/guake.glade.h:5
+#: ../data/guake.glade.h:5 ../src/guake/prefs.py:85
 #, fuzzy
 msgid "Reset terminal"
 msgstr "Термінал Guake"
@@ -145,7 +145,7 @@ msgstr ""
 msgid "Search on Web"
 msgstr ""
 
-#: ../data/guake.glade.h:12
+#: ../data/guake.glade.h:12 ../src/guake/prefs.py:83
 msgid "Quit"
 msgstr "Вийти"
 
@@ -268,202 +268,206 @@ msgid "Use VTE titles for tab names"
 msgstr ""
 
 #: ../data/prefs.glade.h:33
-msgid "Max tab name length:"
+msgid "Abbreviate directories in tab names"
 msgstr ""
 
 #: ../data/prefs.glade.h:34
+msgid "Max tab name length:"
+msgstr ""
+
+#: ../data/prefs.glade.h:35
 msgid "Hide on lose focus"
 msgstr "Ховатися при втраті фокусу"
 
-#: ../data/prefs.glade.h:35
+#: ../data/prefs.glade.h:36
 msgid "Show tab bar"
 msgstr "Показувати панель вкладок"
 
-#: ../data/prefs.glade.h:36
+#: ../data/prefs.glade.h:37
 #, fuzzy
 msgid "Start fullscreen"
 msgstr "Перемикання повноекранного режиму"
 
-#: ../data/prefs.glade.h:37
+#: ../data/prefs.glade.h:38
 msgid "<b>Main Window</b>"
 msgstr "<b>Головне вікно</b>"
 
-#: ../data/prefs.glade.h:38
+#: ../data/prefs.glade.h:39
 msgid "Left"
 msgstr ""
 
-#: ../data/prefs.glade.h:39
+#: ../data/prefs.glade.h:40
 msgid "Center"
 msgstr ""
 
-#: ../data/prefs.glade.h:40
+#: ../data/prefs.glade.h:41
 msgid "Right"
 msgstr ""
 
-#: ../data/prefs.glade.h:41
+#: ../data/prefs.glade.h:42
 #, fuzzy
 msgid "<b>Main Window Horizontal Alignment</b>"
 msgstr "<b>Висота головного вікна</b>"
 
-#: ../data/prefs.glade.h:42
+#: ../data/prefs.glade.h:43
 #, fuzzy
 msgid "<b>Main Window Height</b>"
 msgstr "<b>Висота головного вікна</b>"
 
-#: ../data/prefs.glade.h:43
+#: ../data/prefs.glade.h:44
 #, fuzzy
 msgid "<b>Main Window Width</b>"
 msgstr "<b>Висота головного вікна</b>"
 
-#: ../data/prefs.glade.h:44
+#: ../data/prefs.glade.h:45
 msgid "Custom command file path: "
 msgstr ""
 
-#: ../data/prefs.glade.h:45
+#: ../data/prefs.glade.h:46
 msgid "Please select a json file"
 msgstr ""
 
-#: ../data/prefs.glade.h:46
+#: ../data/prefs.glade.h:47 ../src/guake/prefs.py:75
 msgid "General"
 msgstr "Загальне"
 
-#: ../data/prefs.glade.h:47
+#: ../data/prefs.glade.h:48
 msgid "Default interpreter:"
 msgstr "Типовий інтерпретатор:"
 
-#: ../data/prefs.glade.h:48
+#: ../data/prefs.glade.h:49
 msgid "_Run command as a login shell"
 msgstr "_Запускати команду як оболонку входу"
 
-#: ../data/prefs.glade.h:49
+#: ../data/prefs.glade.h:50
 msgid "_Open new tab in current directory"
 msgstr "_Нові вкладки відкриваються в тій же теці"
 
-#: ../data/prefs.glade.h:50
+#: ../data/prefs.glade.h:51
 msgid "<b>Shell</b>"
 msgstr "<b>Оболонка</b>"
 
-#: ../data/prefs.glade.h:51
+#: ../data/prefs.glade.h:52
 msgid "Shell"
 msgstr ""
 
-#: ../data/prefs.glade.h:52
+#: ../data/prefs.glade.h:53
 msgid "Show scrollbar"
 msgstr "Показувати смужку прокрутки"
 
-#: ../data/prefs.glade.h:53
+#: ../data/prefs.glade.h:54
 msgid "Scrollback lines:"
 msgstr "Рядків в історії прокручування:"
 
-#: ../data/prefs.glade.h:54
+#: ../data/prefs.glade.h:55
 msgid "On output"
 msgstr "При текстовому виводі"
 
-#: ../data/prefs.glade.h:55
+#: ../data/prefs.glade.h:56
 msgid "On key stroke"
 msgstr "При натисненнях клавіш"
 
-#: ../data/prefs.glade.h:56
+#: ../data/prefs.glade.h:57
 msgid "<b>Scroll</b>"
 msgstr "<b>Прокручувати</b>"
 
-#: ../data/prefs.glade.h:57
+#: ../data/prefs.glade.h:58
 msgid "Scrolling"
 msgstr "Прокручування"
 
-#: ../data/prefs.glade.h:58
+#: ../data/prefs.glade.h:59
 msgid "Use the system fixed width font"
 msgstr "Використовувати системний моноширинний шрифт"
 
-#: ../data/prefs.glade.h:59
+#: ../data/prefs.glade.h:60
 msgid "Font:"
 msgstr "Шрифт:"
 
-#: ../data/prefs.glade.h:60
+#: ../data/prefs.glade.h:61
 msgid "Choose some font"
 msgstr "Виберіть шрифт"
 
-#: ../data/prefs.glade.h:61
+#: ../data/prefs.glade.h:62
 msgid "Text color:"
 msgstr "Колір тексту:"
 
-#: ../data/prefs.glade.h:62
+#: ../data/prefs.glade.h:63
 msgid "Background color:"
 msgstr "Колір тла:"
 
-#: ../data/prefs.glade.h:63
+#: ../data/prefs.glade.h:64
 msgid "Cursor shape:"
 msgstr ""
 
-#: ../data/prefs.glade.h:64
+#: ../data/prefs.glade.h:65
 msgid ""
 "Block\n"
 "I-Beam\n"
 "Underline"
 msgstr ""
 
-#: ../data/prefs.glade.h:67
+#: ../data/prefs.glade.h:68
 msgid ""
 "Follow GTK+ setting\n"
 "Blink on\n"
 "Blink off"
 msgstr ""
 
-#: ../data/prefs.glade.h:70
+#: ../data/prefs.glade.h:71
 msgid "Cursor blink mode:"
 msgstr ""
 
-#: ../data/prefs.glade.h:71
+#: ../data/prefs.glade.h:72
 msgid "Allow bold font"
 msgstr ""
 
-#: ../data/prefs.glade.h:72
+#: ../data/prefs.glade.h:73
 msgid "<b>Palette</b>"
 msgstr "<b>Палітра</b>"
 
-#: ../data/prefs.glade.h:73
+#: ../data/prefs.glade.h:74
 msgid "Built-in schemes:"
 msgstr "Вбудовані схеми:"
 
-#: ../data/prefs.glade.h:74
+#: ../data/prefs.glade.h:75
 msgid "Color palette:"
 msgstr "Палітра:"
 
-#: ../data/prefs.glade.h:75
+#: ../data/prefs.glade.h:76
 #, fuzzy
 msgid "Font color"
 msgstr "Колір тексту:"
 
-#: ../data/prefs.glade.h:76
+#: ../data/prefs.glade.h:77
 #, fuzzy
 msgid "Background color"
 msgstr "Колір тла:"
 
-#: ../data/prefs.glade.h:77
+#: ../data/prefs.glade.h:78
 msgid "Use font and background color from the palette"
 msgstr ""
 
-#: ../data/prefs.glade.h:78
+#: ../data/prefs.glade.h:79
 msgid "Demo:"
 msgstr ""
 
-#: ../data/prefs.glade.h:79
+#: ../data/prefs.glade.h:80
 msgid "<b>Effects</b>"
 msgstr "<b>Ефекти</b>"
 
-#: ../data/prefs.glade.h:80
+#: ../data/prefs.glade.h:81
 msgid "Transparency:"
 msgstr "Прозорість:"
 
-#: ../data/prefs.glade.h:81
+#: ../data/prefs.glade.h:82
 msgid "Background image:"
 msgstr "Фонове зображення:"
 
-#: ../data/prefs.glade.h:82
+#: ../data/prefs.glade.h:83 ../src/guake/prefs.py:130
 msgid "Appearance"
 msgstr "Зовнішній вигляд"
 
-#: ../data/prefs.glade.h:83
+#: ../data/prefs.glade.h:84
 msgid ""
 "<small>Quick open is a feature allowing you to open a file directly into "
 "your favorite text editor by clicking on its filename when it appears in "
@@ -471,15 +475,15 @@ msgid ""
 "extract filename below.</small>"
 msgstr ""
 
-#: ../data/prefs.glade.h:84
+#: ../data/prefs.glade.h:85
 msgid "Enable Quick Open when Ctrl+clicking on a filename in the terminal"
 msgstr ""
 
-#: ../data/prefs.glade.h:85
+#: ../data/prefs.glade.h:86
 msgid "Editor command line:"
 msgstr ""
 
-#: ../data/prefs.glade.h:87
+#: ../data/prefs.glade.h:88
 #, no-c-format
 msgid ""
 "<small><i>Use the following elements in the open editor command line:\n"
@@ -491,36 +495,36 @@ msgid ""
 "</i></small>"
 msgstr ""
 
-#: ../data/prefs.glade.h:93
+#: ../data/prefs.glade.h:94
 msgid "Quick open in current terminal"
 msgstr ""
 
-#: ../data/prefs.glade.h:94
+#: ../data/prefs.glade.h:95
 msgid ""
 "Here is the list of supported patterns: (to add your own, please contact the "
 "Guake's authors)"
 msgstr ""
 
-#: ../data/prefs.glade.h:95
+#: ../data/prefs.glade.h:96
 #, fuzzy
 msgid "<b>Quick Open</b>"
 msgstr "<b>Палітра</b>"
 
-#: ../data/prefs.glade.h:96
+#: ../data/prefs.glade.h:97
 msgid "Quick Open"
 msgstr ""
 
-#: ../data/prefs.glade.h:97
+#: ../data/prefs.glade.h:98
 msgid ""
 "To change a shortcut simply click on its name.\n"
 "To disable a shortcut, press the \"Backspace\" key."
 msgstr ""
 
-#: ../data/prefs.glade.h:99
+#: ../data/prefs.glade.h:100
 msgid "Keyboard shortcuts"
 msgstr "Комбінації клавіш"
 
-#: ../data/prefs.glade.h:100
+#: ../data/prefs.glade.h:101
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -531,7 +535,7 @@ msgstr ""
 "певних програм. Вони тут лише для того, щоб ви могли підлаштувати поведінку "
 "термінала під певні програми та операційні системи.</i></small>"
 
-#: ../data/prefs.glade.h:101
+#: ../data/prefs.glade.h:102
 msgid ""
 "ASCII DEL\n"
 "Escape sequence\n"
@@ -541,38 +545,37 @@ msgstr ""
 "Керуюча послідовність\n"
 "Control-H"
 
-#: ../data/prefs.glade.h:104
+#: ../data/prefs.glade.h:105
 msgid "_Backspace key generates:"
 msgstr "_Клавіша Backspace генерує:"
 
-#: ../data/prefs.glade.h:105
+#: ../data/prefs.glade.h:106
 msgid "_Delete key generates:"
 msgstr "К_лавіша Delete генерує:"
 
-#: ../data/prefs.glade.h:106
+#: ../data/prefs.glade.h:107
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "_Скинути опції сумісності на типові"
 
-#: ../data/prefs.glade.h:107
+#: ../data/prefs.glade.h:108
 msgid "<b>Keyboard compatibility</b>"
 msgstr "<b>Сумісність клавіатури</b>"
 
-#: ../data/prefs.glade.h:108
+#: ../data/prefs.glade.h:109
 msgid "Compatibility"
 msgstr "Сумісність"
 
-#: ../src/guake/about.py:47 ../src/guake/gconfhandler.py:427
-#: ../src/guake/guake_app.py:177 ../src/guake/guake_app.py:348
+#: ../src/guake/about.py:47 ../src/guake/gconfhandler.py:435
+#: ../src/guake/guake_app.py:181 ../src/guake/guake_app.py:376
 msgid "Guake Terminal"
 msgstr "Термінал Guake"
 
-#. Adding a new radio button to the tabbar
-#: ../src/guake/gconfhandler.py:365 ../src/guake/guake_app.py:1548
+#: ../src/guake/gconfhandler.py:368 ../src/guake/guake_app.py:1363
 #, fuzzy
 msgid "Terminal"
 msgstr "Термінал %s"
 
-#: ../src/guake/gconfhandler.py:428
+#: ../src/guake/gconfhandler.py:436
 #, python-format
 msgid ""
 "A problem happened when binding <b>%s</b> key.\n"
@@ -582,54 +585,54 @@ msgstr ""
 "Будь ласка, скористайтесь діалогом налаштувань, щоб вибрати іншу гарячу "
 "клавішу (значок у таці був задіяний)."
 
-#: ../src/guake/guake_app.py:128
+#: ../src/guake/guake_app.py:132
 #, fuzzy
 msgid "Do you want to close the tab?"
 msgstr "Ви дійсно хочете вийти з Guake!?"
 
-#: ../src/guake/guake_app.py:131
+#: ../src/guake/guake_app.py:135
 #, fuzzy
 msgid "Do you really want to quit Guake?"
 msgstr "Ви дійсно хочете вийти з Guake!?"
 
-#: ../src/guake/guake_app.py:133
+#: ../src/guake/guake_app.py:137
 #, fuzzy
 msgid " and one tab open"
 msgstr "Додати вкладку"
 
-#: ../src/guake/guake_app.py:135
+#: ../src/guake/guake_app.py:139
 #, python-brace-format
 msgid " and {0} tabs open"
 msgstr ""
 
-#: ../src/guake/guake_app.py:138
+#: ../src/guake/guake_app.py:142
 #, fuzzy
 msgid "There are no processes running"
 msgstr "<b>Один процес досі виконується.</b>"
 
-#: ../src/guake/guake_app.py:140
+#: ../src/guake/guake_app.py:144
 #, fuzzy
 msgid "There is a process still running"
 msgstr "<b>Один процес досі виконується.</b>"
 
-#: ../src/guake/guake_app.py:142
+#: ../src/guake/guake_app.py:146
 #, fuzzy, python-brace-format
 msgid "There are {0} processes still running"
 msgstr "<b>%d процеси(ів) досі виконуються.</b>"
 
-#: ../src/guake/guake_app.py:182
+#: ../src/guake/guake_app.py:186
 msgid "guake-indicator"
 msgstr ""
 
-#: ../src/guake/guake_app.py:182
+#: ../src/guake/guake_app.py:186
 msgid "guake-tray"
 msgstr ""
 
-#: ../src/guake/guake_app.py:186
+#: ../src/guake/guake_app.py:190
 msgid "Show"
 msgstr ""
 
-#: ../src/guake/guake_app.py:349
+#: ../src/guake/guake_app.py:377
 #, python-format
 msgid ""
 "Guake is now running,\n"
@@ -638,129 +641,133 @@ msgstr ""
 "Guake запущено,\n"
 "натискайте <b>%s</b> для його виклику."
 
-#: ../src/guake/guake_app.py:611
+#: ../src/guake/guake_app.py:665
 #, python-format
 msgid "Search on Web: '%s'"
 msgstr ""
 
-#: ../src/guake/guake_app.py:616
+#: ../src/guake/guake_app.py:670
 msgid "Search on Web (no selection)"
 msgstr ""
 
-#: ../src/guake/guake_app.py:622
+#: ../src/guake/guake_app.py:678
+msgid "Open Link: '{}...'"
+msgstr ""
+
+#: ../src/guake/guake_app.py:680
 msgid "Open Link: {}"
 msgstr ""
 
-#: ../src/guake/guake_app.py:625
+#: ../src/guake/guake_app.py:683
 msgid "Open Link..."
 msgstr ""
 
-#: ../src/guake/guake_app.py:1300
+#: ../src/guake/guake_app.py:1402
 msgid "Rename tab"
 msgstr "Перейменувати вкладку"
 
-#: ../src/guake/guake_app.py:1591
+#: ../src/guake/guake_app.py:1716
 msgid "Save to..."
 msgstr ""
 
-#: ../src/guake/guake_app.py:1598 ../src/guake/prefs.py:930
+#: ../src/guake/guake_app.py:1723 ../src/guake/prefs.py:998
 msgid "All files"
 msgstr ""
 
-#: ../src/guake/guake_app.py:1603
+#: ../src/guake/guake_app.py:1728
 msgid "Text and Logs"
 msgstr ""
 
-#: ../src/guake/guake_app.py:1621
+#: ../src/guake/guake_app.py:1746
 msgid "Find"
 msgstr ""
 
-#: ../src/guake/guake_app.py:1623
+#: ../src/guake/guake_app.py:1748
 msgid "Forward"
 msgstr ""
 
-#: ../src/guake/guake_app.py:1624
+#: ../src/guake/guake_app.py:1749
 msgid "Backward"
 msgstr ""
 
-#: ../src/guake/main.py:67
+#: ../src/guake/main.py:68
 msgid "Put Guake in fullscreen mode"
 msgstr ""
 
-#: ../src/guake/main.py:71
+#: ../src/guake/main.py:72
 msgid "Toggles the visibility of the terminal window"
 msgstr "Перемикнути видимість головного вікна"
 
-#: ../src/guake/main.py:75
+#: ../src/guake/main.py:76
 #, fuzzy
 msgid "Shows Guake main window"
 msgstr "Показати вікно налаштувань Guake"
 
-#: ../src/guake/main.py:79
+#: ../src/guake/main.py:80
 #, fuzzy
 msgid "Hides Guake main window"
 msgstr "Показати вікно налаштувань Guake"
 
-#: ../src/guake/main.py:83
+#: ../src/guake/main.py:84
 msgid "Shows Guake preference window"
 msgstr "Показати вікно налаштувань Guake"
 
-#: ../src/guake/main.py:87
+#: ../src/guake/main.py:88
 msgid "Shows Guake's about info"
 msgstr "Показати «Про Guake»"
 
-#: ../src/guake/main.py:91
+#: ../src/guake/main.py:92
 #, fuzzy
 msgid "Add a new tab (with current directory set to NEW_TAB)"
 msgstr "_Нові вкладки відкриваються в тій же теці"
 
-#: ../src/guake/main.py:95
+#: ../src/guake/main.py:96
 msgid "Select a tab (SELECT_TAB is the index of the tab)"
 msgstr ""
 
-#: ../src/guake/main.py:99
+#: ../src/guake/main.py:100
 msgid "Return the selected tab index."
 msgstr "Повернути індекс вибраної вкладки."
 
-#: ../src/guake/main.py:103
+#: ../src/guake/main.py:104
 msgid "Execute an arbitrary command in the selected tab."
 msgstr "Виконати вказану команду у поточній вкладці."
 
-#: ../src/guake/main.py:107
+#: ../src/guake/main.py:108
 msgid "Specify the tab to rename. Default is 0."
 msgstr ""
 
-#: ../src/guake/main.py:111
+#: ../src/guake/main.py:112
 msgid "Set the hexadecimal (#rrggbb) background color of the selected tab."
 msgstr ""
 
-#: ../src/guake/main.py:116
+#: ../src/guake/main.py:117
 msgid "Set the hexadecimal (#rrggbb) foreground color of the selected tab."
 msgstr ""
 
-#: ../src/guake/main.py:122
+#: ../src/guake/main.py:123
 msgid ""
 "Rename the specified tab. Reset to default if TITLE is a single dash \"-\"."
 msgstr ""
 
-#: ../src/guake/main.py:128
+#: ../src/guake/main.py:129
 msgid ""
 "Rename the current tab. Reset to default if TITLE is a single dash \"-\"."
 msgstr ""
 
-#: ../src/guake/main.py:133
+#: ../src/guake/main.py:134
 msgid "Says to Guake go away =("
 msgstr "Наказує Guake зникнути =("
 
-#: ../src/guake/main.py:137
+#: ../src/guake/main.py:138
 msgid "Do not execute the start up script"
 msgstr ""
 
-#: ../src/guake/main.py:231
+#: ../src/guake/main.py:235
 msgid "Guake can not init!"
 msgstr "Guake не може ініціалізуватись!"
 
-#: ../src/guake/main.py:232
+#: ../src/guake/main.py:236
 #, fuzzy
 msgid ""
 "Gconf Error.\n"
@@ -774,32 +781,190 @@ msgstr ""
 msgid "<user shell>"
 msgstr "<оболонка користувача>"
 
-#: ../src/guake/prefs.py:467
+#: ../src/guake/prefs.py:77
+msgid "Toggle Guake visibility"
+msgstr "Показувати й ховати Guake"
+
+#: ../src/guake/prefs.py:81
+#, fuzzy
+msgid "Toggle Hide on Lose Focus"
+msgstr "Ховатися при втраті фокусу"
+
+#: ../src/guake/prefs.py:88
+msgid "Tab management"
+msgstr "Керування вкладками"
+
+#: ../src/guake/prefs.py:90
+#, fuzzy
+msgid "New tab"
+msgstr "Нова вкладка"
+
+#: ../src/guake/prefs.py:92
+msgid "Close tab"
+msgstr "Закрити вкладку"
+
+#: ../src/guake/prefs.py:94
+msgid "Rename current tab"
+msgstr "Перейменувати поточну вкладку"
+
+#: ../src/guake/prefs.py:97
+msgid "Navigation"
+msgstr "Навігація"
+
+#: ../src/guake/prefs.py:99
+msgid "Go to previous tab"
+msgstr "Перейти до попередньої вкладки"
+
+#: ../src/guake/prefs.py:101
+msgid "Go to next tab"
+msgstr "Перейти до наступної вкладки"
+
+#: ../src/guake/prefs.py:103
+#, fuzzy
+msgid "Move current tab left"
+msgstr "Перейменувати поточну вкладку"
+
+#: ../src/guake/prefs.py:105
+#, fuzzy
+msgid "Move current tab right"
+msgstr "Перейменувати поточну вкладку"
+
+#: ../src/guake/prefs.py:107
+#, fuzzy
+msgid "Go to first tab"
+msgstr "Перейти до наступної вкладки"
+
+#: ../src/guake/prefs.py:109
+#, fuzzy
+msgid "Go to second tab"
+msgstr "Перейти до наступної вкладки"
+
+#: ../src/guake/prefs.py:111
+#, fuzzy
+msgid "Go to third tab"
+msgstr "Перейти до наступної вкладки"
+
+#: ../src/guake/prefs.py:113
+#, fuzzy
+msgid "Go to fourth tab"
+msgstr "Перейти до наступної вкладки"
+
+#: ../src/guake/prefs.py:115
+#, fuzzy
+msgid "Go to fifth tab"
+msgstr "Перейти до наступної вкладки"
+
+#: ../src/guake/prefs.py:117
+#, fuzzy
+msgid "Go to sixth tab"
+msgstr "Перейти до наступної вкладки"
+
+#: ../src/guake/prefs.py:119
+#, fuzzy
+msgid "Go to seventh tab"
+msgstr "Перейти до наступної вкладки"
+
+#: ../src/guake/prefs.py:121
+#, fuzzy
+msgid "Go to eighth tab"
+msgstr "Перейти до наступної вкладки"
+
+#: ../src/guake/prefs.py:123
+#, fuzzy
+msgid "Go to ninth tab"
+msgstr "Перейти до наступної вкладки"
+
+#: ../src/guake/prefs.py:125
+#, fuzzy
+msgid "Go to tenth tab"
+msgstr "Перейти до наступної вкладки"
+
+#: ../src/guake/prefs.py:127
+#, fuzzy
+msgid "Go to last tab"
+msgstr "Перейти до наступної вкладки"
+
+#: ../src/guake/prefs.py:132
+msgid "Zoom out"
+msgstr ""
+
+#: ../src/guake/prefs.py:134
+msgid "Zoom in"
+msgstr ""
+
+#: ../src/guake/prefs.py:136
+msgid "Zoom in (alternative)"
+msgstr ""
+
+#: ../src/guake/prefs.py:138
+msgid "Increase height"
+msgstr ""
+
+#: ../src/guake/prefs.py:140
+msgid "Decrease height"
+msgstr ""
+
+#: ../src/guake/prefs.py:142
+#, fuzzy
+msgid "Increase transparency"
+msgstr "Прозорість:"
+
+#: ../src/guake/prefs.py:144
+#, fuzzy
+msgid "Decrease transparency"
+msgstr "Прозорість:"
+
+#: ../src/guake/prefs.py:146
+#, fuzzy
+msgid "Toggle transparency"
+msgstr "Прозорість:"
+
+#: ../src/guake/prefs.py:149
+msgid "Clipboard"
+msgstr "Буфер обміну"
+
+#: ../src/guake/prefs.py:151
+msgid "Copy text to clipboard"
+msgstr "Скопіювати текст до буфера обміну"
+
+#: ../src/guake/prefs.py:153
+msgid "Paste text from clipboard"
+msgstr "Вставити текст з буфера обміну"
+
+#: ../src/guake/prefs.py:156
+msgid "Extra features"
+msgstr ""
+
+#: ../src/guake/prefs.py:159
+msgid "Search select text on web"
+msgstr ""
+
+#: ../src/guake/prefs.py:519
 msgid "Action"
 msgstr "Дія"
 
-#: ../src/guake/prefs.py:477
+#: ../src/guake/prefs.py:529
 msgid "Shortcut"
 msgstr "Комбінація клавіш"
 
-#: ../src/guake/prefs.py:619 ../src/guake/prefs.py:665
+#: ../src/guake/prefs.py:678 ../src/guake/prefs.py:724
 msgid "Custom"
 msgstr ""
 
-#: ../src/guake/prefs.py:926
+#: ../src/guake/prefs.py:994
 msgid "JSON files"
 msgstr ""
 
-#: ../src/guake/prefs.py:1019
+#: ../src/guake/prefs.py:1088
 #, python-format
 msgid "The shortcut \"%s\" is already in use."
 msgstr "Комбінація „%s“ вже зайнята."
 
-#: ../src/guake/prefs.py:1020
+#: ../src/guake/prefs.py:1089
 msgid "Error setting keybinding."
 msgstr "Не вдалося створити прив’язку до клавіш."
 
-#: ../src/guake/prefs.py:1032
+#: ../src/guake/prefs.py:1101
 #, python-format
 msgid ""
 "The shortcut \"%s\" cannot be used because it will become impossible to type "
@@ -840,33 +1005,3 @@ msgstr ""
 
 #~ msgid "Rename the selected tab."
 #~ msgstr "Перейменувати вибрану вкладку."
-
-#~ msgid "Toggle Guake visibility"
-#~ msgstr "Показувати й ховати Guake"
-
-#~ msgid "Tab management"
-#~ msgstr "Керування вкладками"
-
-#~ msgid "Close tab"
-#~ msgstr "Закрити вкладку"
-
-#~ msgid "Rename current tab"
-#~ msgstr "Перейменувати поточну вкладку"
-
-#~ msgid "Navigation"
-#~ msgstr "Навігація"
-
-#~ msgid "Go to previous tab"
-#~ msgstr "Перейти до попередньої вкладки"
-
-#~ msgid "Go to next tab"
-#~ msgstr "Перейти до наступної вкладки"
-
-#~ msgid "Clipboard"
-#~ msgstr "Буфер обміну"
-
-#~ msgid "Copy text to clipboard"
-#~ msgstr "Скопіювати текст до буфера обміну"
-
-#~ msgid "Paste text from clipboard"
-#~ msgstr "Вставити текст з буфера обміну"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Guake 0.4.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-12-01 16:49+0100\n"
+"POT-Creation-Date: 2016-08-17 21:41+0000\n"
 "PO-Revision-Date: \n"
 "Last-Translator: 甘露(Gan Lu) <rhythm.gan@gmail.com>\n"
 "Language-Team: guake@lists.guake.org\n"
@@ -95,7 +95,7 @@ msgstr "复制"
 msgid "Paste"
 msgstr "粘贴"
 
-#: ../data/guake.glade.h:3
+#: ../data/guake.glade.h:3 ../src/guake/prefs.py:79
 msgid "Toggle Fullscreen"
 msgstr "切换全屏"
 
@@ -103,7 +103,7 @@ msgstr "切换全屏"
 msgid "Save to File..."
 msgstr "保存到文件"
 
-#: ../data/guake.glade.h:5
+#: ../data/guake.glade.h:5 ../src/guake/prefs.py:85
 #, fuzzy
 msgid "Reset terminal"
 msgstr "Guake 终端"
@@ -132,7 +132,7 @@ msgstr "打开链接"
 msgid "Search on Web"
 msgstr "使用搜索引擎搜索"
 
-#: ../data/guake.glade.h:12
+#: ../data/guake.glade.h:12 ../src/guake/prefs.py:83
 msgid "Quit"
 msgstr "退出"
 
@@ -252,130 +252,134 @@ msgid "Use VTE titles for tab names"
 msgstr "使用VTE标题作为标签名"
 
 #: ../data/prefs.glade.h:33
-msgid "Max tab name length:"
+msgid "Abbreviate directories in tab names"
 msgstr ""
 
 #: ../data/prefs.glade.h:34
+msgid "Max tab name length:"
+msgstr ""
+
+#: ../data/prefs.glade.h:35
 msgid "Hide on lose focus"
 msgstr "失去焦点后隐藏"
 
-#: ../data/prefs.glade.h:35
+#: ../data/prefs.glade.h:36
 msgid "Show tab bar"
 msgstr "显示标签栏"
 
-#: ../data/prefs.glade.h:36
+#: ../data/prefs.glade.h:37
 msgid "Start fullscreen"
 msgstr "切换全屏"
 
-#: ../data/prefs.glade.h:37
+#: ../data/prefs.glade.h:38
 msgid "<b>Main Window</b>"
 msgstr "<b>主窗口</b>"
 
-#: ../data/prefs.glade.h:38
+#: ../data/prefs.glade.h:39
 msgid "Left"
 msgstr "左"
 
-#: ../data/prefs.glade.h:39
+#: ../data/prefs.glade.h:40
 msgid "Center"
 msgstr "中"
 
-#: ../data/prefs.glade.h:40
+#: ../data/prefs.glade.h:41
 msgid "Right"
 msgstr "右"
 
-#: ../data/prefs.glade.h:41
+#: ../data/prefs.glade.h:42
 msgid "<b>Main Window Horizontal Alignment</b>"
 msgstr "<b>主窗口高度</b>"
 
-#: ../data/prefs.glade.h:42
+#: ../data/prefs.glade.h:43
 msgid "<b>Main Window Height</b>"
 msgstr "<b>主窗口高度</b>"
 
-#: ../data/prefs.glade.h:43
+#: ../data/prefs.glade.h:44
 msgid "<b>Main Window Width</b>"
 msgstr "<b>主窗口高度</b>"
 
-#: ../data/prefs.glade.h:44
+#: ../data/prefs.glade.h:45
 msgid "Custom command file path: "
 msgstr "自定义命令路径"
 
-#: ../data/prefs.glade.h:45
+#: ../data/prefs.glade.h:46
 msgid "Please select a json file"
 msgstr "请选择Json文件"
 
-#: ../data/prefs.glade.h:46
+#: ../data/prefs.glade.h:47 ../src/guake/prefs.py:75
 msgid "General"
 msgstr "常规"
 
-#: ../data/prefs.glade.h:47
+#: ../data/prefs.glade.h:48
 msgid "Default interpreter:"
 msgstr "默认解释器"
 
-#: ../data/prefs.glade.h:48
+#: ../data/prefs.glade.h:49
 msgid "_Run command as a login shell"
 msgstr "运行命令作为登录外壳(_R)"
 
-#: ../data/prefs.glade.h:49
+#: ../data/prefs.glade.h:50
 msgid "_Open new tab in current directory"
 msgstr "在当前目录打开新标签页(_O)"
 
-#: ../data/prefs.glade.h:50
+#: ../data/prefs.glade.h:51
 msgid "<b>Shell</b>"
 msgstr "<b>外壳</b>"
 
-#: ../data/prefs.glade.h:51
+#: ../data/prefs.glade.h:52
 msgid "Shell"
 msgstr "外壳"
 
-#: ../data/prefs.glade.h:52
+#: ../data/prefs.glade.h:53
 msgid "Show scrollbar"
 msgstr "显示滚动条"
 
-#: ../data/prefs.glade.h:53
+#: ../data/prefs.glade.h:54
 msgid "Scrollback lines:"
 msgstr "回卷行数："
 
-#: ../data/prefs.glade.h:54
+#: ../data/prefs.glade.h:55
 msgid "On output"
 msgstr "输出时"
 
-#: ../data/prefs.glade.h:55
+#: ../data/prefs.glade.h:56
 msgid "On key stroke"
 msgstr "键敲下时"
 
-#: ../data/prefs.glade.h:56
+#: ../data/prefs.glade.h:57
 msgid "<b>Scroll</b>"
 msgstr "<b>滚动</b>"
 
-#: ../data/prefs.glade.h:57
+#: ../data/prefs.glade.h:58
 msgid "Scrolling"
 msgstr "滚屏"
 
-#: ../data/prefs.glade.h:58
+#: ../data/prefs.glade.h:59
 msgid "Use the system fixed width font"
 msgstr "使用系统的等宽字体"
 
-#: ../data/prefs.glade.h:59
+#: ../data/prefs.glade.h:60
 msgid "Font:"
 msgstr "字体："
 
-#: ../data/prefs.glade.h:60
+#: ../data/prefs.glade.h:61
 msgid "Choose some font"
 msgstr "选择字体"
 
-#: ../data/prefs.glade.h:61
+#: ../data/prefs.glade.h:62
 msgid "Text color:"
 msgstr "文字颜色："
 
-#: ../data/prefs.glade.h:62
+#: ../data/prefs.glade.h:63
 msgid "Background color:"
 msgstr "背景颜色："
 
-#: ../data/prefs.glade.h:63
+#: ../data/prefs.glade.h:64
 msgid "Cursor shape:"
 msgstr "光标形状"
 
-#: ../data/prefs.glade.h:64
+#: ../data/prefs.glade.h:65
 msgid ""
 "Block\n"
 "I-Beam\n"
@@ -385,66 +389,66 @@ msgstr ""
 "I-Beam\n"
 "下划线"
 
-#: ../data/prefs.glade.h:67
+#: ../data/prefs.glade.h:68
 msgid ""
 "Follow GTK+ setting\n"
 "Blink on\n"
 "Blink off"
 msgstr "使用GTK+设置光标闪动开光标闪动关"
 
-#: ../data/prefs.glade.h:70
+#: ../data/prefs.glade.h:71
 msgid "Cursor blink mode:"
 msgstr "光标闪动类型"
 
-#: ../data/prefs.glade.h:71
+#: ../data/prefs.glade.h:72
 msgid "Allow bold font"
 msgstr "允许使用粗体"
 
-#: ../data/prefs.glade.h:72
+#: ../data/prefs.glade.h:73
 msgid "<b>Palette</b>"
 msgstr "<b>调色板</b>"
 
-#: ../data/prefs.glade.h:73
+#: ../data/prefs.glade.h:74
 msgid "Built-in schemes:"
 msgstr "内建方案："
 
-#: ../data/prefs.glade.h:74
+#: ../data/prefs.glade.h:75
 msgid "Color palette:"
 msgstr "调色板："
 
-#: ../data/prefs.glade.h:75
+#: ../data/prefs.glade.h:76
 msgid "Font color"
 msgstr "文字颜色："
 
-#: ../data/prefs.glade.h:76
+#: ../data/prefs.glade.h:77
 msgid "Background color"
 msgstr "背景颜色："
 
-#: ../data/prefs.glade.h:77
+#: ../data/prefs.glade.h:78
 msgid "Use font and background color from the palette"
 msgstr "使用调色板设置的字体和背景颜色"
 
-#: ../data/prefs.glade.h:78
+#: ../data/prefs.glade.h:79
 msgid "Demo:"
 msgstr "样例"
 
-#: ../data/prefs.glade.h:79
+#: ../data/prefs.glade.h:80
 msgid "<b>Effects</b>"
 msgstr "<b>效果</b>"
 
-#: ../data/prefs.glade.h:80
+#: ../data/prefs.glade.h:81
 msgid "Transparency:"
 msgstr "透明："
 
-#: ../data/prefs.glade.h:81
+#: ../data/prefs.glade.h:82
 msgid "Background image:"
 msgstr "背景图像："
 
-#: ../data/prefs.glade.h:82
+#: ../data/prefs.glade.h:83 ../src/guake/prefs.py:130
 msgid "Appearance"
 msgstr "外观"
 
-#: ../data/prefs.glade.h:83
+#: ../data/prefs.glade.h:84
 msgid ""
 "<small>Quick open is a feature allowing you to open a file directly into "
 "your favorite text editor by clicking on its filename when it appears in "
@@ -452,15 +456,15 @@ msgid ""
 "extract filename below.</small>"
 msgstr ""
 
-#: ../data/prefs.glade.h:84
+#: ../data/prefs.glade.h:85
 msgid "Enable Quick Open when Ctrl+clicking on a filename in the terminal"
 msgstr ""
 
-#: ../data/prefs.glade.h:85
+#: ../data/prefs.glade.h:86
 msgid "Editor command line:"
 msgstr "编辑命令行"
 
-#: ../data/prefs.glade.h:87
+#: ../data/prefs.glade.h:88
 #, no-c-format
 msgid ""
 "<small><i>Use the following elements in the open editor command line:\n"
@@ -472,35 +476,35 @@ msgid ""
 "</i></small>"
 msgstr ""
 
-#: ../data/prefs.glade.h:93
+#: ../data/prefs.glade.h:94
 msgid "Quick open in current terminal"
 msgstr ""
 
-#: ../data/prefs.glade.h:94
+#: ../data/prefs.glade.h:95
 msgid ""
 "Here is the list of supported patterns: (to add your own, please contact the "
 "Guake's authors)"
 msgstr ""
 
-#: ../data/prefs.glade.h:95
+#: ../data/prefs.glade.h:96
 msgid "<b>Quick Open</b>"
 msgstr "<b>快速打开</b>"
 
-#: ../data/prefs.glade.h:96
+#: ../data/prefs.glade.h:97
 msgid "Quick Open"
 msgstr "快速打开"
 
-#: ../data/prefs.glade.h:97
+#: ../data/prefs.glade.h:98
 msgid ""
 "To change a shortcut simply click on its name.\n"
 "To disable a shortcut, press the \"Backspace\" key."
 msgstr ""
 
-#: ../data/prefs.glade.h:99
+#: ../data/prefs.glade.h:100
 msgid "Keyboard shortcuts"
 msgstr "键盘快捷键"
 
-#: ../data/prefs.glade.h:100
+#: ../data/prefs.glade.h:101
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -510,7 +514,7 @@ msgstr ""
 "<small><i><b>Note:</b>这些选项可能会导致一些程序行为异常。仅仅是允许您暂时应"
 "对某程序和期望不同终端行为的操作系统。</i></small>"
 
-#: ../data/prefs.glade.h:101
+#: ../data/prefs.glade.h:102
 msgid ""
 "ASCII DEL\n"
 "Escape sequence\n"
@@ -520,37 +524,36 @@ msgstr ""
 "Escape 序列\n"
 "Control-H"
 
-#: ../data/prefs.glade.h:104
+#: ../data/prefs.glade.h:105
 msgid "_Backspace key generates:"
 msgstr "_Backspace 键产生："
 
-#: ../data/prefs.glade.h:105
+#: ../data/prefs.glade.h:106
 msgid "_Delete key generates:"
 msgstr "_Delete 键产生："
 
-#: ../data/prefs.glade.h:106
+#: ../data/prefs.glade.h:107
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "重新设定兼容性选项为默认值(_R)"
 
-#: ../data/prefs.glade.h:107
+#: ../data/prefs.glade.h:108
 msgid "<b>Keyboard compatibility</b>"
 msgstr "<b>键盘兼容性</b>"
 
-#: ../data/prefs.glade.h:108
+#: ../data/prefs.glade.h:109
 msgid "Compatibility"
 msgstr "兼容性"
 
-#: ../src/guake/about.py:47 ../src/guake/gconfhandler.py:427
-#: ../src/guake/guake_app.py:177 ../src/guake/guake_app.py:348
+#: ../src/guake/about.py:47 ../src/guake/gconfhandler.py:435
+#: ../src/guake/guake_app.py:181 ../src/guake/guake_app.py:376
 msgid "Guake Terminal"
 msgstr "Guake 终端"
 
-#. Adding a new radio button to the tabbar
-#: ../src/guake/gconfhandler.py:365 ../src/guake/guake_app.py:1548
+#: ../src/guake/gconfhandler.py:368 ../src/guake/guake_app.py:1363
 msgid "Terminal"
 msgstr "终端 %s"
 
-#: ../src/guake/gconfhandler.py:428
+#: ../src/guake/gconfhandler.py:436
 #, python-format
 msgid ""
 "A problem happened when binding <b>%s</b> key.\n"
@@ -559,49 +562,49 @@ msgstr ""
 "绑定 <b>%s</b> 键时出现问题。\n"
 "请使用 Guake 首选项对话框选择另外的键（托盘图标已启用）"
 
-#: ../src/guake/guake_app.py:128
+#: ../src/guake/guake_app.py:132
 msgid "Do you want to close the tab?"
 msgstr "您确实想退出 Guake！？"
 
-#: ../src/guake/guake_app.py:131
+#: ../src/guake/guake_app.py:135
 msgid "Do you really want to quit Guake?"
 msgstr "您确实想退出 Guake！？"
 
-#: ../src/guake/guake_app.py:133
+#: ../src/guake/guake_app.py:137
 msgid " and one tab open"
 msgstr "新增标签页"
 
-#: ../src/guake/guake_app.py:135
+#: ../src/guake/guake_app.py:139
 #, python-brace-format
 msgid " and {0} tabs open"
 msgstr "{0}个标签打开"
 
-#: ../src/guake/guake_app.py:138
+#: ../src/guake/guake_app.py:142
 msgid "There are no processes running"
 msgstr "<b>有一个进程仍然在运行</b>"
 
-#: ../src/guake/guake_app.py:140
+#: ../src/guake/guake_app.py:144
 msgid "There is a process still running"
 msgstr "<b>有一个进程仍然在运行</b>"
 
-#: ../src/guake/guake_app.py:142
+#: ../src/guake/guake_app.py:146
 #, fuzzy, python-brace-format
 msgid "There are {0} processes still running"
 msgstr "<b>有 %d 进程正在运行</b>"
 
-#: ../src/guake/guake_app.py:182
+#: ../src/guake/guake_app.py:186
 msgid "guake-indicator"
 msgstr ""
 
-#: ../src/guake/guake_app.py:182
+#: ../src/guake/guake_app.py:186
 msgid "guake-tray"
 msgstr ""
 
-#: ../src/guake/guake_app.py:186
+#: ../src/guake/guake_app.py:190
 msgid "Show"
 msgstr "查看"
 
-#: ../src/guake/guake_app.py:349
+#: ../src/guake/guake_app.py:377
 #, python-format
 msgid ""
 "Guake is now running,\n"
@@ -610,126 +613,131 @@ msgstr ""
 "Guake 正在运行，\n"
 "按 <b>%s</b> 使用它。"
 
-#: ../src/guake/guake_app.py:611
+#: ../src/guake/guake_app.py:665
 #, python-format
 msgid "Search on Web: '%s'"
 msgstr "在网络上搜索：‘%s’"
 
-#: ../src/guake/guake_app.py:616
+#: ../src/guake/guake_app.py:670
 msgid "Search on Web (no selection)"
 msgstr "在网络上搜索（没有选择文字）"
 
-#: ../src/guake/guake_app.py:622
+#: ../src/guake/guake_app.py:678
+#, fuzzy
+msgid "Open Link: '{}...'"
+msgstr "打开链接：{}"
+
+#: ../src/guake/guake_app.py:680
 msgid "Open Link: {}"
 msgstr "打开链接：{}"
 
-#: ../src/guake/guake_app.py:625
+#: ../src/guake/guake_app.py:683
 msgid "Open Link..."
 msgstr "打开链接..."
 
-#: ../src/guake/guake_app.py:1300
+#: ../src/guake/guake_app.py:1402
 msgid "Rename tab"
 msgstr "重命名标签"
 
-#: ../src/guake/guake_app.py:1591
+#: ../src/guake/guake_app.py:1716
 msgid "Save to..."
 msgstr "保存到"
 
-#: ../src/guake/guake_app.py:1598 ../src/guake/prefs.py:930
+#: ../src/guake/guake_app.py:1723 ../src/guake/prefs.py:998
 msgid "All files"
 msgstr "所有文件"
 
-#: ../src/guake/guake_app.py:1603
+#: ../src/guake/guake_app.py:1728
 msgid "Text and Logs"
 msgstr "文字和日志"
 
-#: ../src/guake/guake_app.py:1621
+#: ../src/guake/guake_app.py:1746
 msgid "Find"
 msgstr "查找"
 
-#: ../src/guake/guake_app.py:1623
+#: ../src/guake/guake_app.py:1748
 msgid "Forward"
 msgstr "前进"
 
-#: ../src/guake/guake_app.py:1624
+#: ../src/guake/guake_app.py:1749
 msgid "Backward"
 msgstr "后退"
 
-#: ../src/guake/main.py:67
+#: ../src/guake/main.py:68
 msgid "Put Guake in fullscreen mode"
 msgstr "设置Guake全屏显示"
 
-#: ../src/guake/main.py:71
+#: ../src/guake/main.py:72
 msgid "Toggles the visibility of the terminal window"
 msgstr "切换终端窗口是否可见"
 
-#: ../src/guake/main.py:75
+#: ../src/guake/main.py:76
 msgid "Shows Guake main window"
 msgstr "显示 Guake 的首选项窗口"
 
-#: ../src/guake/main.py:79
+#: ../src/guake/main.py:80
 msgid "Hides Guake main window"
 msgstr "显示 Guake 的首选项窗口"
 
-#: ../src/guake/main.py:83
+#: ../src/guake/main.py:84
 msgid "Shows Guake preference window"
 msgstr "显示 Guake 的首选项窗口"
 
-#: ../src/guake/main.py:87
+#: ../src/guake/main.py:88
 msgid "Shows Guake's about info"
 msgstr "显示 Guake 的“关于”信息"
 
-#: ../src/guake/main.py:91
+#: ../src/guake/main.py:92
 msgid "Add a new tab (with current directory set to NEW_TAB)"
 msgstr "在当前目录打开新标签页(_O)"
 
-#: ../src/guake/main.py:95
+#: ../src/guake/main.py:96
 msgid "Select a tab (SELECT_TAB is the index of the tab)"
 msgstr "按照编号选择一个标签页(_T)"
 
-#: ../src/guake/main.py:99
+#: ../src/guake/main.py:100
 msgid "Return the selected tab index."
 msgstr "回到选定的标签页索引"
 
-#: ../src/guake/main.py:103
+#: ../src/guake/main.py:104
 msgid "Execute an arbitrary command in the selected tab."
 msgstr "在选定标签页执行一个随意的命令。"
 
-#: ../src/guake/main.py:107
+#: ../src/guake/main.py:108
 msgid "Specify the tab to rename. Default is 0."
 msgstr "指定重命名标签页，默认为0"
 
-#: ../src/guake/main.py:111
+#: ../src/guake/main.py:112
 msgid "Set the hexadecimal (#rrggbb) background color of the selected tab."
 msgstr "设置大概前选中标签的背景颜色，格式为(#rrggbb)"
 
-#: ../src/guake/main.py:116
+#: ../src/guake/main.py:117
 msgid "Set the hexadecimal (#rrggbb) foreground color of the selected tab."
 msgstr "设置大概前选中标签的前景颜色，格式为(#rrggbb)"
 
-#: ../src/guake/main.py:122
+#: ../src/guake/main.py:123
 msgid ""
 "Rename the specified tab. Reset to default if TITLE is a single dash \"-\"."
 msgstr "重命名指定标签，如果标题为“-”，设为默认"
 
-#: ../src/guake/main.py:128
+#: ../src/guake/main.py:129
 msgid ""
 "Rename the current tab. Reset to default if TITLE is a single dash \"-\"."
 msgstr "重命名当前标签，如果标题为“-”，设为默认"
 
-#: ../src/guake/main.py:133
+#: ../src/guake/main.py:134
 msgid "Says to Guake go away =("
 msgstr "告诉 Guake 走开 =("
 
-#: ../src/guake/main.py:137
+#: ../src/guake/main.py:138
 msgid "Do not execute the start up script"
 msgstr "启动时不执行脚本"
 
-#: ../src/guake/main.py:231
+#: ../src/guake/main.py:235
 msgid "Guake can not init!"
 msgstr "Guake 无法初始化！"
 
-#: ../src/guake/main.py:232
+#: ../src/guake/main.py:236
 msgid ""
 "Gconf Error.\n"
 "Have you installed <b>guake.schemas</b> properly?"
@@ -742,32 +750,191 @@ msgstr ""
 msgid "<user shell>"
 msgstr "<用户外壳>"
 
-#: ../src/guake/prefs.py:467
+#: ../src/guake/prefs.py:77
+msgid "Toggle Guake visibility"
+msgstr "切换 Guake 是否可见"
+
+#: ../src/guake/prefs.py:81
+#, fuzzy
+msgid "Toggle Hide on Lose Focus"
+msgstr "失去焦点后隐藏"
+
+#: ../src/guake/prefs.py:88
+msgid "Tab management"
+msgstr "标签页管理"
+
+#: ../src/guake/prefs.py:90
+#, fuzzy
+msgid "New tab"
+msgstr "新标签页"
+
+#: ../src/guake/prefs.py:92
+msgid "Close tab"
+msgstr "关闭标签页"
+
+#: ../src/guake/prefs.py:94
+msgid "Rename current tab"
+msgstr "重命名当前标签页"
+
+#: ../src/guake/prefs.py:97
+msgid "Navigation"
+msgstr "导航"
+
+#: ../src/guake/prefs.py:99
+msgid "Go to previous tab"
+msgstr "上一个标签页"
+
+#: ../src/guake/prefs.py:101
+msgid "Go to next tab"
+msgstr "下一个标签页"
+
+#: ../src/guake/prefs.py:103
+#, fuzzy
+msgid "Move current tab left"
+msgstr "重命名当前标签页"
+
+#: ../src/guake/prefs.py:105
+#, fuzzy
+msgid "Move current tab right"
+msgstr "重命名当前标签页"
+
+#: ../src/guake/prefs.py:107
+#, fuzzy
+msgid "Go to first tab"
+msgstr "下一个标签页"
+
+#: ../src/guake/prefs.py:109
+#, fuzzy
+msgid "Go to second tab"
+msgstr "下一个标签页"
+
+#: ../src/guake/prefs.py:111
+#, fuzzy
+msgid "Go to third tab"
+msgstr "下一个标签页"
+
+#: ../src/guake/prefs.py:113
+#, fuzzy
+msgid "Go to fourth tab"
+msgstr "下一个标签页"
+
+#: ../src/guake/prefs.py:115
+#, fuzzy
+msgid "Go to fifth tab"
+msgstr "下一个标签页"
+
+#: ../src/guake/prefs.py:117
+#, fuzzy
+msgid "Go to sixth tab"
+msgstr "下一个标签页"
+
+#: ../src/guake/prefs.py:119
+#, fuzzy
+msgid "Go to seventh tab"
+msgstr "下一个标签页"
+
+#: ../src/guake/prefs.py:121
+#, fuzzy
+msgid "Go to eighth tab"
+msgstr "下一个标签页"
+
+#: ../src/guake/prefs.py:123
+#, fuzzy
+msgid "Go to ninth tab"
+msgstr "下一个标签页"
+
+#: ../src/guake/prefs.py:125
+#, fuzzy
+msgid "Go to tenth tab"
+msgstr "下一个标签页"
+
+#: ../src/guake/prefs.py:127
+#, fuzzy
+msgid "Go to last tab"
+msgstr "下一个标签页"
+
+#: ../src/guake/prefs.py:132
+msgid "Zoom out"
+msgstr ""
+
+#: ../src/guake/prefs.py:134
+msgid "Zoom in"
+msgstr ""
+
+#: ../src/guake/prefs.py:136
+msgid "Zoom in (alternative)"
+msgstr ""
+
+#: ../src/guake/prefs.py:138
+msgid "Increase height"
+msgstr ""
+
+#: ../src/guake/prefs.py:140
+msgid "Decrease height"
+msgstr ""
+
+#: ../src/guake/prefs.py:142
+#, fuzzy
+msgid "Increase transparency"
+msgstr "透明："
+
+#: ../src/guake/prefs.py:144
+#, fuzzy
+msgid "Decrease transparency"
+msgstr "透明："
+
+#: ../src/guake/prefs.py:146
+#, fuzzy
+msgid "Toggle transparency"
+msgstr "透明："
+
+#: ../src/guake/prefs.py:149
+msgid "Clipboard"
+msgstr "剪贴板"
+
+#: ../src/guake/prefs.py:151
+msgid "Copy text to clipboard"
+msgstr "复制文字到剪贴板"
+
+#: ../src/guake/prefs.py:153
+msgid "Paste text from clipboard"
+msgstr "从剪贴板中粘贴文字"
+
+#: ../src/guake/prefs.py:156
+msgid "Extra features"
+msgstr ""
+
+#: ../src/guake/prefs.py:159
+#, fuzzy
+msgid "Search select text on web"
+msgstr "使用搜索引擎搜索"
+
+#: ../src/guake/prefs.py:519
 msgid "Action"
 msgstr "行动"
 
-#: ../src/guake/prefs.py:477
+#: ../src/guake/prefs.py:529
 msgid "Shortcut"
 msgstr "快捷键"
 
-#: ../src/guake/prefs.py:619 ../src/guake/prefs.py:665
+#: ../src/guake/prefs.py:678 ../src/guake/prefs.py:724
 msgid "Custom"
 msgstr "自定义"
 
-#: ../src/guake/prefs.py:926
+#: ../src/guake/prefs.py:994
 msgid "JSON files"
 msgstr "Json文件"
 
-#: ../src/guake/prefs.py:1019
+#: ../src/guake/prefs.py:1088
 #, python-format
 msgid "The shortcut \"%s\" is already in use."
 msgstr "快捷键 \"%s\" 已经被使用"
 
-#: ../src/guake/prefs.py:1020
+#: ../src/guake/prefs.py:1089
 msgid "Error setting keybinding."
 msgstr "设定键绑定时出错"
 
-#: ../src/guake/prefs.py:1032
+#: ../src/guake/prefs.py:1101
 #, python-format
 msgid ""
 "The shortcut \"%s\" cannot be used because it will become impossible to type "
@@ -806,36 +973,6 @@ msgstr ""
 
 #~ msgid "Rename the selected tab."
 #~ msgstr "重命名选定的标签页"
-
-#~ msgid "Toggle Guake visibility"
-#~ msgstr "切换 Guake 是否可见"
-
-#~ msgid "Tab management"
-#~ msgstr "标签页管理"
-
-#~ msgid "Close tab"
-#~ msgstr "关闭标签页"
-
-#~ msgid "Rename current tab"
-#~ msgstr "重命名当前标签页"
-
-#~ msgid "Navigation"
-#~ msgstr "导航"
-
-#~ msgid "Go to previous tab"
-#~ msgstr "上一个标签页"
-
-#~ msgid "Go to next tab"
-#~ msgstr "下一个标签页"
-
-#~ msgid "Clipboard"
-#~ msgstr "剪贴板"
-
-#~ msgid "Copy text to clipboard"
-#~ msgstr "复制文字到剪贴板"
-
-#~ msgid "Paste text from clipboard"
-#~ msgstr "从剪贴板中粘贴文字"
 
 #~ msgid "<b>Background</b>"
 #~ msgstr "<b>背景</b>"

--- a/src/guake/gconfhandler.py
+++ b/src/guake/gconfhandler.py
@@ -97,6 +97,7 @@ class GConfHandler(object):
         notify_add(KEY('/general/compat_delete'), self.delete_changed)
         notify_add(KEY('/general/custom_command_file'), self.custom_command_file_changed)
         notify_add(KEY('/general/max_tab_name_length'), self.max_tab_name_length_changed)
+        notify_add(KEY('/general/abbreviate_tab_names'), self.abbreviate_tab_names_changed)
 
     def custom_command_file_changed(self, client, connection_id, entry, data):
         self.guake.load_custom_commands()
@@ -373,6 +374,13 @@ class GConfHandler(object):
                 tab_custom_name = getattr(tab, 'custom_label_text', False)
                 tab.set_label(tab_custom_name[:max_name_length])
 
+    def abbreviate_tab_names_changed(self, client, connection_id, entry, data):
+        """If the gconf var abbreviate_tab_names be changed, this method will
+        be called and will update tab names.
+        """
+        abbreviate_tab_names = client.get_bool(KEY('/general/abbreviate_tab_names'))
+        self.guake.abbreviate = abbreviate_tab_names and self.guake.is_tabs_scrollbar_visible()
+        self.guake.recompute_tabs_titles()
 
 class GConfKeyHandler(object):
 

--- a/src/guake/guake_app.py
+++ b/src/guake/guake_app.py
@@ -292,6 +292,13 @@ class Guake(SimpleGladeApp):
 
         evtbox.connect('scroll-event', scroll_manager)
 
+        def tabs_scrollbar_hide(hscrollbar):
+                self.get_widget('event-tabs').set_property('height_request', 10)
+        def tabs_scrollbar_show(hscrollbar):
+                self.get_widget('event-tabs').set_property('height_request', -1)
+        self.get_widget('tabs-scrolledwindow').get_hscrollbar().connect('hide', tabs_scrollbar_hide)
+        self.get_widget('tabs-scrolledwindow').get_hscrollbar().connect('show', tabs_scrollbar_show)
+
         # Flag to prevent guake hide when window_losefocus is true and
         # user tries to use the context menu.
         self.showing_context_menu = False

--- a/src/guake/prefs.py
+++ b/src/guake/prefs.py
@@ -259,6 +259,11 @@ class PrefsCallbacks(object):
         """
         self.client.set_bool(KEY('/general/use_vte_titles'), chk.get_active())
 
+    def on_abbreviate_tab_names_toggled(self, chk):
+        """Save `abbreviate_tab_names` property value in gconf
+        """
+        self.client.set_bool(KEY('/general/abbreviate_tab_names'), chk.get_active())
+
     def on_max_tab_name_length_changed(self, spin):
         """Changes the value of max_tab_name_length in gconf
         """
@@ -579,6 +584,11 @@ class PrefsDialog(SimpleGladeApp):
         self.get_widget('quick_open_command_line').set_sensitive(chk.get_active())
         self.get_widget('quick_open_in_current_terminal').set_sensitive(chk.get_active())
 
+    def toggle_use_vte_titles(self, chk):
+        """When vte titles aren't used, there is nothing to abbreviate
+        """
+        self.get_widget('abbreviate_tab_names').set_sensitive(chk.get_active())
+
     def clear_background_image(self, btn):
         """Unset the gconf variable that holds the name of the
         background image of all terminals.
@@ -756,6 +766,11 @@ class PrefsDialog(SimpleGladeApp):
         # use VTE titles
         value = self.client.get_bool(KEY('/general/use_vte_titles'))
         self.get_widget('use_vte_titles').set_active(value)
+
+        # abbreviate tab names
+        self.get_widget('abbreviate_tab_names').set_sensitive(value)
+        value = self.client.get_bool(KEY('/general/abbreviate_tab_names'))
+        self.get_widget('abbreviate_tab_names').set_active(value)
 
         # max tab name length
         value = self.client.get_int(KEY('/general/max_tab_name_length'))


### PR DESCRIPTION
Better fixes for #653 and #666 (preserving tab height)
Option to abbreviate directory paths in tab names when necessary.
Small preference dialog fixes.