### PR TITLE
allow abbreviation independently of max_tab_name_length, fix behaviour

### DIFF
--- a/src/guake/guake_app.py
+++ b/src/guake/guake_app.py
@@ -1386,10 +1386,10 @@ class Guake(SimpleGladeApp):
         vte_title = vte.get_window_title() or _("Terminal")
         try:
             current_directory = vte.get_current_directory()
-            if self.abbreviate and current_directory in vte_title:
+            if self.abbreviate and vte_title.endswith(current_directory):
                 parts = current_directory.split('/')
                 parts = list(map(lambda s: s[:1], parts[:-1])) + [parts[-1]]
-                vte_title = vte_title.replace(current_directory, '/'.join(parts))
+                vte_title = vte_title[:len(vte_title) - len(current_directory)] + '/'.join(parts)
         except OSError:
             pass
         return self._shorten_tab_title(vte_title)
@@ -1823,7 +1823,8 @@ class Guake(SimpleGladeApp):
         self.notebook.set_current_page(new_tab_pos)
 
     def is_tabs_scrollbar_visible(self):
-        return self.get_widget('tabs-scrolledwindow').get_hscrollbar().get_visible()
+        return (self.window.get_visible() and
+                self.get_widget('tabs-scrolledwindow').get_hscrollbar().get_visible())
 
     def delete_tab(self, pagepos, kill=True):
         """This function will destroy the notebook page, terminal and

--- a/src/guake/prefs.py
+++ b/src/guake/prefs.py
@@ -595,10 +595,8 @@ class PrefsDialog(SimpleGladeApp):
         do_use_vte_titles = self.get_widget('use_vte_titles').get_active()
         max_tab_name_length_wdg = self.get_widget('max_tab_name_length')
         max_tab_name_length_wdg.set_sensitive(do_use_vte_titles)
-        max_tab_name_length = max_tab_name_length_wdg.get_value()
         self.get_widget('lbl_max_tab_name_length').set_sensitive(do_use_vte_titles)
-        self.get_widget('abbreviate_tab_names').set_sensitive(do_use_vte_titles and
-                                                              max_tab_name_length != 0)
+        self.get_widget('abbreviate_tab_names').set_sensitive(do_use_vte_titles)
 
     def clear_background_image(self, btn):
         """Unset the gconf variable that holds the name of the


### PR DESCRIPTION
I want abbreviate tab names when necessary, but don't want to cut them
Additionally, fix initial abbreviation and possible unwanted abbreviations before current directory in vte title.