### PR TITLE
Resolve #1451

### DIFF
--- a/guake/notebook.py
+++ b/guake/notebook.py
@@ -199,7 +199,7 @@ class TerminalNotebook(Gtk.Notebook):
         self.emit('terminal-spawned', terminal, terminal.pid)
 
     def new_page_with_focus(self, directory=None):
-        box, page_num, terminal = self.new_page()
+        box, page_num, terminal = self.new_page(directory)
         self.set_current_page(page_num)
         self.rename_page(page_num, _("Terminal"), False)
         terminal.grab_focus()

--- a/releasenotes/notes/fix-1451-d6ed2b40dc05bcf9.yaml
+++ b/releasenotes/notes/fix-1451-d6ed2b40dc05bcf9.yaml
@@ -1,0 +1,2 @@
+fixes:
+  - fixes #1451: `guake --new-tab dir` opens tab in $HOME dir


### PR DESCRIPTION
Pass `directory` argument to `new_page()` in `new_page_with_focus()`. Probably introduced in 0834bad4.