### PR TITLE
Move the startup script setting to the Hooks tab

### DIFF
--- a/data/prefs.glade
+++ b/data/prefs.glade
@@ -212,38 +212,6 @@
 				  <property name="column_spacing">0</property>
 
 				  <child>
-				    <widget class="GtkEntry" id="startup_script">
-				      <property name="visible">True</property>
-				      <property name="tooltip" translatable="yes">Path to a bash script that would be automatically executed when Guake starts, unless you specify --no-startup-script.
-
-This would typically use the configuration by command line feature of Guake:
-
-#!/bin/bash
-
-sleep 5  # it is advised to wait a bit before Guake has been successfully started
-
-guake -r &quot;main&quot; -e &quot;cd ~/projects/myproject/main&quot;
-guake -r &quot;prod&quot; -e &quot;cd ~/projects/myproject/prod&quot;
-</property>
-				      <property name="can_focus">True</property>
-				      <property name="editable">True</property>
-				      <property name="visibility">True</property>
-				      <property name="max_length">0</property>
-				      <property name="text" translatable="yes"></property>
-				      <property name="has_frame">True</property>
-				      <property name="invisible_char">•</property>
-				      <property name="activates_default">False</property>
-				      <signal name="changed" handler="on_startup_script_changed"/>
-				    </widget>
-				    <packing>
-				      <property name="left_attach">1</property>
-				      <property name="right_attach">2</property>
-				      <property name="top_attach">3</property>
-				      <property name="bottom_attach">4</property>
-				    </packing>
-				  </child>
-
-				  <child>
 				    <widget class="GtkCheckButton" id="use_popup">
 				      <property name="visible">True</property>
 				      <property name="can_focus">True</property>
@@ -349,33 +317,7 @@ guake -r &quot;prod&quot; -e &quot;cd ~/projects/myproject/prod&quot;
 				    </packing>
 				  </child>
 
-				  <child>
-				    <widget class="GtkLabel" id="lbl_startup_script">
-				      <property name="width_request">160</property>
-				      <property name="visible">True</property>
-				      <property name="label" translatable="yes">Path to script executed on Guake start:</property>
-				      <property name="use_underline">False</property>
-				      <property name="use_markup">True</property>
-				      <property name="justify">GTK_JUSTIFY_LEFT</property>
-				      <property name="wrap">False</property>
-				      <property name="selectable">False</property>
-				      <property name="xalign">0</property>
-				      <property name="yalign">0.5</property>
-				      <property name="xpad">0</property>
-				      <property name="ypad">0</property>
-				      <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-				      <property name="width_chars">-1</property>
-				      <property name="single_line_mode">True</property>
-				      <property name="angle">0</property>
-				    </widget>
-				    <packing>
-				      <property name="left_attach">1</property>
-				      <property name="right_attach">2</property>
-				      <property name="top_attach">2</property>
-				      <property name="bottom_attach">3</property>
-				    </packing>
-				  </child>
-
+				 
 				  <child>
 				    <widget class="GtkHBox" id="hbox1">
 				      <property name="visible">True</property>
@@ -3972,6 +3914,68 @@ For details, see https://github.com/Guake/guake/issues/793</property>
 					      <property name="y_options"></property>
 					    </packing>
 					  </child>
+					   
+					  <child>
+					    <widget class="GtkEntry" id="startup_script">
+					      <property name="visible">True</property>
+					      <property name="tooltip" translatable="yes">Path to a bash script that would be automatically executed when Guake starts, unless you specify --no-startup-script.
+
+This would typically use the configuration by command line feature of Guake:
+
+#!/bin/bash
+
+sleep 5  # it is advised to wait a bit before Guake has been successfully started
+
+guake -r &quot;main&quot; -e &quot;cd ~/projects/myproject/main&quot;
+guake -r &quot;prod&quot; -e &quot;cd ~/projects/myproject/prod&quot;
+</property>
+					      <property name="can_focus">True</property>
+					      <property name="editable">True</property>
+					      <property name="visibility">True</property>
+					      <property name="max_length">0</property>
+					      <property name="text" translatable="yes"></property>
+					      <property name="has_frame">True</property>
+					      <property name="invisible_char">•</property>
+					      <property name="activates_default">False</property>
+					      <signal name="changed" handler="on_startup_script_changed"/>
+					    </widget>
+					    <packing>
+					      <property name="left_attach">1</property>
+					      <property name="right_attach">2</property>
+					      <property name="top_attach">1</property>
+					      <property name="bottom_attach">2</property>
+					    </packing>
+					  </child>
+					    
+					  <child>
+					    <widget class="GtkLabel" id="lbl_startup_script">
+					      <property name="width_request">160</property>
+					      <property name="visible">True</property>
+                          <property name="label" translatable="yes">On start:</property>
+					      <property name="use_underline">False</property>
+					      <property name="use_markup">True</property>
+					      <property name="justify">GTK_JUSTIFY_LEFT</property>
+					      <property name="wrap">False</property>
+					      <property name="selectable">False</property>
+					      <property name="xalign">0</property>
+					      <property name="yalign">0.5</property>
+					      <property name="xpad">10</property>
+					      <property name="ypad">10</property>
+					      <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+					      <property name="width_chars">-1</property>
+					      <property name="single_line_mode">False</property>
+					      <property name="angle">0</property>
+					    </widget>
+					   <packing>
+					      <property name="left_attach">0</property>
+					      <property name="right_attach">1</property>
+					      <property name="top_attach">1</property>
+					      <property name="bottom_attach">2</property>
+					      <property name="x_options">fill</property>
+					      <property name="y_options"></property>
+					    </packing>
+					  </child>
+					  
 					</widget>
 					<packing>
 					  <property name="padding">0</property>

