### PR TITLE
Update dbusiface.py

### DIFF
--- a/guake/dbusiface.py
+++ b/guake/dbusiface.py
@@ -72,7 +72,7 @@ class DbusManager(dbus.service.Object):
 
     @dbus.service.method(DBUS_NAME, in_signature='i')
     def select_tab(self, tab_index=0):
-        return self.guake.select_tab(int(tab_index))
+        return self.guake.notebook.set_current_page(int(tab_index))
 
     @dbus.service.method(DBUS_NAME, out_signature='i')
     def get_selected_tab(self):


### PR DESCRIPTION
Fixed select_tab interface method.
Now we are forced to use the gtknotebook object, guake.select_tab() was deleted in previous commits.
