### PR TITLE
fix typo in fedora package name

### DIFF
--- a/scripts/bootstrap-dev-fedora.sh
+++ b/scripts/bootstrap-dev-fedora.sh
@@ -4,7 +4,7 @@ echo "Install packages needed for execution"
 
 sudo apt install -y \
     python3-devel \
-    python3-cario \
+    python3-cairo \
     python3-dbus \
     python3-pip \
     keybinder3 \


### PR DESCRIPTION
python3-ca~~r~~iro