### PR TITLE
Add missing module import

### DIFF
--- a/guake/terminal.py
+++ b/guake/terminal.py
@@ -23,6 +23,7 @@ import os
 import re
 import signal
 import subprocess
+import sys
 import threading
 import uuid
 


### PR DESCRIPTION
If `libutempter` not installed, invocation of `sys.stderr.write` can't be performed, because `sys` does not imported.

Here is traceback:
```
Guake not running, starting it
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/dbus/bus.py", line 175, in activate_name_owner
    return self.get_name_owner(bus_name)
  File "/usr/lib/python3/dist-packages/dbus/bus.py", line 361, in get_name_owner
    's', (bus_name,), **keywords)
  File "/usr/lib/python3/dist-packages/dbus/connection.py", line 651, in call_blocking
    message, timeout)
dbus.exceptions.DBusException: org.freedesktop.DBus.Error.NameHasNoOwner: Could not get owner of name 'org.guake3.RemoteControl': no such name

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/guake/main.py", line 295, in main
    remote_object = bus.get_object(DBUS_NAME, DBUS_PATH)
  File "/usr/lib/python3/dist-packages/dbus/bus.py", line 241, in get_object
    follow_name_owner_changes=follow_name_owner_changes)
  File "/usr/lib/python3/dist-packages/dbus/proxies.py", line 248, in __init__
    self._named_service = conn.activate_name_owner(bus_name)
  File "/usr/lib/python3/dist-packages/dbus/bus.py", line 180, in activate_name_owner
    self.start_service_by_name(bus_name)
  File "/usr/lib/python3/dist-packages/dbus/bus.py", line 278, in start_service_by_name
    'su', (bus_name, flags)))
  File "/usr/lib/python3/dist-packages/dbus/connection.py", line 651, in call_blocking
    message, timeout)
dbus.exceptions.DBusException: org.freedesktop.DBus.Error.ServiceUnknown: The name org.guake3.RemoteControl was not provided by any .service files

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/guake/terminal.py", line 59, in <module>
    libutempter = cdll.LoadLibrary('libutempter.so.0')
  File "/usr/lib/python3.6/ctypes/__init__.py", line 426, in LoadLibrary
    return self._dlltype(name)
  File "/usr/lib/python3.6/ctypes/__init__.py", line 348, in __init__
    self._handle = _dlopen(self._name, mode)
OSError: libutempter.so.0: cannot open shared object file: No such file or directory

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/bin/guake", line 10, in <module>
    sys.exit(exec_main())
  File "/usr/local/lib/python3.6/dist-packages/guake/main.py", line 410, in exec_main
    if not main():
  File "/usr/local/lib/python3.6/dist-packages/guake/main.py", line 309, in main
    from guake.guake_app import Guake
  File "/usr/local/lib/python3.6/dist-packages/guake/guake_app.py", line 68, in <module>
    from guake.notebook import TerminalNotebook
  File "/usr/local/lib/python3.6/dist-packages/guake/notebook.py", line 21, in <module>
    from guake.boxes import DualTerminalBox
  File "/usr/local/lib/python3.6/dist-packages/guake/boxes.py", line 12, in <module>
    from guake.callbacks import MenuHideCallback
  File "/usr/local/lib/python3.6/dist-packages/guake/callbacks.py", line 8, in <module>
    from guake.prefs import PrefsDialog
  File "/usr/local/lib/python3.6/dist-packages/guake/prefs.py", line 59, in <module>
    from guake.terminal import GuakeTerminal
  File "/usr/local/lib/python3.6/dist-packages/guake/terminal.py", line 65, in <module>
    sys.stderr.write("[WARN] ===================================================================\n")
NameError: name 'sys' is not defined
```