### PR TITLE
add option groups (run, make, dev, opt) to the bootstrap scripts

### DIFF
--- a/docs/source/user/installing.rst
+++ b/docs/source/user/installing.rst
@@ -41,7 +41,16 @@ your system.
 Install from source
 ===================
 
-If you want to install Guake from its sources, use:
+If you want to install Guake from its sources make sure that you have the 
+needed dependencies installed. If you are unsure about the dependencies you 
+can run to install them:
+
+.. code-block:: bash
+    $bash script/bootstrap-[debian, arch, fedora].sh run make
+
+Note: inster your distribution in the square brackets.
+
+To install Guake itself, use:
 
 .. code-block:: bash
 

--- a/releasenotes/notes/update-bootstrap-scripts-1ba9e40b4ab1bfd4.yaml
+++ b/releasenotes/notes/update-bootstrap-scripts-1ba9e40b4ab1bfd4.yaml
@@ -1,0 +1,2 @@
+other:
+    Add option groupes to the bootstrap scripts

--- a/scripts/bootstrap-dev-arch.sh
+++ b/scripts/bootstrap-dev-arch.sh
@@ -1,12 +1,71 @@
 #!/bin/bash
 
-echo "Install packages needed for execution"
-sudo pacman -S \
-    libkeybinder3 \
-    libnotify \
-    libutempter \
-    python-cairo \
-    python-dbus \
-    python-gobject \
-    python-pbr \
-    vte3 \
+RUN=0
+MAKE=0
+DEV=0
+OPT=0
+ARGC="$#"
+
+while test $# -gt 0
+do
+    case "$1" in
+        run)
+          RUN=1
+          ;;
+        make)
+          MAKE=1
+          ;;
+        dev)
+          DEV=1
+          ;;
+        opt)
+          OPT=1
+          ;;
+    esac
+    shift
+done
+
+if [[ "$ARGC" == "0" ]]; then
+          RUN=1;
+          MAKE=1;
+          DEV=1;
+          OPT=0;
+fi
+
+
+if [[ $RUN == "1" ]]; then
+    echo "Install packages needed for execution"
+    sudo pacman -S \
+        libkeybinder3 \
+        libnotify \
+        python-cairo \
+        python-dbus \
+        python-gobject \
+        python-pbr \
+        vte3
+fi
+
+if [[ $MAKE == "1" ]]; then
+    echo "Install packages needed for making guake"
+    sudo pacman -S \
+        gettext \
+        gsettings-desktop-schemas \
+        make \
+        pandoc
+fi
+
+if [[ $DEV == "1" ]]; then
+    echo "Install needed development packages"
+    sudo pacman -S \
+        dconf-editor \
+        glade \
+        poedit \
+        gnome-tweak-tool
+fi
+
+if [[ $OPT == "1" ]]; then
+echo "Install packages optional for execution"
+    sudo pacman -S \
+        libutempter \
+        numix-gtk-theme
+fi

--- a/scripts/bootstrap-dev-debian.sh
+++ b/scripts/bootstrap-dev-debian.sh
@@ -1,36 +1,76 @@
 #!/bin/bash
 
-echo "Install packages needed for execution"
+RUN=0
+MAKE=0
+DEV=0
+OPT=0
+ARGC="$#"
 
-sudo apt install -y \
-    gir1.2-keybinder-3.0 \
-    gir1.2-notify-0.7 \
-    gir1.2-vte-2.91 \
-    libkeybinder-3.0-0 \
-    python3 \
-    python3-cairo \
-    python3-dbus \
-    python3-gi \
-    python3-pbr \
-    python3-pip \
+while test $# -gt 0
+do
+    case "$1" in
+        run)
+          RUN=1
+          ;;
+        make)
+          MAKE=1
+          ;;
+        dev)
+          DEV=1
+          ;;
+        opt)
+          OPT=1
+          ;;
+    esac
+    shift
+done
 
-echo "Install needed development packages on a Debian/Ubuntu system"
-sudo apt install -y \
-    aspell-fr \
-    colortest \
-    dconf-editor \
-    gettext \
-    glade \
-    poedit \
-    gnome-tweak-tool \
-    gsettings-desktop-schemas \
-    make \
-    pandoc \
+if [[ "$ARGC" == "0" ]]; then
+          RUN=1;
+          MAKE=1;
+          DEV=1;
+          OPT=0;
+fi
 
