### PR TITLE
fix preferences desktop file

### DIFF
--- a/guake/data/guake-prefs.template.desktop
+++ b/guake/data/guake-prefs.template.desktop
@@ -1,13 +1,12 @@
 [Desktop Entry]
 Name=Guake Preferences
 Comment=Configure your Guake sessions
-TryExec=guake -p
+TryExec=guake
 Exec=guake -p
 Icon=guake
 Type=Application
 StartupNotify=true
 Categories=GTK;GNOME;Settings;X-GNOME-PersonalSettings;
-OnlyShowIn=GNOME;
 X-GNOME-Settings-Panel=guake
 X-Desktop-File-Install-Version=0.15
 Keywords=Terminal;Utility;


### PR DESCRIPTION
`TryExec` should only be the file name see https://developer.gnome.org/desktop-entry-spec/
`OnlyShowIn` removed

Closes: #1170