### PR TITLE
Fix url match

### DIFF
--- a/guake/terminal.py
+++ b/guake/terminal.py
@@ -170,11 +170,11 @@ class GuakeTerminal(Vte.Terminal):
         """
         try:
             for expr in TERMINAL_MATCH_EXPRS:
-                tag = self.match_add_regex(Vte.Regex.new_for_match(expr, 0, 0), 0)
+                tag = self.match_add_regex(Vte.Regex.new_for_match(expr, len(expr), 0), 0)
                 self.match_set_cursor_type(tag, Gdk.CursorType.HAND2)
 
             for _useless, match, _otheruseless in QUICK_OPEN_MATCHERS:
-                tag = self.match_add_regex(Vte.Regex.new_for_match(match, 0, 0), 0)
+                tag = self.match_add_regex(Vte.Regex.new_for_match(match, len(match), 0), 0)
                 self.match_set_cursor_type(tag, Gdk.CursorType.HAND2)
         except (GLib.Error, AttributeError) as e:  # pylint: disable=catching-non-exception
             try:

--- a/releasenotes/notes/fix-hyperlink-50901cd04a88876e.yaml
+++ b/releasenotes/notes/fix-hyperlink-50901cd04a88876e.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+      - corrected usage of Vte.Regex.new_for_match to fix hyperlink matching #1295


### PR DESCRIPTION
Updated `terminal.py` to use the [documented function signature](https://lazka.github.io/pgi-docs/Vte-2.91/classes/Regex.html#Vte.Regex.new_for_match) for `Vte.Regex.new_for_match`. Tested locally, and this corrected the broken hyperlink matching in `3.2.0`. Let me know if I missed anything!

Fixes #1295 