### PR TITLE
Homogeneous tabs

### DIFF
--- a/data/guake.glade
+++ b/data/guake.glade
@@ -399,47 +399,28 @@
             <property name="extension_events">all</property>
             <property name="no_show_all">True</property>
             <child>
-              <widget class="GtkScrolledWindow" id="tabs-scrolledwindow">
+              <widget class="GtkEventBox" id="event-tabs">
+                <property name="height_request">10</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="hscrollbar_policy">automatic</property>
-                <property name="vscrollbar_policy">never</property>
+                <property name="can_focus">False</property>
+                <property name="events">GDK_BUTTON_PRESS_MASK | GDK_STRUCTURE_MASK</property>
                 <child>
-                  <widget class="GtkViewport" id="tabs-viewport">
+                  <widget class="GtkHBox" id="hbox-tabs">
+                    <property name="homogeneous">True</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="shadow_type">none</property>
                     <child>
-                      <widget class="GtkEventBox" id="event-tabs">
-                        <property name="height_request">10</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="events">GDK_BUTTON_PRESS_MASK | GDK_STRUCTURE_MASK</property>
-                        <child>
-                          <widget class="GtkHBox" id="hbox-tabs">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                          </widget>
-                        </child>
-                      </widget>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
                     </child>
                   </widget>
                 </child>
               </widget>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
             </child>
             <child>
               <widget class="GtkButton" id="button1">

--- a/src/guake/guake_app.py
+++ b/src/guake/guake_app.py
@@ -1420,7 +1420,9 @@ class Guake(SimpleGladeApp):
         tab = self.tabs.get_children()[page]
         # if tab has been renamed by user, don't override.
         if not getattr(tab, 'custom_label_set', False):
-            tab.set_label(self.compute_tab_title(vte))
+            vte_title = self.compute_tab_title(vte)
+            tab.set_label(vte_title)
+            gtk.Tooltips().set_tip(tab, vte_title)
 
     def on_rename_current_tab_activate(self, *args):
         """Shows a dialog to rename the current tab.

--- a/src/guake/guake_app.py
+++ b/src/guake/guake_app.py
@@ -299,23 +299,6 @@ class Guake(SimpleGladeApp):
         self.abbreviate = False
         self.was_deleted_tab = False
 
-        def tabs_scrollbar_hide(hscrollbar):
-            self.get_widget('event-tabs').set_property('height_request', 10)
-            if self.abbreviate and self.was_deleted_tab:
-                self.was_deleted_tab = False
-                self.abbreviate = False
-                self.recompute_tabs_titles()
-
-        def tabs_scrollbar_show(hscrollbar):
-            self.get_widget('event-tabs').set_property('height_request', -1)
-            if self.client.get_bool(KEY("/general/abbreviate_tab_names")):
-                self.abbreviate = True
-                self.recompute_tabs_titles()
-
-        tabs_scrollbar = self.get_widget('tabs-scrolledwindow').get_hscrollbar()
-        tabs_scrollbar.connect('hide', tabs_scrollbar_hide)
-        tabs_scrollbar.connect('show', tabs_scrollbar_show)
-
         # Flag to prevent guake hide when window_losefocus is true and
         # user tries to use the context menu.
         self.showing_context_menu = False


### PR DESCRIPTION
Slightly different way of handling the tabs where they share the full screen width. So a single tab is full width, 2 are half width each etc. Basically how things like gnome-terminal behave
I've also added a tooltip so the title can be read if it's too long to read in the tab