### PR TITLE
Fix window width with Unity

### DIFF
--- a/src/guake/guake_app.py
+++ b/src/guake/guake_app.py
@@ -1008,10 +1008,12 @@ class Guake(SimpleGladeApp):
         if self.is_using_unity():
 
             # For Ubuntu 12.10 and above, try to use dconf:
-            # see if unity dock is hiden => unity_hide
-            # and the width of unity dock. => unity_dock
+            # see if unity dock is hidden => unity_hide
+            # and the width of unity dock => unity_dock
+            # and the position of the unity dock. => unity_pos
             found = False
             unity_hide = 0
+            unity_pos = "Left"
             # float() conversion might mess things up. Add 0.01 so the comparison will always be
             # valid, even in case of float("10.10") = 10.099999999999999
             if float(platform.linux_distribution()[1]) + 0.01 >= 12.10:
@@ -1022,6 +1024,9 @@ class Guake(SimpleGladeApp):
                     unity_dock = int(subprocess.check_output(
                         ['/usr/bin/dconf', 'read',
                          '/org/compiz/profiles/unity/plugins/unityshell/icon-size']) or "48")
+                    unity_pos = subprocess.check_output(
+                        ['/usr/bin/dconf', 'read',
+                         '/com/canonical/unity/launcher/launcher-position']) or "Left"
                     found = True
                 except:
                     # in case of error, just ignore it, 'found' will not be set to True and so
@@ -1036,9 +1041,11 @@ class Guake(SimpleGladeApp):
                 unity_dock = unity_icon_size + 17
 
             # launcher_hide_mode = 1 => autohide
