### PR TITLE
Update autogen.sh now gnome-common is obsolete

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,21 +1,37 @@
 #!/bin/sh
 # Run this to generate all the initial makefiles, etc.
+test -n "$srcdir" || srcdir=$(dirname "$0")
+test -n "$srcdir" || srcdir=.
 
-srcdir=`dirname $0`
-test -z "$srcdir" && srcdir=.
+olddir=$(pwd)
 
-PKG_NAME="guake"
+cd $srcdir
 
-(test -f $srcdir/src/guake/guake) || {
-    echo -n "**Error**: Directory "\`$srcdir\'" does not look like the"
-    echo " top-level $PKG_NAME directory"
-    exit 1
+(test -f configure.ac) || {
+        echo "*** ERROR: Directory '$srcdir' does not look like the top-level project directory ***"
+        exit 1
 }
 
-which gnome-autogen.sh || {
-    echo "You need to install gnome-common from GNOME SVN and make"
-    echo "sure the gnome-autogen.sh script is in your \$PATH."
-    exit 1
-}
+# shellcheck disable=SC2016
+PKG_NAME=$(autoconf --trace 'AC_INIT:$1' configure.ac)
 
-REQUIRED_AUTOMAKE_VERSION=1.9 USE_GNOME2_MACROS=1 . gnome-autogen.sh $@
+if [ "$#" = 0 -a "x$NOCONFIGURE" = "x" ]; then
+        echo "*** WARNING: I am going to run 'configure' with no arguments." >&2
+        echo "*** If you wish to pass any to it, please specify them on the" >&2
+        echo "*** '$0' command line." >&2
+        echo "" >&2
+fi
+
+intltoolize --force --copy --automake || exit 1
+autoreconf --verbose --force --install || exit 1
+
+cd "$olddir"
+if [ "$NOCONFIGURE" = "" ]; then
+        $srcdir/configure "$@" || exit 1
+
+        if [ "$1" = "--help" ]; then exit 0 else
+                echo "Now type 'make' to compile $PKG_NAME" || exit 1
+        fi
+else
+        echo "Skipping configure process."
+fi

--- a/autogen.sh
+++ b/autogen.sh
@@ -22,6 +22,7 @@ if [ "$#" = 0 -a "x$NOCONFIGURE" = "x" ]; then
         echo "" >&2
 fi
 
+aclocal --install || exit 1
 intltoolize --force --copy --automake || exit 1
 autoreconf --verbose --force --install || exit 1
 


### PR DESCRIPTION
I've just replaced with the template from
https://wiki.gnome.org/Projects/GnomeCommon/Migration

and added the following line as suggested for intltoolize (which
itself is "almost obsolete"
`intltoolize --force --copy --automake || exit 1`