### PR TITLE
New dbus interface method to execute command on focused splitted term…

### DIFF
--- a/guake/dbusiface.py
+++ b/guake/dbusiface.py
@@ -145,3 +145,7 @@ class DbusManager(dbus.service.Object):
     @dbus.service.method(DBUS_NAME)
     def h_split_current_terminal(self):
         self.guake.notebook.get_current_terminal().get_parent().split_h()
+
+    @dbus.service.method(DBUS_NAME, in_signature='s')
+    def execute_command_current_termbox(self, command):
+        self.guake.notebook.get_current_terminal().execute_command(command)


### PR DESCRIPTION
Added execute_command_current_termbox dbus function.
The difference between the old execute_command and the execute_command_current_termbox is that the first execute the command in all terminals tied to the current guake tab, the second one sends the command ONLY to the terminal on focus (useful after splitting terms).
This feature  would allow my guake-indicator to perform more complex macros like, for example, opening a new tab, splitting vertically and execute a command in the first split and another in the second.

