### PR TITLE
TerminalNotebook.get_terminals corrected

### DIFF
--- a/guake/dbusiface.py
+++ b/guake/dbusiface.py
@@ -128,7 +128,7 @@ class DbusManager(dbus.service.Object):
 
     @dbus.service.method(DBUS_NAME, in_signature='i', out_signature='s')
     def get_gtktab_name(self, tab_index=0):
-        return self.guake.tabs.get_children()[tab_index].get_label()
+        return self.guake.notebook.get_tab_text_index(tab_index)
 
     @dbus.service.method(DBUS_NAME, out_signature='s')
     def get_selected_uuidtab(self):

--- a/guake/guake_app.py
+++ b/guake/guake_app.py
@@ -370,7 +370,7 @@ class Guake(SimpleGladeApp):
         if command[-1] != '\n':
             command += '\n'
 
-        terminal = self.notebook.get_last_terminal_focused()
+        terminal = self.notebook.get_current_terminal()
         terminal.feed_child(command)
 
     def execute_command_by_uuid(self, tab_uuid, command):

--- a/guake/notebook.py
+++ b/guake/notebook.py
@@ -86,7 +86,7 @@ class TerminalNotebook(Gtk.Notebook):
         page = self.get_nth_page(index)
         return page.get_terminals()
 
-    def get_terminals(self, index):
+    def get_terminals(self):
         terminals = []
         for page in self.iter_pages():
             terminals += page.get_terminals()


### PR DESCRIPTION
The method get_terminals does not require index parameter.
If placed it causes the get_count_tab() dbus method to crash.

get_tab_terminal dbus interface returns 
```
return len(self.guake.notebook.get_terminals())
```
It's passing no arguments, but it seems that get_terminals requires an index.
The index argument is not used anywhere inside the get_terminals method so i decided to remove it.
Please accept this pull request because after the notebook reworking, my project guake-indicator is in trouble since there is a lot to fix.