-if [[ $1 == "--with-optional" ]]; then
 
+if [[ $RUN == "1" ]]; then
+    echo "Install packages needed for execution"
+    sudo apt install -y \
+        gir1.2-keybinder-3.0 \
+        gir1.2-notify-0.7 \
+        gir1.2-vte-2.91 \
+        libkeybinder-3.0-0 \
+        python3 \
+        python3-cairo \
+        python3-dbus \
+        python3-gi \
+        python3-pbr \
+        python3-pip
+fi
+
+if [[ $MAKE == "1" ]]; then
+    echo "Install packages needed for making guake"
+    sudo apt install -y \
+        gettext \
+        gsettings-desktop-schemas \
+        make \
+        pandoc
+fi
+
+if [[ $DEV == "1" ]]; then
+    echo "Install needed development packages"
+    sudo apt install -y \
+        aspell-fr \
+        colortest \
+        dconf-editor \
+        glade \
+        poedit \
+        gnome-tweak-tool
+fi
+
+if [[ $OPT == "1" ]]; then
+    echo "Install packages optional for execution"
     sudo apt install -y \
         libutempter0 \
         numix-gtk-theme \
-
 fi

--- a/scripts/bootstrap-dev-fedora.sh
+++ b/scripts/bootstrap-dev-fedora.sh
@@ -1,10 +1,69 @@
 #!/bin/bash
 
-echo "Install packages needed for execution"
+RUN=0
+MAKE=0
+DEV=0
+OPT=0
+ARGC="$#"
 
-sudo apt install -y \
-    python3-devel \
-    python3-cairo \
-    python3-dbus \
-    python3-pip \
-    keybinder3 \
+while test $# -gt 0
+do
+    case "$1" in
+        run)
+          RUN=1
+          ;;
+        make)
+          MAKE=1
+          ;;
+        dev)
+          DEV=1
+          ;;
+        opt)
+          OPT=1
+          ;;
+    esac
+    shift
+done
+
+if [[ "$ARGC" == "0" ]]; then
+          RUN=1;
+          MAKE=1;
+          DEV=1;
+          OPT=0;
+fi
+
+
+if [[ $RUN == "1" ]]; then
+    echo "Install packages needed for execution"
+    sudo yum install \
+        python3-devel \
+        python3-cairo \
+        python3-dbus \
+        python3-pip \
+        keybinder3 \
+fi
+
+if [[ $MAKE == "1" ]]; then
+    echo "Install packages needed for making guake"
+    sudo yum install \
+        gettext \
+        gsettings-desktop-schemas \
+        make \
+        pandoc
+fi
+
+if [[ $DEV == "1" ]]; then
+    echo "Install needed development packages"
+    sudo yum install \
+        dconf-editor \
+        glade \
+        poedit \
+        gnome-tweak-tool
+fi
+
+if [[ $OPT == "1" ]]; then
+    echo "Install packages optional for execution"
+    sudo yum install \
+        libutempter \
+        numix-gtk-theme \
+fi


### PR DESCRIPTION
I added options to the scripts so that users who just want to install the dependencies needed for running and making guke (`make install`) like here <https://github.com/Guake/guake/issues/1198#issuecomment-385054211> can install dependencies more easily.

I basicly grouped the dependecies in to 4 groups 
* run: packages needed for running
* make: packages needed for `make && make install`
* dev: packages like poedit which are just needed for developing
* opt: optional packages for running 


```
./scripts/bootstrap-debian.sh # will install every group except opt

./scripts/bootstrap-debian.sh run # will install only the run group
./scripts/bootstrap-debian.sh dev # will install only the dev group

./scripts/bootstrap-debian.sh run make # will install the run and the make group
./scripts/bootstrap-debian.sh make run # will install the run and the make group

./scripts/bootstrap-debian.sh make run opt # will install the run, make and opt group

...
```
I also added a paragraph about the dependencies to <http://guake.readthedocs.io/en/stable/user/installing.html#install-from-source> (docs/user/install.rst)