### PR TITLE
Multiws

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,6 +75,9 @@ Dependencies
  * python-notify
  * python-vte
  * python-xdg
+ * python-wnck
+ * python-appindicator (ubuntu)
+ * notify-osd (ubuntu)
  * libutempter
 
 To build guake, you will need the following packages too:

--- a/src/guake/guake_app.py
+++ b/src/guake/guake_app.py
@@ -1651,14 +1651,21 @@ class Guake(SimpleGladeApp):
         """Gets the working directory of the current tab to create a
         new one in the same dir.
         """
-        active_terminal = self.notebook.get_current_terminal()
-        directory = os.path.expanduser('~')
-        if active_terminal:
-            active_pid = active_terminal.get_pid()
-            if active_pid:
-                cwd = os.readlink("/proc/{0}/cwd".format(active_pid))
-                if os.path.exists(cwd):
-                    directory = cwd
+        if (hasattr(self, "current_workspace") and
+            self.current_workspace in self.active_by_workspaces):
+            active_box = self.active_by_workspaces[self.current_workspace]
+            active_terminal = active_box.terminal
+            directory = os.path.expanduser('~')
+            if active_terminal:
+                active_pid = active_terminal.get_pid()
+                if active_pid:
+                    cwd = os.readlink("/proc/{0}/cwd".format(active_pid))
+                    if os.path.exists(cwd):
+                        directory = cwd
+        else:
+            # Do not carry working dir across workspaces:
+            directory = os.path.expanduser('~')
+
         return directory
 
     def get_fork_params(self, default_params=None, box=None):

--- a/src/guake/guake_app.py
+++ b/src/guake/guake_app.py
@@ -1964,7 +1964,10 @@ class Guake(SimpleGladeApp):
             # avoiding the delay on next Guake show request
             self.add_tab()
         else:
-            self.set_terminal_focus()
+            # FIXME: pretty arbitrary...
+            box, bnt = self.boxes_by_workspaces[self.current_workspace][-1]
+            self.active_by_workspaces[self.current_workspace] = box
+            self.set_active_box(box)
 
         self.was_deleted_tab = True
         abbreviate_tab_names = self.client.get_bool(KEY('/general/abbreviate_tab_names'))

--- a/src/guake/guake_app.py
+++ b/src/guake/guake_app.py
@@ -1894,6 +1894,16 @@ class Guake(SimpleGladeApp):
 
         self.tabs.get_children()[pagepos].destroy()
         self.notebook.delete_tab(pagepos, kill=kill)
+        tab = self.tabs.get_children()[pagepos]
+
+        current_boxes = self.boxes_by_workspaces[self.current_workspace]
+        for rel_pos in range(len(current_boxes)):
+            box, bnt = current_boxes[rel_pos]
+            if bnt is tab:
+                current_boxes.pop(rel_pos)
+                box.destroy()
+                bnt.destroy()
+                break
 
         if not self.notebook.has_term():
             self.hide()

--- a/src/guake/guake_app.py
+++ b/src/guake/guake_app.py
@@ -42,6 +42,7 @@ from urllib import url2pathname
 from urlparse import urlsplit
 from xdg.DesktopEntry import DesktopEntry
 from xml.sax.saxutils import escape as xml_escape
+import wnck
 
 import guake.notifier
 
@@ -355,6 +356,10 @@ class Guake(SimpleGladeApp):
         # resizer stuff
         self.resizer.connect('motion-notify-event', self.on_resizer_drag)
 
+        # Workspaces tracking
+        self.screen = wnck.screen_get_default()
+        self.screen.connect( "active-workspace-changed", self.workspace_changed )
+
         # adding the first tab on guake
         self.add_tab()
 
@@ -554,6 +559,14 @@ class Guake(SimpleGladeApp):
         index = tab or self.notebook.get_current_page()
         for terminal in self.notebook.get_terminals_for_tab(index):
             terminal.custom_fgcolor = gtk.gdk.color_parse(fgcolor)
