### PR TITLE
fix #1177

### DIFF
--- a/guake/boxes.py
+++ b/guake/boxes.py
@@ -68,6 +68,10 @@ class RootTerminalBox(Gtk.Box, TerminalHolder):
                 "(RootTerminalBox.add(%s))" % type(terminal_holder)
             )
 
+    def focus():
+        if self.get_terminals():
+            self.get_terminals()[0].grab_focus()
+
     def get_child(self):
         return self.child
 

--- a/guake/callbacks.py
+++ b/guake/callbacks.py
@@ -1,5 +1,6 @@
 import gi
 gi.require_version('Gtk', '3.0')
+from gi.repository import Gdk
 from gi.repository import Gtk
 from guake.about import AboutDialog
 from guake.dialogs import RenameDialog
@@ -91,3 +92,20 @@ class TerminalContextMenuCallbacks():
 
     def on_quit(self, *args):
         self.notebook.guake.accel_quit()
+
+
+class NotebookScrollCallback():
+
+    def __init__(self, notebook):
+        self.notebook = notebook
+
+    def on_scroll(self, widget, event):
+        direction = event.get_scroll_direction().direction
+        if direction is Gdk.ScrollDirection.DOWN or \
+                direction is Gdk.ScrollDirection.RIGHT:
+            self.notebook.next_page()
+        else:
+            self.notebook.prev_page()
+        # important to return True to stop propagation of the event
+        # from the label up to the notebook
+        return True

--- a/releasenotes/notes/tab-scroll-switching-6c674056d1394dcd.yaml
+++ b/releasenotes/notes/tab-scroll-switching-6c674056d1394dcd.yaml
@@ -1,0 +1,2 @@
+features:
+  - enable tab switching by scrolling (mouse wheel) over the tabs/tab-bar


### PR DESCRIPTION
Allow the user to switch tabs by using the scroll/mouse wheel over the tab/tab-bar.

This fixes #1177 