### PR TITLE
Fixed path to guake data in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ wheels:
 
 
 run-local: compile-glib-schemas
-	export GUAKE_DATA_DIR=$(shell pwd)/data ; pipenv run ./run-local.sh
+	export GUAKE_DATA_DIR=$(shell pwd)/guake/data ; pipenv run ./run-local.sh
 
 
 shell:


### PR DESCRIPTION
#1189 

The problem is: make runs from *guake* folder and data stores into *guake/guake*.
I see two solutions:
1. Edit *GUAKE_DATA_DIR* into Makefile, as I do or
1. Remove export of *GUAKE_DATA_DIR* from Makefile, because globals would set correct [default value](https://github.com/Guake/guake/blob/master/guake/globals.py#L52) if *GUAKE_DATA_DIR* is not in environmental variables

First one seems better for me because someone can set this env var manually