### PR TITLE
Fix cursor blinking mode in new tabs

### DIFF
--- a/guake/terminal.py
+++ b/guake/terminal.py
@@ -153,12 +153,13 @@ class GuakeTerminal(Vte.Terminal):
             pass
         self.set_audible_bell(client.get_boolean('use-audible-bell'))
         self.set_sensitive(True)
+
+        cursor_blink_mode = self.settings.style.get_int('cursor-blink-mode')
+        self.set_property('cursor-blink-mode', cursor_blink_mode)
+
         # TODO PORT there is no method set_flags anymore
         # self.set_flags(gtk.CAN_DEFAULT)
         # self.set_flags(gtk.CAN_FOCUS)
-        # TODO PORT getting it and then setting it???
-        # cursor_blink_mode = client.get_int(KEY('/style/cursor_blink_mode'))
-        # client.set_int(KEY('/style/cursor_blink_mode'), cursor_blink_mode)
         # TODO PORT getting it and then setting it???
         # cursor_shape = client.get_int(KEY('/style/cursor_shape'))
         # client.set_int(KEY('/style/cursor_shape'), cursor_shape)

--- a/releasenotes/notes/bugfix-705c264a6b77f4d3.yaml
+++ b/releasenotes/notes/bugfix-705c264a6b77f4d3.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    Apply cursor blinking to new tabs as well, not only on settings change.


### PR DESCRIPTION
Previously, cursor blink mode was just applied when changing.

Steps to reproduce the issue:

1. Open guake
2. Change Cursor Blink Mode to Off in Preferences -> Appearance
3. Observe: Blink mode of current terminals is correctly changed, no more cursor epilepsy.
4. Open a new terminal (Right-click -> New Tab)
5. Observe: Blinking cursor, setting is not applied.

The fix is trivial: Upon tab start, apply the blink mode property.