### PR TITLE
Added 'hide' hotkey for hiding guake window unconditionally without opening and showing it

### DIFF
--- a/guake/data/org.guake.gschema.xml
+++ b/guake/data/org.guake.gschema.xml
@@ -266,6 +266,11 @@
             <summary>Keybinding to show and focus guake.</summary>
             <description>Global keybinding to allow user call guake from each place after it's opened without clicks.</description>
         </key>
+        <key name="hide" type="s">
+            <default>''</default>
+            <summary>Keybinding to hide guake.</summary>
+            <description>Global keybinding to allow user call guake from each place after it's opened without clicks.</description>
+        </key>
     </schema>
     <schema id="guake.keybindings.local" path="/apps/guake/keybindings/local/">
         <key name="quit" type="s">

--- a/guake/guake_app.py
+++ b/guake/guake_app.py
@@ -801,6 +801,17 @@ class Guake(SimpleGladeApp):
         self.show()
         self.set_terminal_focus()
 
+    def hide_win(self, *args):
+
+        if self.forceHide:
+            self.forceHide = False
+            return
+
+        if self.preventHide:
+            return
+
+        self.hide()
+
     def win_prepare(self, *args):
         # TODO PORT reenable this after keybinder fixes (this is  mostly done but needs testing)
         event_time = self.hotkeys.get_current_event_time()

--- a/guake/keybindings.py
+++ b/guake/keybindings.py
@@ -45,7 +45,7 @@ class Keybindings(object):
 
         # Setup global keys
         self.globalhotkeys = {}
-        globalkeys = ['show-hide', 'show-focus']
+        globalkeys = ['show-hide', 'show-focus', 'hide']
         for key in globalkeys:
             guake.settings.keybindingsGlobal.onChangedValue(key, self.reload_global)
             guake.settings.keybindingsGlobal.triggerOnChangedValue(
@@ -97,6 +97,10 @@ class Keybindings(object):
         elif key == "show-focus":
             if not self.guake.hotkeys.bind(value, self.guake.show_focus):
                 print("can't bind show-focus key")
+                return
+        elif key == "hide":
+            if not self.guake.hotkeys.bind(value, self.guake.hide_win):
+                print("can't bind hide key")
                 return
 
     def reload_accelerators(self, *args):

--- a/guake/prefs.py
+++ b/guake/prefs.py
@@ -86,6 +86,10 @@ HOTKEYS = [
                 'label': _('Show and focus Guake window')
             },
             {
+                'key': 'hide',
+                'label': _('Hide Guake window')
+            },
+            {
                 'key': 'toggle-fullscreen',
                 'label': _('Toggle Fullscreen')
             },
@@ -1084,7 +1088,8 @@ class PrefsDialog(SimpleGladeApp):
             model.set(giter, 0, '', 1, _(group['label']))
             for item in group['keys']:
                 child = model.append(giter)
-                if item['key'] == "show-hide" or item['key'] == "show-focus":
+                if item['key'] == "show-hide" or item['key'] == "show-focus"
+                		or item['key'] == "hide":
                     accel = self.settings.keybindingsGlobal.get_string(item['key'])
                 else:
                     accel = self.settings.keybindingsLocal.get_string(item['key'])
@@ -1170,7 +1175,7 @@ class PrefsDialog(SimpleGladeApp):
         model.set_value(giter, 2, hotkey)
 
         # setting the new value in gconf
-        if gconf_path == "show-hide" or gconf_path == "show-focus":
+        if gconf_path == "show-hide" or gconf_path == "show-focus" or gconf_path == "hide":
             self.settings.keybindingsGlobal.set_string(gconf_path, key)
         else:
             self.settings.keybindingsLocal.set_string(gconf_path, key)

--- a/releasenotes/notes/hide-win-hotkey-4d48cf5c34809d90.yaml
+++ b/releasenotes/notes/hide-win-hotkey-4d48cf5c34809d90.yaml
@@ -1,0 +1,6 @@
+features:
+  - |
+    The additional feature to manipulate guake window from global environment.
+    You can use show-hide hotkey to hide window, but for convenient purposes
+    there are hide-win hotkey. It is useful when you don't want to check what
+    state of guake window have and just to use direct action.


### PR DESCRIPTION
The additional feature to manipulate guake window from global environment.
You can use show-hide hotkey to hide window, but for convenient purposes there are hide-win hotkey. It is useful when you don't want to check what state of guake window have and just to use direct action.

As an addition to #1133
