### PR TITLE
add domain (gettext) to guake.glade, about.glade and prefs.glade

### DIFF
--- a/guake/data/about.glade
+++ b/guake/data/about.glade
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated with glade 3.18.3 -->
-<interface>
+<interface domain="guake">
   <requires lib="gtk+" version="3.18"/>
   <object class="GtkAboutDialog" id="aboutdialog">
     <property name="can_focus">False</property>

--- a/guake/data/guake.glade
+++ b/guake/data/guake.glade
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated with glade 3.18.3 -->
-<interface>
+<interface domain="guake">
   <requires lib="gtk+" version="3.10"/>
   <object class="GtkMenu" id="context-menu">
     <property name="visible">True</property>

--- a/guake/data/prefs.glade
+++ b/guake/data/prefs.glade
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated with glade 3.20.0 -->
-<interface>
+<interface domain="guake">
   <requires lib="gtk+" version="3.18"/>
   <object class="GtkAdjustment" id="max_tab_name_length_adj">
     <property name="upper">1000</property>


### PR DESCRIPTION
Adding a domain attribute to the interface definitions in the glade files.

Read more: https://developer.gnome.org/gtk3/stable/GtkBuilder.html