### PR TITLE
Fix schemas not compiled in custom schema dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ install-schemas:
 	install -Dm644 "guake/data/org.guake.gschema.xml" "$(DESTDIR)$(SCHEMA_DIR)/"
 
 compile-shemas:
-	if [ $(COMPILE_SCHEMA) = 1 ]; then glib-compile-schemas $(DESTDIR)$(prefix)/share/glib-2.0/schemas/; fi
+	if [ $(COMPILE_SCHEMA) = 1 ]; then glib-compile-schemas $(DESTDIR)$(gsettingsschemadir); fi
 
 
 uninstall-system: uninstall-schemas


### PR DESCRIPTION
00731c7080e888101877cb2810425ee1568f2561 added an option to override
GSettings schema directory, but it did not update the directory
where the schemas are compiled.