### PR TITLE
Automatically open editor for the releasenote

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -253,6 +253,7 @@ generate-desktop:
 
 reno:
 	pipenv run reno new $(SLUG)
+	@hash $$EDITOR 2> /dev/null; if [[ $$? -eq 0 ]]; then $$EDITOR releasenotes/notes/$$(ls releasenotes/notes -rt | tail -n 1); fi
 
 reno-lint:
 	pipenv run reno lint

--- a/Makefile
+++ b/Makefile
@@ -252,8 +252,7 @@ generate-desktop:
 
 
 reno:
-	pipenv run reno new $(SLUG)
-	@hash $$EDITOR 2> /dev/null; if [[ $$? -eq 0 ]]; then $$EDITOR releasenotes/notes/$$(ls releasenotes/notes -rt | tail -n 1); fi
+	pipenv run reno new $(SLUG) --edit
 
 reno-lint:
 	pipenv run reno lint

--- a/releasenotes/notes/auto-edit-648e3609c9aee103.yaml
+++ b/releasenotes/notes/auto-edit-648e3609c9aee103.yaml
@@ -1,0 +1,3 @@
+features:
+  - |
+    Automatically open reno files for editing


### PR DESCRIPTION
I thought it would be nice if `make reno SLUG=<short_name_of_my_feature>` would automatically open the created file for editing for you.
