### PR TITLE
Fix a lot of "TODO PORT" sections

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -213,6 +213,9 @@ wheel: wheels
 run-local: compile-glib-schemas-dev
 	pipenv run ./scripts/run-local.sh
 
+run-local-prefs: compile-glib-schemas-dev
+	pipenv run ./scripts/run-local-prefs.sh
+
 run-fr: compile-glib-schemas-dev
 	LC_ALL=fr_FR.UTF8 pipenv run ./scripts/run-local.sh
 
@@ -445,6 +448,7 @@ install: install-system
 purge: purge-system
 pypi: pypi-publish
 run: run-local
+run-prefs: run-local-prefs
 styles: style
 uninstall: uninstall-system
 upgrade: update

--- a/guake/keybindings.py
+++ b/guake/keybindings.py
@@ -25,6 +25,8 @@ from gi.repository import Gtk
 
 from guake import notifier
 from guake.common import pixmapfile
+from locale import gettext as _
+
 
 log = logging.getLogger(__name__)
 
@@ -40,11 +42,6 @@ class Keybindings():
         """
         self.guake = guake
         self.accel_group = None  # see reload_accelerators
-
-        # TODO PORT
-        # self.client = gconf.client_get_default()
-        # TODO PORT
-        # notify_add = self.client.notify_add
 
         # Setup global keys
         self.globalhotkeys = {}
@@ -84,23 +81,20 @@ class Keybindings():
         if key == "show-hide":
             log.debug("reload_global: %r", value)
             if not self.guake.hotkeys.bind(value, self.guake.show_hide):
-                print("port this")
-                # TODO port this
-                return
                 keyval, mask = Gtk.accelerator_parse(value)
                 label = Gtk.accelerator_get_label(keyval, mask)
                 filename = pixmapfile('guake-notification.png')
-                guake.notifier.showMessage(
+                notifier.showMessage(
                     _('Guake Terminal'),
                     _(
                         'A problem happened when binding <b>%s</b> key.\n'
                         'Please use Guake Preferences dialog to choose another '
                         'key'
-                    ) % xml_escape(label), filename
+                    ) % label, filename
                 )
         elif key == "show-focus":
             if not self.guake.hotkeys.bind(value, self.guake.show_focus):
-                print("can't bind show-focus key")
+                log.warn("can't bind show-focus key")
                 return
 
     def reload_accelerators(self, *args):

--- a/guake/paths.py.in
+++ b/guake/paths.py.in
@@ -35,7 +35,7 @@ def get_default_package_root():
 
 
 def get_data_files_dir():
-    d = os.path.dirname(sys.modules["guake"].__file__)
+    d = os.path.dirname(os.path.dirname(sys.modules["guake"].__file__))
     p = os.path.basename(os.path.abspath(os.path.join(d, "..")))
     if p in ["site-packages", "dist-packages"]:
         # current "guake" package has been installed in a prefix structure (/usr, /usr/local or

--- a/guake/prefs.py
+++ b/guake/prefs.py
@@ -679,8 +679,9 @@ class PrefsDialog(SimpleGladeApp):
         treeview.set_model(self.store)
         treeview.set_rules_hint(True)
 
-        # TODO PORT this is killing the editing of the accl
-        # treeview.connect('button-press-event', self.start_editing)
+        treeview.connect('button-press-event', self.start_editing)
+
+        treeview.set_activate_on_single_click(True)
 
         renderer = Gtk.CellRendererText()
         column = Gtk.TreeViewColumn(_('Action'), renderer, text=1)
@@ -1352,27 +1353,17 @@ class PrefsDialog(SimpleGladeApp):
 
         Thanks to gnome-keybinding-properties.c =)
         """
-        # TODO PORT some thing in here is breaking stuff
-
-        if event.window != treeview.get_bin_window():
-            return False
-
         x, y = int(event.x), int(event.y)
         ret = treeview.get_path_at_pos(x, y)
         if not ret:
             return False
 
         path, column, cellx, celly = ret
-        if path and len(path) > 1:
 
-            def real_cb():
-                treeview.grab_focus()
-                treeview.set_cursor(path, column, True)
+        treeview.row_activated(path, Gtk.TreeViewColumn(None))
+        treeview.set_cursor(path)
 
-            treeview.stop_emission('button-press-event')
-            GObject.idle_add(real_cb)
-
-        return True
+        return False
 
 
 class KeyEntry():

--- a/guake/simplegladeapp.py
+++ b/guake/simplegladeapp.py
@@ -73,13 +73,8 @@ class SimpleGladeApp():
 
         self.builder = Gtk.Builder()
         self.builder.add_from_file(self.glade_path)
-        # TODO PORT connect
-        # self.builder.connect_signals(self.custom_handler)
 
         if root:
-            # TODO PORT remove the next line is not needed Guake shuold not pass an root parameter
-            # this would mess stuff up
-            # self.main_widget = self.builder.get_object("window-root")
             self.main_widget = self.builder.get_object(root)
             self.main_widget.show_all()
         else:
