### PR TITLE
Added hotkey "show-focus"

### DIFF
--- a/guake/data/org.guake.gschema.xml
+++ b/guake/data/org.guake.gschema.xml
@@ -271,6 +271,11 @@
             <summary>Keybinding to show/hide guake.</summary>
             <description>Global keybinding to allow user call guake from each place after it's opened without clicks.</description>
         </key>
+        <key name="show-focus" type="s">
+            <default>''</default>
+            <summary>Keybinding to show and focus guake.</summary>
+            <description>Global keybinding to allow user call guake from each place after it's opened without clicks.</description>
+        </key>
     </schema>
     <schema id="guake.keybindings.local" path="/apps/guake/keybindings/local/">
         <key name="quit" type="s">

--- a/guake/guake_app.py
+++ b/guake/guake_app.py
@@ -759,6 +759,48 @@ class Guake(SimpleGladeApp):
         if self.preventHide:
             return
 
+        self.win_prepare()
+
+        if not self.window.get_property('visible'):
+            log.debug("Showing the terminal")
+            self.show()
+            self.set_terminal_focus()
+            return
+
+        # Disable the focus_if_open feature
+        #  - if doesn't work seamlessly on all system
+        #  - self.window.window.get_state doesn't provides us the right information on all
+        #    systems, especially on MATE/XFCE
+        #
+        # if self.client.get_bool(KEY('/general/focus_if_open')):
+        #     restore_focus = False
+        #     if self.window.window:
+        #         state = int(self.window.window.get_state())
+        #         if ((state & GDK_WINDOW_STATE_STICKY or
+        #                 state & GDK_WINDOW_STATE_WITHDRAWN
+        #              )):
+        #             restore_focus = True
+        #     else:
+        #         restore_focus = True
+        # if not self.hidden:
+        # restore_focus = True
+        #     if restore_focus:
+        #         log.debug("DBG: Restoring the focus to the terminal")
+        #         self.hide()
+        #         self.show()
+        #         self.window.window.focus()
+        #         self.set_terminal_focus()
+        #         return
+
+        log.debug("hiding the terminal")
+        self.hide()
+
+    def show_focus(self, *args):
+        self.win_prepare()
+        self.show()
+        self.set_terminal_focus()
+
+    def win_prepare(self, *args):
         # TODO PORT reenable this after keybinder fixes (this is  mostly done but needs testing)
         event_time = self.hotkeys.get_current_event_time()
         if not self.settings.general.get_boolean('window-refocus') and \
@@ -799,40 +841,6 @@ class Guake(SimpleGladeApp):
             log.debug("GDK_WINDOW_STATE_WITHDRAWN? %s", is_withdrawn)
             log.debug("GDK_WINDOW_STATE_ABOVE? %s", is_above)
             log.debug("GDK_WINDOW_STATE_ICONIFIED? %s", is_iconified)
