### PR TITLE
0.8.x dbus fullscreen toggle

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -15,7 +15,7 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
-AC_INIT([guake], [0.8.11], [http://guake-project.org/])
+AC_INIT([guake], [0.8.13], [http://guake-project.org/])
 
 AC_CONFIG_HEADERS([config.h])
 

--- a/configure.ac
+++ b/configure.ac
@@ -15,7 +15,7 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
-AC_INIT([guake], [0.8.13], [http://guake-project.org/])
+AC_INIT([guake], [0.8.14], [http://guake-project.org/])
 
 AC_CONFIG_HEADERS([config.h])
 

--- a/src/guake/dbusiface.py
+++ b/src/guake/dbusiface.py
@@ -64,6 +64,14 @@ class DbusManager(dbus.service.Object):
     def fullscreen(self):
         self.guake.fullscreen()
 
+    @dbus.service.method(DBUS_NAME)
+    def unfullscreen(self):
+        self.guake.unfullscreen()
+
+    @dbus.service.method(DBUS_NAME)
+    def fullscreen_toggle(self):
+        self.guake.accel_toggle_fullscreen()
+
     @dbus.service.method(DBUS_NAME, in_signature='s')
     def add_tab(self, directory=''):
         return self.guake.add_tab(directory)


### PR DESCRIPTION
Currently fullscreen keyboard shortcut for me is broken, no matter what I set it to and I can't jump to a non 0.8.x branch right now for GTK+3. I used this base DBUS script from https://github.com/Guake/guake/issues/492#issuecomment-324165795 and made this script https://gist.github.com/ElijahLynn/6a5f6b1ef64e39c40ef3626caacbe95b. The script uses 2 new DBUS methods that I added to Guake in this PR: unfullscreen() and fullscreen_toggle(). 

I put the script in `~/bin/guake_fullscreen_toggle.py` then set Ubuntu 14.04 to a custom keyboard shortcut (ctrl+shift+alt+t) with a value of `python /home/elijah/bin/guake_fullscreen_toggle.py` (can't use the `~` home shortcut) to invoke the DBUS fullscreen toggle script and it works nicely now.

The unfullscreen() isn't needed for the toggle script but I left it in because I found it useful during testing with the `d-feet` program. 