+
+    def workspace_changed(self, screen, previous_workspace):
+
+        workspace = self.screen.get_active_workspace()
+
+        w_num = workspace.get_number()
+
+        self.current_workspace = w_num
 
     def execute_command(self, command, tab=None):
         """Execute the `command' in the `tab'. If tab is None, the

--- a/src/guake/guake_app.py
+++ b/src/guake/guake_app.py
@@ -1651,6 +1651,9 @@ class Guake(SimpleGladeApp):
         """Gets the working directory of the current tab to create a
         new one in the same dir.
         """
+
+        directory = os.path.expanduser('~')
+
         if (hasattr(self, "current_workspace") and
             self.current_workspace in self.active_by_workspaces):
             active_box = self.active_by_workspaces[self.current_workspace]
@@ -1662,9 +1665,6 @@ class Guake(SimpleGladeApp):
                     cwd = os.readlink("/proc/{0}/cwd".format(active_pid))
                     if os.path.exists(cwd):
                         directory = cwd
-        else:
-            # Do not carry working dir across workspaces:
-            directory = os.path.expanduser('~')
 
         return directory
 
@@ -1828,7 +1828,8 @@ class Guake(SimpleGladeApp):
         if not w_num in self.boxes_by_workspaces:
             self.boxes_by_workspaces[w_num] = []
 
-        self.boxes_by_workspaces[w_num].append( (box, bnt) )
+        self.boxes_by_workspaces[w_num].append((box, bnt))
+        self.active_by_workspaces[w_num] = box
 
     def save_tab(self, directory=None):
         self.preventHide = True

--- a/src/guake/guake_app.py
+++ b/src/guake/guake_app.py
@@ -1920,7 +1920,9 @@ class Guake(SimpleGladeApp):
                 bnt.destroy()
                 break
 
-        if not self.notebook.has_term():
+        # FIXME: rather adapt self.notebook.has_term():
+        if not self.boxes_by_workspaces[self.current_workspace]:
+            # No more boxes in current workspace
             self.hide()
             # avoiding the delay on next Guake show request
             self.add_tab()

--- a/src/guake/guake_app.py
+++ b/src/guake/guake_app.py
@@ -359,6 +359,7 @@ class Guake(SimpleGladeApp):
 
         # Workspaces tracking
         self.boxes_by_workspaces = {}
+        self.active_by_workspaces = {}
         self.screen = wnck.screen_get_default()
         self.screen.connect( "active-workspace-changed", self.workspace_changed )
 
@@ -570,6 +571,7 @@ class Guake(SimpleGladeApp):
 
         if previous_workspace:
             prev_w_num = previous_workspace.get_number()
+            self.active_by_workspaces[prev_w_num] = self.get_active_box()
             if prev_w_num != w_num:
                 # Workspace did change
                 for box, bnt in self.boxes_by_workspaces[prev_w_num]:
@@ -582,8 +584,20 @@ class Guake(SimpleGladeApp):
                     for box, bnt in self.boxes_by_workspaces[w_num]:
                         box.show()
                         bnt.show()
-
+                    self.set_active_box(self.active_by_workspaces[w_num])
         self.current_workspace = w_num
+
+    def get_active_box(self):
+        """Return the currently shown GuakeTerminalBox.
+        """
+        page_num = self.notebook.get_current_page()
+        return self.notebook.get_nth_page(page_num)
+
+    def set_active_box(self, box):
+        """Show the given GuakeTerminalBox.
+        """
+        page_num = self.notebook.page_num(box)
+        self.notebook.set_current_page(page_num)
 
     def execute_command(self, command, tab=None):
         """Execute the `command' in the `tab'. If tab is None, the

--- a/src/guake/guake_app.py
+++ b/src/guake/guake_app.py
@@ -568,6 +568,21 @@ class Guake(SimpleGladeApp):
 
         w_num = workspace.get_number()
 
+        if previous_workspace:
+            prev_w_num = previous_workspace.get_number()
+            if prev_w_num != w_num:
+                # Workspace did change
+                for box, bnt in self.boxes_by_workspaces[prev_w_num]:
+                    box.hide()
+                    bnt.hide()
+                if not w_num in self.boxes_by_workspaces:
+                    # New workspace - hence empty
+                    self.add_tab()
+                else:
+                    for box, bnt in self.boxes_by_workspaces[w_num]:
+                        box.show()
+                        bnt.show()
+
         self.current_workspace = w_num
 
     def execute_command(self, command, tab=None):


### PR DESCRIPTION
Here is an old attempt at workspace-specific guake. It is far from ready, I'm opening the PR just in case it is useful to someone else (see  #32).

Doesn't even merge at the moment, but I'll try to solve this soon.

More important is to understand whether the strategy I adopted, which was the simplest possible, was also the best one. What I do is to simply keep a single instance of the terminal, but hide the tabs (which are all in a same notebook container) depending on which workspace is shown. Maybe a better approach would be to have more conceptually separated instances (maybe even processes!), which could also make it easier (just guessing) e.g. to "open a terminal here" in nautilus.

Apart from this, the current implementation has at least a couple of limitations:
- the functionality cannot be switched on/off
- I remember some occasional unexplained bug when closing a tab
  ... but apart from that, I really liked it (and this is why I plan to at least rebase to make it usable again).
