### PR TITLE
uuid object imported on guake_app.py

### DIFF
--- a/guake/guake_app.py
+++ b/guake/guake_app.py
@@ -25,6 +25,7 @@ import platform
 import subprocess
 import sys
 import traceback
+import uuid
 
 from pathlib import Path
 from urllib.parse import quote_plus


### PR DESCRIPTION
uuid import was not transferred from old Guake 0.X to Guake3.
That causes errors when using dbus uuid related functions for example:
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/dbus/service.py", line 707, in _message_cb
    retval = candidate_method(self, *args, **keywords)
  File "/home/agarzi/github/guake3/guake/guake/dbusiface.py", line 143, in execute_command_by_uuid
    self.guake.execute_command_by_uuid(tab_uuid, command)
  File "/home/agarzi/github/guake3/guake/guake/guake_app.py", line 558, in execute_command_by_uuid
    tab_uuid = uuid.UUID(tab_uuid)
NameError: name 'uuid' is not defined

Please accept this pull request otherwise my guake-indicator will break as it's impossibile to communicate with Guake3 by d-bus calls.
