### PR TITLE
fix terminal directory selection after tab has been closed

### DIFF
--- a/guake/guake_app.py
+++ b/guake/guake_app.py
@@ -915,10 +915,12 @@ class Guake(SimpleGladeApp):
         return TabNameUtils.shorten(vte_title, self.settings)
 
     def on_terminal_title_changed(self, vte, term):
-        box = term.get_parent()
+        # box must be a page
+        box = term.get_parent().get_root_box()
         use_vte_titles = self.settings.general.get_boolean('use-vte-titles')
         if not use_vte_titles:
             return
+        # this may return -1, should be checked ;)
         page_num = self.notebook.page_num(box)
         # if tab has been renamed by user, don't override.
         if not getattr(box, 'custom_label_set', False):

--- a/guake/notebook.py
+++ b/guake/notebook.py
@@ -171,11 +171,11 @@ class TerminalNotebook(Gtk.Notebook):
             directory = os.environ['HOME']
             try:
                 if self.guake.settings.general.get_boolean('open-tab-cwd'):
-                    active_terminal = self.get_current_terminal()
-                    if not active_terminal:
-                        directory = os.path.expanduser('~')
-                    directory = active_terminal.get_current_directory()
-            except:  # pylint: disable=bare-except
+                    active_terminal = self.get_focused_terminal()
+                    directory = os.path.expanduser('~')
+                    if active_terminal:
+                        directory = active_terminal.get_current_directory()
+            except Exception as e:
                 pass
         terminal.spawn_sync_pid(directory)
 


### PR DESCRIPTION
3641525:
Just for future reference:
1. open guake
2. change to directory x 
3. open new tab
5. new tab will run in directory x
4. close new tab
3. open new tab
2. new tab won't run in directory x but in ~


5f8ed30 :
fix #1398 
