### PR TITLE
fix #1395 reimplement main window hide prevention

### DIFF
--- a/guake/boxes.py
+++ b/guake/boxes.py
@@ -9,10 +9,12 @@ from gi.repository import Gdk
 from gi.repository import Gtk
 from gi.repository import Vte
 
+from guake.callbacks import MenuHideCallback
 from guake.callbacks import TerminalContextMenuCallbacks
 from guake.dialogs import RenameDialog
 from guake.menus import mk_tab_context_menu
 from guake.menus import mk_terminal_context_menu
+from guake.utils import HidePrevention
 from guake.utils import TabNameUtils
 
 log = logging.getLogger(__name__)
@@ -182,6 +184,8 @@ class TerminalBox(Gtk.Box, TerminalHolder):
                     self.get_guake().notebook
                 )
             )
+            menu.connect("hide", MenuHideCallback(self.get_window()).on_hide)
+            HidePrevention(self.get_window()).prevent()
             try:
                 menu.popup_at_pointer(event)
             except AttributeError:
@@ -265,6 +269,8 @@ class TabLabelEventBox(Gtk.EventBox):
     def on_button_press(self, target, event, user_data):
         if event.button == 3:
             menu = mk_tab_context_menu(self)
+            menu.connect("hide", MenuHideCallback(self.get_window()).on_hide)
+            HidePrevention(self.get_window()).prevent()
             try:
                 menu.popup_at_pointer(event)
             except AttributeError:

--- a/guake/callbacks.py
+++ b/guake/callbacks.py
@@ -7,6 +7,7 @@ from guake.dialogs import RenameDialog
 from guake.dialogs import SaveTerminalDialog
 from guake.prefs import PrefsDialog
 from guake.utils import FullscreenManager
+from guake.utils import HidePrevention
 from guake.utils import TabNameUtils
 from guake.utils import get_server_time
 from urllib.parse import quote_plus
@@ -109,3 +110,12 @@ class NotebookScrollCallback():
         # important to return True to stop propagation of the event
         # from the label up to the notebook
         return True
+
+
+class MenuHideCallback():
+
+    def __init__(self, window):
+        self.window = window
+
+    def on_hide(self, *args):
+        HidePrevention(self.window).allow()

--- a/guake/guake_app.py
+++ b/guake/guake_app.py
@@ -77,6 +77,7 @@ from guake.terminal import GuakeTerminal
 from guake.theme import patch_gtk_theme
 from guake.theme import select_gtk_theme
 from guake.utils import FullscreenManager
+from guake.utils import HidePrevention
 from guake.utils import RectCalculator
 from guake.utils import TabNameUtils
 from guake.utils import get_server_time
@@ -140,7 +141,6 @@ class Guake(SimpleGladeApp):
 
         self.hidden = True
         self.forceHide = False
-        self.preventHide = False
 
         # trayicon! Using SVG handles better different OS trays
         # img = pixmapfile('guake-tray.svg')
@@ -402,7 +402,7 @@ class Guake(SimpleGladeApp):
         """Hides terminal main window when it loses the focus and if
         the window_losefocus gconf variable is True.
         """
-        if self.preventHide:
+        if not HidePrevention(self.window).may_hide():
             return
 
         value = self.settings.general.get_boolean('window-losefocus')
@@ -454,7 +454,7 @@ class Guake(SimpleGladeApp):
             self.forceHide = False
             return
 
-        if self.preventHide:
+        if not HidePrevention(self.window).may_hide():
             return
 
         if not self.win_prepare():
@@ -637,7 +637,7 @@ class Guake(SimpleGladeApp):
         """Hides the main window of the terminal and sets the visible
         flag to False.
         """
-        if self.preventHide:
+        if not HidePrevention(self.window).may_hide():
             return
         self.hidden = True
         self.get_widget('window-root').unstick()
@@ -979,7 +979,7 @@ class Guake(SimpleGladeApp):
     def find_tab(self, directory=None):
         log.debug("find")
         # TODO SEARCH
-        self.preventHide = True
+        HidePrevention(self.window).prevent()
         search_text = Gtk.TextView()
 
         dialog = Gtk.Dialog(
@@ -1001,7 +1001,7 @@ class Guake(SimpleGladeApp):
     def _dialog_response_callback(self, dialog, response_id):
         if response_id not in (RESPONSE_FORWARD, RESPONSE_BACKWARD):
             dialog.destroy()
-            self.preventHide = False
+            HidePrevention(self.window).allow()
             return
 
         start, end = dialog.buffer.get_bounds()

--- a/guake/utils.py
+++ b/guake/utils.py
@@ -65,6 +65,21 @@ class TabNameUtils():
         return text
 
 
+class HidePrevention():
+
+    def __init__(self, window):
+        self.window = window
+
+    def may_hide(self):
+        return getattr(self.window, 'can_hide', True)
+
+    def prevent(self):
+        setattr(self.window, 'can_hide', False)
+
+    def allow(self):
+        setattr(self.window, 'can_hide', True)
+
+
 class FullscreenManager():
 
     def __init__(self, settings, window):

--- a/guake/utils.py
+++ b/guake/utils.py
@@ -68,15 +68,25 @@ class TabNameUtils():
 class HidePrevention():
 
     def __init__(self, window):
+        """Create a new HidePrevention object like `HidePrevention(window)`
+        """
         self.window = window
 
     def may_hide(self):
+        """returns True if the window is allowed to hide and
+        False if `prevent()` is called from some where
+        """
         return getattr(self.window, 'can_hide', True)
 
     def prevent(self):
+        """sets a flag on the window object which indicates to
+        may_hide that the window is NOT allowed to be hidden.
+        """
         setattr(self.window, 'can_hide', False)
 
     def allow(self):
+        """sets the flag so that it indicates to may_hide that the window is allowed to be hidden
+        """
         setattr(self.window, 'can_hide', True)
 
 


### PR DESCRIPTION
in the utils package there is now a class called `HidePrevention` which can be used to prevent the main window from hiding.
create a new HidePrevention object like `HidePrevention(window)` 
* `may_hide()` returns True if the window is allowed to hide and false if `prevent()` is called from some where 
* `prevent()`sets a flag on the window object which indicates to `may_hide()`  that the window is **not** allowed to be hidden
* `allow()` sets the flag so that it indicates to `may_hide()`  that the window is allowed to be hidden