--- a/po/de.po
+++ b/po/de.po
@@ -10,15 +10,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Guake 0.4.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-07 13:00+0200\n"
-"PO-Revision-Date: 2017-08-07 13:51+0200\n"
+"POT-Creation-Date: 2017-08-20 18:56+0200\n"
+"PO-Revision-Date: 2017-08-20 19:09+0200\n"
 "Last-Translator: Mario Aichinger <aichingm@gmail.com>\n"
 "Language-Team: guake@lists.guake.org\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.0.2\n"
+"X-Generator: Poedit 2.0.3\n"
 
 #: ../data/about.glade.h:1
 msgid "About Guake"
@@ -172,6 +172,421 @@ msgstr ""
 "<span color=\"black\">Aussehen und Verhalten von Guake verändern!</span>"
 
 #: ../data/prefs.glade.h:4
+msgid "Enable popup notifications on startup"
+msgstr "Popup-Benachrichtigungen beim Start einschalten"
+
+#: ../data/prefs.glade.h:5
+msgid "Show tray icon"
+msgstr "Symbol in der Benachrichtigungsleiste anzeigen"
+
+#: ../data/prefs.glade.h:6
+msgid "Always prompt on quit"
+msgstr "Beim Beenden immer nachfragen"
+
+#: ../data/prefs.glade.h:7
+msgid "_Flash terminal on bell"
+msgstr "_Blinken bei Terminalglocke"
+
+#: ../data/prefs.glade.h:8
+msgid "_Play system alert sound on bell"
+msgstr "_Bei Terminalglocke Systemalarmton ausgeben"
+
+#: ../data/prefs.glade.h:9
+msgid "Prompt on close tab:"
+msgstr "Beim schließen eines Reiters nachfragen:"
+
+#: ../data/prefs.glade.h:10
+msgid ""
+"Never\n"
+"With process running\n"
+"Always"
+msgstr ""
+"Nie\n"
+"Bei laufendem Prozess\n"
+"Immer"
+
+#: ../data/prefs.glade.h:13
+msgid "<b>General</b>"
+msgstr "<b>Allgemein</b>"
+
+#: ../data/prefs.glade.h:14
+msgid "Bottom align window instead of top align"
+msgstr "Fenster an den unteren Rand statt an den oberen Rand setzen"
+
+#: ../data/prefs.glade.h:15
+msgid "Appear on mouse display"
+msgstr "Auf dem Mausbildschirm anzeigen"
+
+#: ../data/prefs.glade.h:16
+msgid "Appear on display:"
+msgstr "Anzeigedisplay:"
+
+#: ../data/prefs.glade.h:17
+msgid "Place tabs on top"
+msgstr "Reiter oben platzieren"
+
+#: ../data/prefs.glade.h:18
+msgid "<b>Placement</b>"
+msgstr "<b>Platzierung</b>"
+
+#: ../data/prefs.glade.h:19
+msgid "Stay on top"
+msgstr "Im Vordergrund bleiben"
+
+#: ../data/prefs.glade.h:20
+msgid "Refocus if open"
+msgstr "Fokus wiederherstellen wenn bereits geöffnet"
+
+#: ../data/prefs.glade.h:21
+msgid "Hide on lose focus"
+msgstr "Verstecken, wenn der Fokus verloren geht"
+
+#: ../data/prefs.glade.h:22
+msgid "Show tab bar"
+msgstr "Reiterleiste anzeigen"
+
+#: ../data/prefs.glade.h:23
+msgid "Start fullscreen"
+msgstr "Vollbild starten"
+
+#: ../data/prefs.glade.h:24
+msgid "Use VTE titles for tab names"
+msgstr "VTE-Titel als Reiternamen benutzen"
+
+#: ../data/prefs.glade.h:25
+msgid "Abbreviate directories in tab names"
+msgstr "Verzeichnisnamen in Reitern abkürzen"
+
+#: ../data/prefs.glade.h:26
+msgid "Max tab name length:"
+msgstr "Max. Tab-Namen-Länge:"
+
+#: ../data/prefs.glade.h:27
+msgid "<b>Main Window</b>"
+msgstr "<b>Hauptfenster</b>"
+
+#: ../data/prefs.glade.h:28
+msgid "Left"
+msgstr "Links"
+
+#: ../data/prefs.glade.h:29
+msgid "Center"
+msgstr "Mittig"
+
+#: ../data/prefs.glade.h:30
+msgid "Right"
+msgstr "Rechts"
+
+#: ../data/prefs.glade.h:31
+msgid "<b>Main Window Horizontal Alignment</b>"
+msgstr "<b>Horizontale Ausrichtung des Hauptfensters</b>"
+
+#: ../data/prefs.glade.h:32
+msgid "<b>Main Window Height</b>"
+msgstr "<b>Höhe des Hauptfensters</b>"
+
+#: ../data/prefs.glade.h:33
+msgid "<b>Main Window Width</b>"
+msgstr "<b>Breite des Hauptfensters</b>"
+
+#: ../data/prefs.glade.h:34
+msgid "Custom command file path: "
+msgstr "Benutzerdefinierter Befehl: "
+
+#: ../data/prefs.glade.h:35
+msgid "Please select a json file"
+msgstr "Bitte wählen Sie eine JSON-Datei aus"
+
+#: ../data/prefs.glade.h:36 ../src/guake/prefs.py:75
+msgid "General"
+msgstr "Allgemein"
+
+#: ../data/prefs.glade.h:37
+msgid "Default interpreter:"
+msgstr "Standard-Interpreter:"
+
+#: ../data/prefs.glade.h:38
+msgid "_Run command as a login shell"
+msgstr "Befehl als Loginshell ausführen"
+
+#: ../data/prefs.glade.h:39
+msgid "_Open new tab in current directory"
+msgstr "_Neuen Reiter in aktuellem Verzeichnis öffnen"
+
+#: ../data/prefs.glade.h:40
+msgid "<b>Shell</b>"
+msgstr "<b>Shell</b>"
+
+#: ../data/prefs.glade.h:41
+msgid "Shell"
+msgstr "Shell"
+
+#: ../data/prefs.glade.h:42
+msgid "Show scrollbar"
+msgstr "Scroll-Balken anzeigen"
+
+#: ../data/prefs.glade.h:43
+msgid "Scrollback lines:"
+msgstr "Zurückscrollbare Zeilen:"
+
+#: ../data/prefs.glade.h:44
+msgid "On output"
+msgstr "Bei Ausgabe"
+
+#: ../data/prefs.glade.h:45
+msgid "On key stroke"
+msgstr "Auf Tastendruck"
+
+#: ../data/prefs.glade.h:46
+msgid "<b>Scroll</b>"
+msgstr "<b>Bildlauf</b>"
+
+#: ../data/prefs.glade.h:47
+msgid "Scrolling"
+msgstr "Bildlauf"
+
+#: ../data/prefs.glade.h:48
+msgid "Use the system fixed width font"
+msgstr "Die dicktengleiche Systemschrift benutzen"
+
+#: ../data/prefs.glade.h:49
+msgid "Font:"
+msgstr "Schriftart:"
+
+#: ../data/prefs.glade.h:50
+msgid "Show resizer"
+msgstr "Größenänderer anzeigen"
+
+#: ../data/prefs.glade.h:51
+msgid "Choose some font"
+msgstr "Schrift auswählen"
+
+#: ../data/prefs.glade.h:52
+msgid "Text color:"
+msgstr "Schriftfarbe:"
+
+#: ../data/prefs.glade.h:53
+msgid "Background color:"
+msgstr "Hintergrundfarbe:"
+
+#: ../data/prefs.glade.h:54
+msgid "Cursor shape:"
+msgstr "Form des Text-Cursors:"
+
+#: ../data/prefs.glade.h:55
+msgid ""
+"Block\n"
+"I-Beam\n"
+"Underline"
+msgstr ""
+"Block\n"
+"I-Strich\n"
+"Unterstreichen"
+
+#: ../data/prefs.glade.h:58
+msgid ""
+"Follow GTK+ setting\n"
+"Blink on\n"
+"Blink off"
+msgstr ""
+"GTK+ Einstellung benutzen\n"
+"Blinken an\n"
+"Blinken aus"
+
+#: ../data/prefs.glade.h:61
+msgid "Cursor blink mode:"
+msgstr "Blinkmodus des Zeigers:"
+
+#: ../data/prefs.glade.h:62
+msgid "Allow bold font"
+msgstr "Schriftstärke fett erlauben"
+
+#: ../data/prefs.glade.h:63
+msgid "<b>Palette</b>"
+msgstr "<b>Farbpalette</b>"
+
+#: ../data/prefs.glade.h:64
+msgid "Built-in schemes:"
+msgstr "Eingebaute Schemata:"
+
+# changed according to translation as present in gnome-settings
+#: ../data/prefs.glade.h:65
+msgid "Color palette:"
+msgstr "Farbpalette:"
+
+#: ../data/prefs.glade.h:66
+msgid "Font color"
+msgstr "Schriftfarbe"
+
+#: ../data/prefs.glade.h:67
+msgid "Background color"
+msgstr "<b>Hintergrundfarbe</b>"
+
+#: ../data/prefs.glade.h:68
+msgid "Use font and background color from the palette"
+msgstr "Schriftart und Hintergrundfarbe der Farbpalette benutzen"
+
+#: ../data/prefs.glade.h:69
+msgid "Demo:"
+msgstr "Demo:"
+
+#: ../data/prefs.glade.h:70
+msgid "<b>Effects</b>"
+msgstr "<b>Effekte</b>"
+
+#: ../data/prefs.glade.h:71
+msgid "Transparency:"
+msgstr "Transparenz:"
+
+#: ../data/prefs.glade.h:72
+msgid "Background image:"
+msgstr "Hintergrundbild:"
+
+#: ../data/prefs.glade.h:73
+msgid "Select A File"
+msgstr "Datei auswählen"
+
+#: ../data/prefs.glade.h:74 ../src/guake/prefs.py:130
+msgid "Appearance"
+msgstr "Aussehen"
+
+#: ../data/prefs.glade.h:75
+msgid ""
+"<small>Quick open is a feature allowing you to open a file directly into "
+"your favorite text editor by clicking on its filename when it appears in "
+"your terminal. See the list of currently supported text patterns used to "
+"extract filename below.</small>"
+msgstr ""
+"<small>Schnell-Öffnen bietet die Möglichkeit, eine Datei direkt in einem "
+"bevorzugten Text-Editor durch klicken auf den Dateinamen zu öffnen, wenn er "
+"im Terminal erscheint. In der Liste der verfügbaren Text-Muster finden sich "
+"Beispiele, wie der Dateiname aus dem Terminal extrahiert werden kann.</small>"
+
+#: ../data/prefs.glade.h:76
+msgid "Enable Quick Open when Ctrl+clicking on a filename in the terminal"
+msgstr ""
+"Schnell-Öffnen bei Strg+Klick auf einen Dateinamen im Terminal aktivieren"
+
+#: ../data/prefs.glade.h:77
+msgid "Editor command line:"
+msgstr "Kommandozeilen"
+
+#: ../data/prefs.glade.h:79
+#, no-c-format
+msgid ""
+"<small><i>Use the following elements in the open editor command line:\n"
+" - <b>%(file_path)s</b>: path to the file that has been clicked\n"
+" - <b>%(line_number)s</b>: if your editor supports it, you can directly open "
+"the file to a given line number when found on the screen.\n"
+"\n"
+"For example, for sublime, use <b>subl %(file_path)s:%(line_number)s</b>\n"
+"</i></small>"
+msgstr ""
+"<small><i>Benutze die folgenden Platzhalter in der \"Öffnen mit Editor\" "
+"Zeile:\n"
+" - <b>%(file_path)s</b>: Pfad zu der Datei die angeklickt wurde.\n"
+" - <b>%(line_number)s</b>: falls der Editor es unterstützt, kannst du die "
+"Datei direkt an der angegebenen Zeilennummer öffnen, wenn diese vorhanden "
+"ist.\n"
+"\n"
+"Zum Beispiel benutze sublime mit: <b>subl %(file_path)s:%(line_number)s</b>\n"
+"</i></small>"
+
+#: ../data/prefs.glade.h:85
+msgid "Quick open in current terminal"
+msgstr "Schnell-Öffnen im Terminal"
+
+#: ../data/prefs.glade.h:86
+msgid ""
+"Here is the list of supported patterns: (to add your own, please contact the "
+"Guake's authors)"
+msgstr ""
+"Hier ist eine Liste der unterstützen Muster: (um Eigene hinzuzufügen, "
+"kontaktiere bitte die Autoren von Guake)"
+
+#: ../data/prefs.glade.h:87
+msgid "<b>Quick Open</b>"
+msgstr "<b>Schnell öffnen</b>"
+
+#: ../data/prefs.glade.h:88
+msgid "Quick Open"
+msgstr "Schnell öffnen"
+
+#: ../data/prefs.glade.h:89
+msgid ""
+"To change a shortcut simply click on its name.\n"
+"To disable a shortcut, press the \"Backspace\" key."
+msgstr ""
+"Um eine Tastenkombination zu ändern, klicke auf dessen Namen.\n"
+"Um eine Tastenkombination abzuschalten, drücke die \"Rücktaste\"."
+
+#: ../data/prefs.glade.h:91
+msgid "Keyboard shortcuts"
+msgstr "Tastenkombination"
+
+#: ../data/prefs.glade.h:92
+msgid ""
+"<small><i><b>Note:</b> These options may cause some applications to behave "
+"incorrectly.  They are only here to allow you to work around certain "
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
+msgstr ""
+"<small><i><b>Notiz:</b> Diese Optionen könnten dazu führen, dass andere "
+"Programme nicht mehr ordnungsgemäß funktionieren. Diese Optionen dienen nur "
+"dazu verschiedene Programme und Systeme zu unterstützen, die ein anderes "
+"Terminalverhalten besitzen\" </i></small>"
+
+#: ../data/prefs.glade.h:93
+msgid ""
+"ASCII DEL\n"
+"Escape sequence\n"
+"Control-H"
+msgstr ""
+"ASCII DEL\n"
+"Escape Sequenz\n"
+"Strg-H"
+
+#: ../data/prefs.glade.h:96
+msgid "_Backspace key generates:"
+msgstr "_Rückschritttaste bewirkt:"
+
+#: ../data/prefs.glade.h:97
+msgid "_Delete key generates:"
+msgstr "_Entfernen-Taste bewirkt:"
+
+#: ../data/prefs.glade.h:98
+msgid "_Reset Compatibility Options to Defaults"
+msgstr "_Zurücksetzen der Kompatibilitätsoptionen"
+
+#: ../data/prefs.glade.h:99
+msgid "<b>Keyboard compatibility</b>"
+msgstr "<b>Tastatur Kompatibilität </b>"
+
+#: ../data/prefs.glade.h:100
+msgid "Compatibility"
+msgstr "Kompatibilität"
+
+#: ../data/prefs.glade.h:101
+msgid ""
+"<small>In this dialog you can attach your own command or script to various "
+"guake events</small>"
+msgstr ""
+"<small>In diesem Dialog können Sie ihr eigenes Kommando oder Skript mit "
+"verschiedenen Guake-Events verknüpfen</small>"
+
+#: ../data/prefs.glade.h:102
+msgid ""
+"Insert command or path to script.\n"
+"For details, see https://github.com/Guake/guake/issues/793"
+msgstr ""
+"Kommando oder Path zu einem Skript einfühgen.\n"
+"Für Details siehe: https://github.com/Guake/guake/issues/793"
+
+#: ../data/prefs.glade.h:104
+msgid "On show:"
+msgstr "Beim Anzeigen:"
+
+#: ../data/prefs.glade.h:105
 msgid ""
 "Path to a bash script that would be automatically executed when Guake "
 "starts, unless you specify --no-startup-script.\n"
