### PR TITLE
Update bootstrap-dev-debian.sh

### DIFF
--- a/bootstrap-dev-debian.sh
+++ b/bootstrap-dev-debian.sh
@@ -7,6 +7,8 @@ sudo apt install -y \
     dconf-editor \
     gettext \
     gir1.2-keybinder-3.0 \
+    gir1.2-vte-2.91 \
+    gir1.2-notify-0.7 \
     glade \
     gsettings-desktop-schemas \
     libkeybinder-3.0-0 \


### PR DESCRIPTION
Added gir1.2-vte-2.91 gir1.2-notify-0.7 to bootstrap-dev-debian.sh, Guake3 won't work on Debian 9 without these.

Please see issue #1077 titled "pkg_resources.DistributionNotFound: The 'guake' distribution was not found and is required by the application" for more information
