### PR TITLE
Open new home tab hotkey with `CTRL+SHIFT+H`

### DIFF
--- a/data/org.guake.gschema.xml
+++ b/data/org.guake.gschema.xml
@@ -307,6 +307,11 @@
             <default>'&lt;Control&gt;&lt;Shift&gt;t'</default>
             <summary>Add a new tab.</summary>
             <description>Calls the function to add a new tab in guake window.</description>
+	</key>
+        <key name="new-tab-home" type="s">
+            <default>'&lt;Control&gt;&lt;Shift&gt;h'</default>
+            <summary>Add a new tab in home directory.</summary>
+            <description>Calls the function to add a new home directory tab in guake window.</description>
         </key>
         <key name="close-tab" type="s">
             <default>'&lt;Control&gt;&lt;Shift&gt;w'</default>

--- a/guake/guake_app.py
+++ b/guake/guake_app.py
@@ -497,7 +497,7 @@ class Guake(SimpleGladeApp):
         #         self.set_terminal_focus()
         #         return
 
-        log.info("hiding the terminal")
+        log.info("Hiding the terminal")
         self.hide()
 
     def show_focus(self, *args):
@@ -780,6 +780,12 @@ class Guake(SimpleGladeApp):
         """Callback to add a new tab. Called by the accel key.
         """
         self.add_tab()
+        return True
+
+    def accel_add_home(self, *args):
+        """Callback to add a new tab in home directory. Called by the accel key.
+        """
+        self.add_tab(os.environ['HOME'])
         return True
 
     def accel_prev(self, *args):

--- a/guake/keybindings.py
+++ b/guake/keybindings.py
@@ -55,16 +55,23 @@ class Keybindings():
 
         # Setup local keys
         keys = [
-            'toggle-fullscreen', 'new-tab', 'new-tab-home', 'close-tab', 'rename-current-tab', 'previous-tab',
-            'next-tab', 'clipboard-copy', 'clipboard-paste', 'quit', 'zoom-in', 'zoom-out',
-            'increase-height', 'decrease-height', 'increase-transparency', 'decrease-transparency',
-            'toggle-transparency', "search-on-web", 'move-tab-left', 'move-tab-right',
-            'switch-tab1', 'switch-tab2', 'switch-tab3', 'switch-tab4', 'switch-tab5',
-            'switch-tab6', 'switch-tab7', 'switch-tab8', 'switch-tab9', 'switch-tab10',
-            'switch-tab-last', 'reset-terminal', 'split-tab-vertical', 'split-tab-horizontal',
-            'close-terminal', 'focus-terminal-up', 'focus-terminal-down', 'focus-terminal-right',
-            'focus-terminal-left', 'move-terminal-split-up', 'move-terminal-split-down',
-            'move-terminal-split-left', 'move-terminal-split-right'
+            'toggle-fullscreen', 'new-tab', 'new-tab-home',
+            'close-tab', 'rename-current-tab', 'previous-tab',
+            'next-tab', 'clipboard-copy', 'clipboard-paste', 'quit',
+            'zoom-in', 'zoom-out', 'increase-height',
+            'decrease-height', 'increase-transparency',
+            'decrease-transparency', 'toggle-transparency',
+            "search-on-web", 'move-tab-left', 'move-tab-right',
+            'switch-tab1', 'switch-tab2', 'switch-tab3',
+            'switch-tab4', 'switch-tab5', 'switch-tab6',
+            'switch-tab7', 'switch-tab8', 'switch-tab9',
+            'switch-tab10', 'switch-tab-last', 'reset-terminal',
+            'split-tab-vertical', 'split-tab-horizontal',
+            'close-terminal', 'focus-terminal-up',
+            'focus-terminal-down', 'focus-terminal-right',
+            'focus-terminal-left', 'move-terminal-split-up',
+            'move-terminal-split-down', 'move-terminal-split-left',
+            'move-terminal-split-right'
         ]
         for key in keys:
             guake.settings.keybindingsLocal.onChangedValue(key, self.reload_accelerators)

--- a/guake/keybindings.py
+++ b/guake/keybindings.py
@@ -55,7 +55,7 @@ class Keybindings():
 
         # Setup local keys
         keys = [
-            'toggle-fullscreen', 'new-tab', 'close-tab', 'rename-current-tab', 'previous-tab',
+            'toggle-fullscreen', 'new-tab', 'new-tab-home', 'close-tab', 'rename-current-tab', 'previous-tab',
             'next-tab', 'clipboard-copy', 'clipboard-paste', 'quit', 'zoom-in', 'zoom-out',
             'increase-height', 'decrease-height', 'increase-transparency', 'decrease-transparency',
             'toggle-transparency', "search-on-web", 'move-tab-left', 'move-tab-right',
@@ -133,6 +133,10 @@ class Keybindings():
         key, mask = Gtk.accelerator_parse(getk('new-tab'))
         if key > 0:
             self.accel_group.connect(key, mask, Gtk.AccelFlags.VISIBLE, self.guake.accel_add)
+
+        key, mask = Gtk.accelerator_parse(getk('new-tab-home'))
+        if key > 0:
+            self.accel_group.connect(key, mask, Gtk.AccelFlags.VISIBLE, self.guake.accel_add_home)
 
         key, mask = Gtk.accelerator_parse(getk('close-tab'))
         if key > 0:

--- a/guake/notebook.py
+++ b/guake/notebook.py
@@ -165,6 +165,7 @@ class TerminalNotebook(Gtk.Notebook):
         self.delete_page(self.get_current_page(), kill, prompt)
 
     def new_page(self, directory=None):
+        log.info("Spawning new terminal at %s", directory)
         terminal = self.terminal_spawn(directory)
         terminal_box = TerminalBox()
         terminal_box.set_terminal(terminal)

--- a/guake/notebook.py
+++ b/guake/notebook.py
@@ -199,7 +199,7 @@ class TerminalNotebook(Gtk.Notebook):
         self.emit('terminal-spawned', terminal, terminal.pid)
 
     def new_page_with_focus(self, directory=None):
-        box, page_num, terminal = self.new_page()
+        box, page_num, terminal = self.new_page(directory)
         self.set_current_page(page_num)
         self.rename_page(page_num, _("Terminal"), False)
         terminal.grab_focus()

--- a/guake/prefs.py
+++ b/guake/prefs.py
@@ -124,6 +124,10 @@ HOTKEYS = [
                 'label': _('New tab')
             },
             {
+                'key': 'new-tab-home',
+                'label': _('New tab in home directory')
+            },
+            {
                 'key': 'close-tab',
                 'label': _('Close tab')
             },

--- a/releasenotes/notes/fix-1451-d6ed2b40dc05bcf9.yaml
+++ b/releasenotes/notes/fix-1451-d6ed2b40dc05bcf9.yaml
@@ -1,0 +1,2 @@
+fixes:
+  - fixes #1451: `guake --new-tab dir` opens tab in $HOME dir

--- a/releasenotes/notes/hotkey-new-tab-home-3942e1e6ba0932af.yaml
+++ b/releasenotes/notes/hotkey-new-tab-home-3942e1e6ba0932af.yaml
@@ -1,0 +1,2 @@
+features:
+  - new hotkey (CTRL+SHIFT+H) to open new tab in home directory


### PR DESCRIPTION
Even if I set `Open new tab in current directory` by default sometimes I just want to start fresh at my home dir, so I created this new hotkey.

Although I must admit it is redundant with `CTRL+SHIFT+T` if the user does not set `Open new tab in current directory`. Maybe remove that option altogether and open new tabs in current dir by default, or just enable the hotkey if the option is set?

Not: only works with my fix for #1451 