### PR TITLE
Fix file path variable

### DIFF
--- a/data/prefs.glade
+++ b/data/prefs.glade
@@ -2322,9 +2322,9 @@ To disable a shortcut, press the "Backspace" key.</property>
                                             <property name="can_focus">False</property>
                                             <property name="has_entry">True</property>
                                             <items>
-                                              <item>subl %(filepath)s:%(line_number)s</item>
-                                              <item>code -g %(filepath)s:%(line_number)s</item>
-                                              <item>atom %(filepath)s:%(line_number)s</item>
+                                              <item>subl %(file_path)s:%(line_number)s</item>
+                                              <item>code -g %(file_path)s:%(line_number)s</item>
+                                              <item>atom %(file_path)s:%(line_number)s</item>
                                             </items>
                                             <child internal-child="entry">
                                               <object class="GtkEntry" id="quick_open_command_line">


### PR DESCRIPTION
Consider this error:
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/guake/callbacks.py", line 81, in on_quick_open
    self.terminal.quick_open()
  File "/usr/local/lib/python3.6/dist-packages/guake/terminal.py", line 321, in quick_open
    self._execute_quick_open(fp, lo)
  File "/usr/local/lib/python3.6/dist-packages/guake/terminal.py", line 367, in _execute_quick_open
    resolved_cmdline = cmdline % {"file_path": filepath, "line_number": line_number}
KeyError: 'filepath'
```
You can reproduce it, if enable quick open, select one of default templates, and try to open some file from terminal.