### PR TITLE
remove visible bell

### DIFF
--- a/guake/data/org.guake.gschema.xml
+++ b/guake/data/org.guake.gschema.xml
@@ -106,11 +106,6 @@
             <summary>Audible bell</summary>
             <description>If true, the system alert sound will be played on a bell character.</description>
         </key>
-        <key name="use-visible-bell" type="b">
-            <default>false</default>
-            <summary>Visible bell</summary>
-            <description>If true, the terminal will flash on a bell character.</description>
-        </key>
         <key name="window-width" type="i">
             <default>100</default>
             <summary>Window width.</summary>

--- a/guake/data/prefs.glade
+++ b/guake/data/prefs.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.20.0 -->
+<!-- Generated with glade 3.20.2 -->
 <interface>
   <requires lib="gtk+" version="3.18"/>
   <object class="GtkAdjustment" id="transparency">
@@ -185,22 +185,6 @@
                                           </packing>
                                         </child>
                                         <child>
-                                          <object class="GtkCheckButton" id="use_visible_bell">
-                                            <property name="label" translatable="yes">_Flash terminal on bell</property>
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="halign">start</property>
-                                            <property name="use_underline">True</property>
-                                            <property name="draw_indicator">True</property>
-                                            <signal name="toggled" handler="on_use_visible_bell_toggled" swapped="no"/>
-                                          </object>
-                                          <packing>
-                                            <property name="left_attach">0</property>
-                                            <property name="top_attach">1</property>
-                                          </packing>
-                                        </child>
-                                        <child>
                                           <object class="GtkCheckButton" id="use_audible_bell">
                                             <property name="label" translatable="yes">_Play system alert sound on bell</property>
                                             <property name="visible">True</property>
@@ -283,6 +267,22 @@
                                             <property name="use_underline">True</property>
                                             <property name="draw_indicator">True</property>
                                             <signal name="toggled" handler="on_use_trayicon_toggled" swapped="no"/>
+                                          </object>
+                                          <packing>
+                                            <property name="left_attach">0</property>
+                                            <property name="top_attach">1</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkCheckButton" id="use_visible_bell">
+                                            <property name="label" translatable="yes">_Flash terminal on bell</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="no_show_all">True</property>
+                                            <property name="halign">start</property>
+                                            <property name="use_underline">True</property>
+                                            <property name="draw_indicator">True</property>
+                                            <signal name="toggled" handler="on_use_visible_bell_toggled" swapped="no"/>
                                           </object>
                                           <packing>
                                             <property name="left_attach">1</property>
@@ -2642,6 +2642,9 @@ For example, for sublime, use &lt;b&gt;subl %(file_path)s:%(line_number)s&lt;/b&
           </packing>
         </child>
       </object>
+    </child>
+    <child type="titlebar">
+      <placeholder/>
     </child>
   </object>
 </interface>

--- a/guake/prefs.py
+++ b/guake/prefs.py
@@ -419,12 +419,6 @@ class PrefsCallbacks(object):
                 'window-halignment', which_align[halign_button.get_name()]
             )
 
-    def on_use_visible_bell_toggled(self, chk):
-        """Changes the value of use_visible_bell in gconf
-        """
-        # TODO PORT remove this vte has no visual bell feature any more
-        self.settings.general.set_boolean('use-visible-bell', chk.get_active())
-
     def on_use_audible_bell_toggled(self, chk):
         """Changes the value of use_audible_bell in gconf
         """
@@ -955,11 +949,6 @@ class PrefsDialog(SimpleGladeApp):
         # start fullscreen
         value = self.settings.general.get_boolean('start-fullscreen')
         self.get_widget('start_fullscreen').set_active(value)
-
-        # use visible bell
-        # TODO PORT remove this. the new vte has now visual bell feature
-        value = self.settings.general.get_boolean('use-visible-bell')
-        self.get_widget('use_visible_bell').set_active(value)
 
         # use audible bell
         value = self.settings.general.get_boolean('use-audible-bell')

--- a/guake/terminal.py
+++ b/guake/terminal.py
@@ -93,7 +93,6 @@ class Terminal(Vte.Terminal):
         # word_chars = client.get_string(KEY('/general/word_chars'))
         # self.set_word_chars(word_chars)
         # self.set_audible_bell(client.get_bool(KEY('/general/use_audible_bell')))
-        # self.set_visible_bell(client.get_bool(KEY('/general/use_visible_bell')))
         self.set_sensitive(True)
         self.set_can_default(True)
         self.set_can_focus(True)
@@ -235,8 +234,6 @@ class GuakeTerminal(Vte.Terminal):
             # self.set_word_chars(word_chars)
             pass
         self.set_audible_bell(client.get_boolean('use-audible-bell'))
-        # TODO PORT I hve not seen a way to port this
-        # self.set_visible_bell(client.get_boolean('use-visible-bell'))
         self.set_sensitive(True)
         # TODO PORT there is no method set_flags anymore
         # self.set_flags(gtk.CAN_DEFAULT)

--- a/releasenotes/notes/remove-visible-bell-12de7acf136d3fa4.yaml
+++ b/releasenotes/notes/remove-visible-bell-12de7acf136d3fa4.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    [gtk3] Remove or manually implement visible bell #1081


### PR DESCRIPTION
Remove the code for the visible bell feature. 

**Note:** The Gtk widget is not removed (just hidden) to keep the translations alive. In case this feature gets reimplemented just set the widget to **visible** and enable **show all**.

This closes #1081 