### PR TITLE
Added split current terminal methods on dbusinterface

### DIFF
--- a/guake/dbusiface.py
+++ b/guake/dbusiface.py
@@ -137,3 +137,11 @@ class DbusManager(dbus.service.Object):
     @dbus.service.method(DBUS_NAME, in_signature='ss')
     def execute_command_by_uuid(self, tab_uuid, command):
         self.guake.execute_command_by_uuid(tab_uuid, command)
+
+    @dbus.service.method(DBUS_NAME)
+    def v_split_current_terminal(self):
+        self.guake.notebook.get_current_terminal().get_parent().split_v()
+
+    @dbus.service.method(DBUS_NAME)
+    def h_split_current_terminal(self):
+        self.guake.notebook.get_current_terminal().get_parent().split_h()


### PR DESCRIPTION
I'd like to take advantage of the recent split terminal functionality on dbus interface.
For this reason I added 2 new methods:

v_split_current_terminal 
h_split_current_terminal

The first method splits the current terminal vertically via a dbus call
The second method splits the current terminal horizontally via a dbus call.

I'd like this feature to be added to Guake so I can write more complex scripts with guake indicator (for example a command on a new split rather than on a new tab).

Thanks