@@ -198,424 +613,9 @@ msgstr ""
 "\\nguake -r \"main\" -e \"cd ~/projects/myproject/main\"\n"
 "guake -r \"prod\" -e \"cd ~/projects/myproject/prod\"\n"
 
-#: ../data/prefs.glade.h:15
-msgid "Enable popup notifications on startup"
-msgstr "Popup-Benachrichtigungen beim Start einschalten"
-
-#: ../data/prefs.glade.h:16
-msgid "Show tray icon"
-msgstr "Symbol in der Benachrichtigungsleiste anzeigen"
-
-#: ../data/prefs.glade.h:17
-msgid "Always prompt on quit"
-msgstr "Beim Beenden immer nachfragen"
-
-#: ../data/prefs.glade.h:18
-msgid "_Flash terminal on bell"
-msgstr "_Blinken bei Terminalglocke"
-
-#: ../data/prefs.glade.h:19
-msgid "_Play system alert sound on bell"
-msgstr "_Bei Terminalglocke Systemalarmton ausgeben"
-
-#: ../data/prefs.glade.h:20
-msgid "Path to script executed on Guake start:"
-msgstr "Pfad zu einem Skript das beim Start ausgeführt wird:"
-
-#: ../data/prefs.glade.h:21
-msgid "Prompt on close tab:"
-msgstr "Beim schließen eines Reiters nachfragen:"
-
-#: ../data/prefs.glade.h:22
-msgid ""
-"Never\n"
-"With process running\n"
-"Always"
-msgstr ""
-"Nie\n"
-"Bei laufendem Prozess\n"
-"Immer"
-
-#: ../data/prefs.glade.h:25
-msgid "<b>General</b>"
-msgstr "<b>Allgemein</b>"
-
-#: ../data/prefs.glade.h:26
-msgid "Bottom align window instead of top align"
-msgstr "Fenster an den unteren Rand statt an den oberen Rand setzen"
-
-#: ../data/prefs.glade.h:27
-msgid "Appear on mouse display"
-msgstr "Auf dem Mausbildschirm anzeigen"
-
-#: ../data/prefs.glade.h:28
-msgid "Appear on display:"
-msgstr "Anzeigedisplay:"
-
-#: ../data/prefs.glade.h:29
-msgid "Place tabs on top"
-msgstr "Reiter oben platzieren"
-
-#: ../data/prefs.glade.h:30
-msgid "<b>Placement</b>"
-msgstr "<b>Platzierung</b>"
-
-#: ../data/prefs.glade.h:31
-msgid "Stay on top"
-msgstr "Im Vordergrund bleiben"
-
-#: ../data/prefs.glade.h:32
-msgid "Refocus if open"
-msgstr "Fokus wiederherstellen wenn bereits geöffnet"
-
-#: ../data/prefs.glade.h:33
-msgid "Hide on lose focus"
-msgstr "Verstecken, wenn der Fokus verloren geht"
-
-#: ../data/prefs.glade.h:34
-msgid "Show tab bar"
-msgstr "Reiterleiste anzeigen"
-
-#: ../data/prefs.glade.h:35
-msgid "Start fullscreen"
-msgstr "Vollbild starten"
-
-#: ../data/prefs.glade.h:36
-msgid "Use VTE titles for tab names"
-msgstr "VTE-Titel als Reiternamen benutzen"
-
-#: ../data/prefs.glade.h:37
-msgid "Abbreviate directories in tab names"
-msgstr "Verzeichnisnamen in Reitern abkürzen"
-
-#: ../data/prefs.glade.h:38
-msgid "Max tab name length:"
-msgstr "Max. Tab-Namen-Länge:"
-
-#: ../data/prefs.glade.h:39
-msgid "<b>Main Window</b>"
-msgstr "<b>Hauptfenster</b>"
-
-#: ../data/prefs.glade.h:40
-msgid "Left"
-msgstr "Links"
-
-#: ../data/prefs.glade.h:41
-msgid "Center"
-msgstr "Mittig"
-
-#: ../data/prefs.glade.h:42
-msgid "Right"
-msgstr "Rechts"
-
-#: ../data/prefs.glade.h:43
-msgid "<b>Main Window Horizontal Alignment</b>"
-msgstr "<b>Horizontale Ausrichtung des Hauptfensters</b>"
-
-#: ../data/prefs.glade.h:44
-msgid "<b>Main Window Height</b>"
-msgstr "<b>Höhe des Hauptfensters</b>"
-
-#: ../data/prefs.glade.h:45
-msgid "<b>Main Window Width</b>"
-msgstr "<b>Breite des Hauptfensters</b>"
-
-#: ../data/prefs.glade.h:46
-msgid "Custom command file path: "
-msgstr "Benutzerdefinierter Befehl: "
-
-#: ../data/prefs.glade.h:47
-msgid "Please select a json file"
-msgstr "Bitte wählen Sie eine JSON-Datei aus"
-
-#: ../data/prefs.glade.h:48 ../src/guake/prefs.py:75
-msgid "General"
-msgstr "Allgemein"
-
-#: ../data/prefs.glade.h:49
-msgid "Default interpreter:"
-msgstr "Standard-Interpreter:"
-
-#: ../data/prefs.glade.h:50
-msgid "_Run command as a login shell"
-msgstr "Befehl als Loginshell ausführen"
-
-#: ../data/prefs.glade.h:51
-msgid "_Open new tab in current directory"
-msgstr "_Neuen Reiter in aktuellem Verzeichnis öffnen"
-
-#: ../data/prefs.glade.h:52
-msgid "<b>Shell</b>"
-msgstr "<b>Shell</b>"
-
-#: ../data/prefs.glade.h:53
-msgid "Shell"
-msgstr "Shell"
-
-#: ../data/prefs.glade.h:54
-msgid "Show scrollbar"
-msgstr "Scroll-Balken anzeigen"
-
-#: ../data/prefs.glade.h:55
-msgid "Scrollback lines:"
-msgstr "Zurückscrollbare Zeilen:"
-
-#: ../data/prefs.glade.h:56
-msgid "On output"
-msgstr "Bei Ausgabe"
-
-#: ../data/prefs.glade.h:57
-msgid "On key stroke"
-msgstr "Auf Tastendruck"
-
-#: ../data/prefs.glade.h:58
-msgid "<b>Scroll</b>"
-msgstr "<b>Bildlauf</b>"
-
-#: ../data/prefs.glade.h:59
-msgid "Scrolling"
-msgstr "Bildlauf"
-
-#: ../data/prefs.glade.h:60
-msgid "Use the system fixed width font"
-msgstr "Die dicktengleiche Systemschrift benutzen"
-
-#: ../data/prefs.glade.h:61
-msgid "Font:"
-msgstr "Schriftart:"
-
-#: ../data/prefs.glade.h:62
-msgid "Show resizer"
-msgstr "Größenänderer anzeigen"
-
-#: ../data/prefs.glade.h:63
-msgid "Choose some font"
-msgstr "Schrift auswählen"
-
-#: ../data/prefs.glade.h:64
-msgid "Text color:"
-msgstr "Schriftfarbe:"
-
-#: ../data/prefs.glade.h:65
-msgid "Background color:"
-msgstr "Hintergrundfarbe:"
-
-#: ../data/prefs.glade.h:66
-msgid "Cursor shape:"
-msgstr "Form des Text-Cursors:"
-
-#: ../data/prefs.glade.h:67
-msgid ""
-"Block\n"
-"I-Beam\n"
-"Underline"
-msgstr ""
-"Block\n"
-"I-Strich\n"
-"Unterstreichen"
-
-#: ../data/prefs.glade.h:70
-msgid ""
-"Follow GTK+ setting\n"
-"Blink on\n"
-"Blink off"
-msgstr ""
-"GTK+ Einstellung benutzen\n"
-"Blinken an\n"
-"Blinken aus"
-
-#: ../data/prefs.glade.h:73
-msgid "Cursor blink mode:"
-msgstr "Blinkmodus des Zeigers:"
-
-#: ../data/prefs.glade.h:74
-msgid "Allow bold font"
-msgstr "Schriftstärke fett erlauben"
-
-#: ../data/prefs.glade.h:75
-msgid "<b>Palette</b>"
-msgstr "<b>Farbpalette</b>"
-
-#: ../data/prefs.glade.h:76
-msgid "Built-in schemes:"
-msgstr "Eingebaute Schemata:"
-
-# changed according to translation as present in gnome-settings
-#: ../data/prefs.glade.h:77
-msgid "Color palette:"
-msgstr "Farbpalette:"
-
-#: ../data/prefs.glade.h:78
-msgid "Font color"
-msgstr "Schriftfarbe"
-
-#: ../data/prefs.glade.h:79
-msgid "Background color"
-msgstr "<b>Hintergrundfarbe</b>"
-
-#: ../data/prefs.glade.h:80
-msgid "Use font and background color from the palette"
-msgstr "Schriftart und Hintergrundfarbe der Farbpalette benutzen"
-
-#: ../data/prefs.glade.h:81
-msgid "Demo:"
-msgstr "Demo:"
-
-#: ../data/prefs.glade.h:82
-msgid "<b>Effects</b>"
-msgstr "<b>Effekte</b>"
-
-#: ../data/prefs.glade.h:83
-msgid "Transparency:"
-msgstr "Transparenz:"
-
-#: ../data/prefs.glade.h:84
-msgid "Background image:"
-msgstr "Hintergrundbild:"
-
-#: ../data/prefs.glade.h:85
-msgid "Select A File"
-msgstr "Datei auswählen"
-
-#: ../data/prefs.glade.h:86 ../src/guake/prefs.py:130
-msgid "Appearance"
-msgstr "Aussehen"
-
-#: ../data/prefs.glade.h:87
-msgid ""
-"<small>Quick open is a feature allowing you to open a file directly into "
-"your favorite text editor by clicking on its filename when it appears in "
-"your terminal. See the list of currently supported text patterns used to "
-"extract filename below.</small>"
-msgstr ""
-"<small>Schnell-Öffnen bietet die Möglichkeit, eine Datei direkt in einem "
-"bevorzugten Text-Editor durch klicken auf den Dateinamen zu öffnen, wenn er "
-"im Terminal erscheint. In der Liste der verfügbaren Text-Muster finden sich "
-"Beispiele, wie der Dateiname aus dem Terminal extrahiert werden kann.</small>"
-
-#: ../data/prefs.glade.h:88
-msgid "Enable Quick Open when Ctrl+clicking on a filename in the terminal"
-msgstr ""
-"Schnell-Öffnen bei Strg+Klick auf einen Dateinamen im Terminal aktivieren"
-
-#: ../data/prefs.glade.h:89
-msgid "Editor command line:"
-msgstr "Kommandozeilen"
-
-#: ../data/prefs.glade.h:91
-#, no-c-format
-msgid ""
-"<small><i>Use the following elements in the open editor command line:\n"
-" - <b>%(file_path)s</b>: path to the file that has been clicked\n"
-" - <b>%(line_number)s</b>: if your editor supports it, you can directly open "
-"the file to a given line number when found on the screen.\n"
-"\n"
-"For example, for sublime, use <b>subl %(file_path)s:%(line_number)s</b>\n"
-"</i></small>"
-msgstr ""
-"<small><i>Benutze die folgenden Platzhalter in der \"Öffnen mit Editor\" "
-"Zeile:\n"
-" - <b>%(file_path)s</b>: Pfad zu der Datei die angeklickt wurde.\n"
-" - <b>%(line_number)s</b>: falls der Editor es unterstützt, kannst du die "
-"Datei direkt an der angegebenen Zeilennummer öffnen, wenn diese vorhanden "
-"ist.\n"
-"\n"
-"Zum Beispiel benutze sublime mit: <b>subl %(file_path)s:%(line_number)s</b>\n"
-"</i></small>"
-
-#: ../data/prefs.glade.h:97
-msgid "Quick open in current terminal"
-msgstr "Schnell-Öffnen im Terminal"
-
-#: ../data/prefs.glade.h:98
-msgid ""
-"Here is the list of supported patterns: (to add your own, please contact the "
-"Guake's authors)"
-msgstr ""
-"Hier ist eine Liste der unterstützen Muster: (um Eigene hinzuzufügen, "
-"kontaktiere bitte die Autoren von Guake)"
-
-#: ../data/prefs.glade.h:99
-msgid "<b>Quick Open</b>"
-msgstr "<b>Schnell öffnen</b>"
-
-#: ../data/prefs.glade.h:100
-msgid "Quick Open"
-msgstr "Schnell öffnen"
-
-#: ../data/prefs.glade.h:101
-msgid ""
-"To change a shortcut simply click on its name.\n"
-"To disable a shortcut, press the \"Backspace\" key."
-msgstr ""
-"Um eine Tastenkombination zu ändern, klicke auf dessen Namen.\n"
-"Um eine Tastenkombination abzuschalten, drücke die \"Rücktaste\"."
-
-#: ../data/prefs.glade.h:103
-msgid "Keyboard shortcuts"
-msgstr "Tastenkombination"
-
-#: ../data/prefs.glade.h:104
-msgid ""
-"<small><i><b>Note:</b> These options may cause some applications to behave "
-"incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal behavior.</"
-"i></small>"
-msgstr ""
-"<small><i><b>Notiz:</b> Diese Optionen könnten dazu führen, dass andere "
-"Programme nicht mehr ordnungsgemäß funktionieren. Diese Optionen dienen nur "
-"dazu verschiedene Programme und Systeme zu unterstützen, die ein anderes "
-"Terminalverhalten besitzen\" </i></small>"
-
-#: ../data/prefs.glade.h:105
-msgid ""
-"ASCII DEL\n"
-"Escape sequence\n"
-"Control-H"
-msgstr ""
-"ASCII DEL\n"
-"Escape Sequenz\n"
-"Strg-H"
-
-#: ../data/prefs.glade.h:108
-msgid "_Backspace key generates:"
-msgstr "_Rückschritttaste bewirkt:"
-
-#: ../data/prefs.glade.h:109
-msgid "_Delete key generates:"
-msgstr "_Entfernen-Taste bewirkt:"
-
-#: ../data/prefs.glade.h:110
-msgid "_Reset Compatibility Options to Defaults"
-msgstr "_Zurücksetzen der Kompatibilitätsoptionen"
-
-#: ../data/prefs.glade.h:111
-msgid "<b>Keyboard compatibility</b>"
-msgstr "<b>Tastatur Kompatibilität </b>"
-
-#: ../data/prefs.glade.h:112
-msgid "Compatibility"
-msgstr "Kompatibilität"
-
-#: ../data/prefs.glade.h:113
-msgid ""
-"<small>In this dialog you can attach your own command or script to various "
-"guake events</small>"
-msgstr ""
-"<small>In diesem Dialog können Sie ihr eigenes Kommando oder Skript mit "
-"verschiedenen Guake-Events verknüpfen</small>"
-
-#: ../data/prefs.glade.h:114
-msgid ""
-"Insert command or path to script.\n"
-"For details, see https://github.com/Guake/guake/issues/793"
-msgstr ""
-"Kommando oder Path zu einem Skript einfühgen.\n"
-"Für Details siehe: https://github.com/Guake/guake/issues/793"
-
 #: ../data/prefs.glade.h:116
-msgid "On show:"
-msgstr "Beim Anzeigen:"
+msgid "On start:"
+msgstr "Beim Starten:"
 
 # From Wikipedia: https://de.wikipedia.org/wiki/Hook_(Informatik)
 #: ../data/prefs.glade.h:117
@@ -1024,6 +1024,9 @@ msgstr ""
 "möglich ist die Kombination zu benutzen.\n"
 "\n"
 "Versuchen Sie es mit den Tasten Strg, Alt oder Shift zur gleichen Zeit.\n"
+
+#~ msgid "Path to script executed on Guake start:"
+#~ msgstr "Pfad zu einem Skript das beim Start ausgeführt wird:"
 
 #~ msgid "key binding error"
 #~ msgstr "Fehler beim Ändern des Kürzels"


### PR DESCRIPTION
Move the text input used for the startup script setting to the `Hooks` tab and label it with "On start:".
This change makes the `General` tab a little less cluttered and populates the quite empty `Hooks` tab. It also updates the German translation for the changed label.
![guake-pref-startuphook](https://user-images.githubusercontent.com/6470959/29496942-244d1e00-85de-11e7-9a41-629da536e660.png)