@@ -120,8 +115,6 @@ class SimpleGladeApp():
             an instance with methods as code of callbacks.
             It means it has methods like on_button1_clicked, on_entry1_activate, etc.
         """
-        # TODO PORT connect
-
         self.builder.connect_signals(callbacks_proxy)
 
     def normalize_names(self):
@@ -332,59 +325,3 @@ class SimpleGladeApp():
 
     def get_widgets(self):
         return self.builder.get_objects()
-
-
-class SimpleGtk3App():
-
-    """
-    Basic GtkBuilder wrapper that implements the functions from
-    simplegladeapp.py used by Guake with the purpose to minimize
-    the changes required in Guake while porting it to GtkBuilder.
-    """
-
-    def __init__(self, path):
-        """
-        Load a GtkBuilder ui definition file specified by path.
-        Self will be used as object to to connect the signals.
-        """
-        self.builder = Gtk.Builder()
-        self.builder.add_from_file(path)
-        # TODO PORT connect
-        # self.builder.connect_signals(self)
-
-    def quit(self):
-        """
-        Quit processing of gtk events.
-        """
-        Gtk.main_quit()
-
-    def run(self):
-        """
-        Starts the main gtk loop.
-        """
-        Gtk.main()
-
-    def get_widget(self, name):
-        """
-        Returns the interface widget specified by the name.
-        """
-        return self.builder.get_object(name)
-
-    def get_widgets(self):
-        """
-        Returns all the interface widgets.
-        """
-        return self.builder.get_objects()
-
-    # -- predefined callbacks --
-    def gtk_main_quit(self, *args):
-        """
-        Calls self.quit()
-        """
-        self.quit()
-
-    def gtk_widget_destroy(self, widget, *args):
-        """
-        Destroyes the widget.
-        """
-        widget.destroy()

--- a/guake/terminal.py
+++ b/guake/terminal.py
@@ -55,14 +55,12 @@ def halt(loc):
     code.interact(local=loc)
 
 
-# TODO PORT
-# __all__ = ['Terminal', 'TerminalBox']
+__all__ = ['TerminalBox', 'GuakeTerminal', 'GuakeTerminalBox']
 
 # pylint: enable=anomalous-backslash-in-string
 
 
 class TerminalBox(Gtk.HBox):
-
     """A box to group the terminal and a scrollbar.
     """
 
@@ -143,11 +141,7 @@ class GuakeTerminal(Vte.Terminal):
         client = self.settings.general
         word_chars = client.get_string('word-chars')
         if word_chars:
-            # TODO PORT this does not work this way any more see:
-            #   https://lazka.github.io/
-            #          pgi-docs/Vte-2.91/classes/Terminal.html#Vte.Terminal.set_word_char_exceptions
-            # self.set_word_chars(word_chars)
-            pass
+            self.set_word_char_exceptions(word_chars)
         self.set_audible_bell(client.get_boolean('use-audible-bell'))
         self.set_sensitive(True)
 
@@ -157,12 +151,8 @@ class GuakeTerminal(Vte.Terminal):
         if (Vte.MAJOR_VERSION, Vte.MINOR_VERSION) >= (0, 50):
             self.set_allow_hyperlink(True)
 
-        # TODO PORT there is no method set_flags anymore
-        # self.set_flags(gtk.CAN_DEFAULT)
-        # self.set_flags(gtk.CAN_FOCUS)
-        # TODO PORT getting it and then setting it???
-        # cursor_shape = client.get_int(KEY('/style/cursor_shape'))
-        # client.set_int(KEY('/style/cursor_shape'), cursor_shape)
+        self.set_can_default(True)
+        self.set_can_focus(True)
 
     def add_matches(self):
         """Adds all regular expressions declared in
@@ -465,16 +455,13 @@ class GuakeTerminal(Vte.Terminal):
                 pass
 
 
-# TODO PORT port this from HBOX to Box with orientation horitzontal
-
-
-class GuakeTerminalBox(Gtk.HBox):
+class GuakeTerminalBox(Gtk.Box):
 
     """A box to group the terminal and a scrollbar.
     """
 
     def __init__(self, window, settings):
-        super(GuakeTerminalBox, self).__init__()
+        super(GuakeTerminalBox, self).__init__(orientation=Gtk.Orientation.HORIZONTAL)
         self.terminal = GuakeTerminal(window, settings)
         self.add_terminal()
         self.add_scroll_bar()

--- a/releasenotes/notes/gtk3-ports-676e683e82c3fa77.yaml
+++ b/releasenotes/notes/gtk3-ports-676e683e82c3fa77.yaml
@@ -1,0 +1,9 @@
+features:
+  - load default font via python Gio and not via cli call
+  - add json example for custom commands in the code
+  - port screen selectino (use_mouse) to Gdk
+  - add notification for failed show-hide key rebindings
+  - add one-click key binding editing
+  - port word character exceptions for newer vte versions
+  - use Gtk.Box instead of Gtk.HBox
+

--- a/releasenotes/notes/notebook-tabs-7986ca919d5904b3.yaml
+++ b/releasenotes/notes/notebook-tabs-7986ca919d5904b3.yaml
@@ -1,0 +1,2 @@
+features:
+  - use Gtk.Notebook's tabs implementation

--- a/scripts/run-local-prefs.sh
+++ b/scripts/run-local-prefs.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+echo "execute Guake GTK3 for developer."
+
+VIRTUALENV_PATH=$(pipenv --venv)
+
+source $VIRTUALENV_PATH/bin/activate
+
+bash <<EOF
+python 2>/dev/null <<EOC
+import gi
+EOC
+if [ \$? -eq 1 ]; then
+    pew toggleglobalsitepackages
+fi
+PYTHONPATH=. python3 guake/main.py --no-startup-script -p
+echo "Done"
+EOF


### PR DESCRIPTION
There are still some `TODO PORT` sections left but I can't test stuff related to Unity and appindecator since I don't have a 16.-- Ubuntu box running...

I ported the monitor selection when using the "use_mouse" option to Gdk since the Gtk parts  are deprecated, but some one should test them (I have currently only my laptop with me and no access to a second monitor) 

I also changed https://github.com/Guake/guake/compare/master...aichingm:dev/todo-port?expand=1#diff-7a93ec37877f9e75dacff02a373a6734R39

and added a `run-prefs` make target to make development of the prefs window more enjoyable.
