### PR TITLE
set reno pre_release_tag_re

### DIFF
--- a/releasenotes/config.yaml
+++ b/releasenotes/config.yaml
@@ -2,6 +2,7 @@
 branch: master
 earliest_version: 3.0.0.a4
 collapse_pre_releases: true
+pre_release_tag_re: (?P<pre_release>\.(?:[ab]|rc)+\d*)$
 stop_at_branch_base: true
 sections:
   # The prelude section is implicitly included.


### PR DESCRIPTION
Configure the regex to find pre-release versions matching the style
used in this repository (ending in "\.([ab]|rc)\d*" without the "0"
before the pre-release type), rather than the default (ending in
"\.\d+([ab]|rc)\d*").

Signed-off-by: Doug Hellmann <doug@doughellmann.com>