### PR TITLE
 Fix guake showing up on startup, and on flags: -t, --hide and --show 

### DIFF
--- a/guake/main.py
+++ b/guake/main.py
@@ -315,11 +315,6 @@ def main():
         # it is already running, so, lets toggle its visibility.
         remote_object.show_hide()
 
-    # TODO PORT remove the next line it only exists for testing...
-    remote_object.show_hide()
-    # TODO PORT remove the next line it only exists for testing...
-    # remote_object.show_prefs()
-
     if options.execute_startup_script:
         if not already_running:
             startup_script = instance.settings.general.get_string("startup-script")

--- a/releasenotes/notes/fix-guake-showing-up-on-startup-0fdece37dc1616e4.yaml
+++ b/releasenotes/notes/fix-guake-showing-up-on-startup-0fdece37dc1616e4.yaml
@@ -1,0 +1,4 @@
+fixes:
+  - |
+    2 issues - command options don't work, crash when disabling keybinding #1111 (only the first issue)
+    [gtk3] Guake window is open upon startup #1113


### PR DESCRIPTION
Fix the first part of the issue #1111 and issue #1113 by removing testing code marked with `#TODO PORT`.