### PR TITLE
Add the possibility to terminate guake with ctrl+c

### DIFF
--- a/guake/main.py
+++ b/guake/main.py
@@ -19,6 +19,7 @@ Boston, MA 02110-1301 USA
 """
 import logging
 import os
+import signal
 import subprocess
 import sys
 import uuid
@@ -338,6 +339,7 @@ def main():
 def exec_main():
     if not main():
         log.info("Running main gtk loop")
+        signal.signal(signal.SIGINT, signal.SIG_DFL)
         Gtk.main()
 
 

--- a/releasenotes/notes/add-control-c-handler-fb2967d1ba8ee495.yaml
+++ b/releasenotes/notes/add-control-c-handler-fb2967d1ba8ee495.yaml
@@ -1,0 +1,3 @@
+features:
+  - |
+    Add the possibility to terminate guake with ctrl+c


### PR DESCRIPTION
This allows to terminate guake with ctrl+c when running via `make run` or from command line.

