### PR TITLE
Fix enabling hyperlinks

### DIFF
--- a/guake/terminal.py
+++ b/guake/terminal.py
@@ -153,7 +153,7 @@ class GuakeTerminal(Vte.Terminal):
         self.set_property('cursor-blink-mode', cursor_blink_mode)
 
         if (Vte.MAJOR_VERSION, Vte.MINOR_VERSION) >= (0, 50):
-            self.set_allow_hyperlink()
+            self.set_allow_hyperlink(True)
 
         # TODO PORT there is no method set_flags anymore
         # self.set_flags(gtk.CAN_DEFAULT)


### PR DESCRIPTION
PR #1261 tried to enable hyperlink support but forgot to pass a boolean
argument to the set_allow_hyperlink method [1].

Closes: #1264

[1]: https://lazka.github.io/pgi-docs/#Vte-2.91/classes/Terminal.html#Vte.Terminal.set_allow_hyperlink