### PR TITLE
Add missing python-dbus dep to dev.sh

### DIFF
--- a/dev.sh
+++ b/dev.sh
@@ -54,7 +54,7 @@ if [[ $EXEC_AUTOGEN == true ]]; then
     sudo apt-get install -y python-gtk2 python-gtk2-dev python-vte glade python-glade2
     sudo apt-get install -y python-vte python-gconf python-appindicator
     sudo apt-get install -y notify-osd libutempter0 glade-gtk2
-    sudo apt-get install -y python-notify python-xdg python-keybinder
+    sudo apt-get install -y python-notify python-xdg python-keybinder python-dbus
     sudo pip install colorlog
     if [[ -f Makefile ]]; then
         make clean


### PR DESCRIPTION
Ran into https://github.com/Guake/guake/issues/898 when installing from source. The suggested fix worked for me:

![guake-proof](https://user-images.githubusercontent.com/705860/31640639-710e81ce-b294-11e7-89f4-2cf9084f3e36.png)

Closes https://github.com/Guake/guake/issues/898