-            if unity_hide != 1:
-                self.printDebug("correcting window width because of launcher width %s "
-                                "(from %s to %s)",
+            # only adjust guake window width if Unity dock is positioned "Left" or "Right"
+            if unity_hide != 1 and (unity_pos == "Left" or unity_pos == "Right") :
+                self.printDebug("correcting window width because of launcher position %s "
+                                "and width %s (from %s to %s)",
+                                unity_pos,
                                 unity_dock,
                                 window_rect.width,
                                 window_rect.width - unity_dock)

--- a/src/guake/guake_app.py
+++ b/src/guake/guake_app.py
@@ -34,7 +34,6 @@ import platform
 import pygtk
 import subprocess
 import sys
-import traceback
 import uuid
 import xdg.Exceptions
 
@@ -298,6 +297,23 @@ class Guake(SimpleGladeApp):
 
         self.abbreviate = False
         self.was_deleted_tab = False
+
+        def tabs_scrollbar_hide(hscrollbar):
+            self.get_widget('event-tabs').set_property('height_request', 10)
+            if self.abbreviate and self.was_deleted_tab:
+                self.was_deleted_tab = False
+                self.abbreviate = False
+                self.recompute_tabs_titles()
+
+        def tabs_scrollbar_show(hscrollbar):
+            self.get_widget('event-tabs').set_property('height_request', -1)
+            if self.client.get_bool(KEY("/general/abbreviate_tab_names")):
+                self.abbreviate = True
+                self.recompute_tabs_titles()
+
+        tabs_scrollbar = self.get_widget('tabs-scrolledwindow').get_hscrollbar()
+        tabs_scrollbar.connect('hide', tabs_scrollbar_hide)
+        tabs_scrollbar.connect('show', tabs_scrollbar_show)
 
         # Flag to prevent guake hide when window_losefocus is true and
         # user tries to use the context menu.
@@ -833,8 +849,21 @@ class Guake(SimpleGladeApp):
         if not self.notebook.has_term():
             self.add_tab()
 
+        try:
+            # does it work in other gtk backends
+            time = gtk.gdk.x11_get_server_time(self.window.window)
+        except:
+            time = 0
+
         self.window.set_keep_below(False)
+        self.printDebug("order to present and deiconify")
+        self.window.present()
+        self.window.deiconify()
+        self.window.window.deiconify()
         self.window.show_all()
+        self.window.window.focus(time)
+        self.window.set_type_hint(gtk.gdk.WINDOW_TYPE_HINT_DOCK)
+        self.window.set_type_hint(gtk.gdk.WINDOW_TYPE_HINT_NORMAL)
 
         if self.selected_color is None:
             self.selected_color = getattr(self.window.get_style(), "light")[int(gtk.STATE_SELECTED)]
@@ -853,12 +882,6 @@ class Guake(SimpleGladeApp):
         # this work arround an issue in fluxbox
         if not self.is_fullscreen:
             self.client.notify(KEY('/general/window_height'))
-
-        try:
-            # does it work in other gtk backends
-            time = gtk.gdk.x11_get_server_time(self.window.window)
-        except AttributeError:
-            time = 0
 
         # When minized, the window manager seems to refuse to resume
         # log.debug("self.window: %s. Dir=%s", type(self.window), dir(self.window))
@@ -879,15 +902,6 @@ class Guake(SimpleGladeApp):
         #     glib.timeout_add_seconds(1, lambda: self.timeout_restore(time))
         #
 
-        self.printDebug("order to present and deiconify")
-        self.window.present()
-        self.window.deiconify()
-        self.window.window.deiconify()
-        self.window.window.show()
-        self.window.window.focus(time)
-        self.window.set_type_hint(gtk.gdk.WINDOW_TYPE_HINT_DOCK)
-        self.window.set_type_hint(gtk.gdk.WINDOW_TYPE_HINT_NORMAL)
-
         # log.debug("Restoring skip_taskbar_hint and skip_pager_hint")
         # if is_iconified:
         #     self.get_widget('window-root').set_skip_taskbar_hint(False)
@@ -900,7 +914,6 @@ class Guake(SimpleGladeApp):
         self.client.notify(KEY('/style/background/color'))
 
         self.printDebug("Current window position: %r", self.window.get_position())
-        self.execute_hook('show')
 
     def hide_from_remote(self):
         """
@@ -1041,8 +1054,8 @@ class Guake(SimpleGladeApp):
                 unity_dock = unity_icon_size + 17
 
             # launcher_hide_mode = 1 => autohide
-            # only adjust guake window width if Unity dock is positioned "Left" or "Right"
-            if unity_hide != 1 and (unity_pos == "Left" or unity_pos == "Right") :
+            # only adjust guake window width if Unity dock is positioned left or right
+            if unity_hide != 1 and (unity_pos == "Left" or unity_pos == "Right"):
                 self.printDebug("correcting window width because of launcher position %s "
                                 "and width %s (from %s to %s)",
                                 unity_pos,
@@ -1055,7 +1068,7 @@ class Guake(SimpleGladeApp):
         total_width = window_rect.width
         total_height = window_rect.height
 
-        self.printDebug("Correcteed monitor size:")
+        self.printDebug("Corrected monitor size:")
         self.printDebug("  total_width: %s", total_width)
         self.printDebug("  total_height: %s", total_height)
 
@@ -1136,7 +1149,6 @@ class Guake(SimpleGladeApp):
         self.client.notify(KEY('/style/background/image'))
         self.client.notify(KEY('/style/background/transparency'))
         self.client.notify(KEY('/general/use_default_font'))
-        self.client.notify(KEY('/general/show_resizer'))
         self.client.notify(KEY('/general/use_palette_font_and_background_color'))
         self.client.notify(KEY('/general/compat_backspace'))
         self.client.notify(KEY('/general/compat_delete'))
@@ -1429,9 +1441,7 @@ class Guake(SimpleGladeApp):
         tab = self.tabs.get_children()[page]
         # if tab has been renamed by user, don't override.
         if not getattr(tab, 'custom_label_set', False):
-            vte_title = self.compute_tab_title(vte)
-            tab.set_label(vte_title)
-            gtk.Tooltips().set_tip(tab, vte_title)
+            tab.set_label(self.compute_tab_title(vte))
 
     def on_rename_current_tab_activate(self, *args):
         """Shows a dialog to rename the current tab.
@@ -1978,23 +1988,3 @@ class Guake(SimpleGladeApp):
         current_term = self.notebook.get_current_terminal()
         current_term.reset(full=True, clear_history=True)
         self.preventHide = False
-
-    def execute_hook(self, event_name):
-        """Execute shell commands related to current event_name"""
-        hook = self.client.get_string(KEY("/hooks/%s" % event_name))
-        if hook is not None:
-            hook = hook.split()
-            try:
-                subprocess.Popen(hook)
-            except OSError as oserr:
-                if oserr.errno == 8:
-                    log.error("Hook execution failed! Check shebang at first line of %s!", hook)
-                    log.debug(traceback.format_exc())
-                else:
-                    log.error(str(oserr))
-            except Exception as e:
-                log.error("hook execution failed! %s", e)
-                log.debug(traceback.format_exc())
-            else:
-                log.debug('hook on event %s has been executed', event_name)
-        return


### PR DESCRIPTION
Addresses #422, #522, #565 when Unity dock is used on the bottom of the screen by adding a check for the dock's position; modify Guake's width to account for the Unity dock's width **iff** the dock is positioned "Left" or "Right".