-
-        if not self.window.get_property('visible'):
-            log.debug("Showing the terminal")
-            self.show()
-            self.set_terminal_focus()
-            return
-
-        # Disable the focus_if_open feature
-        #  - if doesn't work seamlessly on all system
-        #  - self.window.window.get_state doesn't provides us the right information on all
-        #    systems, especially on MATE/XFCE
-        #
-        # if self.client.get_bool(KEY('/general/focus_if_open')):
-        #     restore_focus = False
-        #     if self.window.window:
-        #         state = int(self.window.window.get_state())
-        #         if ((state & GDK_WINDOW_STATE_STICKY or
-        #                 state & GDK_WINDOW_STATE_WITHDRAWN
-        #              )):
-        #             restore_focus = True
-        #     else:
-        #         restore_focus = True
-        # if not self.hidden:
-        # restore_focus = True
-        #     if restore_focus:
-        #         log.debug("DBG: Restoring the focus to the terminal")
-        #         self.hide()
-        #         self.show()
-        #         self.window.window.focus()
-        #         self.set_terminal_focus()
-        #         return
-
-        log.debug("hiding the terminal")
-        self.hide()
 
     def show(self):
         """Shows the main window and grabs the focus on it.

--- a/guake/keybindings.py
+++ b/guake/keybindings.py
@@ -45,7 +45,7 @@ class Keybindings(object):
 
         # Setup global keys
         self.globalhotkeys = {}
-        globalkeys = ['show-hide']
+        globalkeys = ['show-hide', 'show-focus']
         for key in globalkeys:
             guake.settings.keybindingsGlobal.onChangedValue(key, self.reload_global)
             guake.settings.keybindingsGlobal.triggerOnChangedValue(
@@ -78,21 +78,26 @@ class Keybindings(object):
             pass
 
         self.globalhotkeys[key] = value
-        if not self.guake.hotkeys.bind(value, self.guake.show_hide):
-            print("shit")
-            # TODO port this
-            return
-            keyval, mask = Gtk.accelerator_parse(value)
-            label = Gtk.accelerator_get_label(keyval, mask)
-            filename = pixmapfile('guake-notification.png')
-            notifier.showMessage(
-                _('Guake Terminal'),
-                _(
-                    'A problem happened when binding <b>%s</b> key.\n'
-                    'Please use Guake Preferences dialog to choose another '
-                    'key'
-                ) % xml_escape(label), filename
-            )
+        if key == "show-hide":
+            if not self.guake.hotkeys.bind(value, self.guake.show_hide):
+                print("shit")
+                # TODO port this
+                return
+                keyval, mask = Gtk.accelerator_parse(value)
+                label = Gtk.accelerator_get_label(keyval, mask)
+                filename = pixmapfile('guake-notification.png')
+                guake.notifier.showMessage(
+                    _('Guake Terminal'),
+                    _(
+                        'A problem happened when binding <b>%s</b> key.\n'
+                        'Please use Guake Preferences dialog to choose another '
+                        'key'
+                    ) % xml_escape(label), filename
+                )
+        elif key == "show-focus":
+            if not self.guake.hotkeys.bind(value, self.guake.show_focus):
+                print("can't bind show-focus key")
+                return
 
     def reload_accelerators(self, *args):
         """Reassign an accel_group to guake main window and guake

--- a/guake/prefs.py
+++ b/guake/prefs.py
@@ -82,6 +82,10 @@ HOTKEYS = [
                 'label': _('Toggle Guake visibility')
             },
             {
+                'key': 'show-focus',
+                'label': _('Show and focus Guake window')
+            },
+            {
                 'key': 'toggle-fullscreen',
                 'label': _('Toggle Fullscreen')
             },
@@ -1086,7 +1090,7 @@ class PrefsDialog(SimpleGladeApp):
             model.set(giter, 0, '', 1, _(group['label']))
             for item in group['keys']:
                 child = model.append(giter)
-                if item['key'] == "show-hide":
+                if item['key'] == "show-hide" or item['key'] == "show-focus":
                     accel = self.settings.keybindingsGlobal.get_string(item['key'])
                 else:
                     accel = self.settings.keybindingsLocal.get_string(item['key'])
@@ -1172,7 +1176,7 @@ class PrefsDialog(SimpleGladeApp):
         model.set_value(giter, 2, hotkey)
 
         # setting the new value in gconf
-        if gconf_path == "show-hide":
+        if gconf_path == "show-hide" or gconf_path == "show-focus":
             self.settings.keybindingsGlobal.set_string(gconf_path, key)
         else:
             self.settings.keybindingsLocal.set_string(gconf_path, key)

--- a/releasenotes/notes/show-focus-cab5307b44905f7e.yaml
+++ b/releasenotes/notes/show-focus-cab5307b44905f7e.yaml
@@ -1,0 +1,5 @@
+features:
+  - |
+    Added hotkey for showing and focusing Guake window when it is opened or closed.
+    It is convenient when Guake window are overlapped with another windows and user
+    needs to just showing it without closing and opening it again.

--- a/test.py
+++ b/test.py
@@ -6,6 +6,7 @@ from gi.repository import Gtk
 
 
 class CellRendererAccel(Gtk.Window):
+
     def __init__(self):
         Gtk.Window.__init__(self)
         self.set_title("CellRendererAccel")


### PR DESCRIPTION
Added hotkey for showing and focusing Guake window when it is opened or closed.
It is convenient when Guake window are overlapped with another windows and user needs to just showing it without closing and opening it again.