### PR TITLE
Update installing.rst

### DIFF
--- a/docs/source/user/installing.rst
+++ b/docs/source/user/installing.rst
@@ -28,7 +28,7 @@ Then you can open it via:
 guake
 ```
 
-To allow global 'F12' to open the guake, go to Setting >> Device >> Keyboard >> Scroll to bottom >> "+" to create a new global short cut with 'F12' keybinding and comand 'guake'. 
+To allow global 'F12' to open the guake, go to Setting >> Device >> Keyboard >> Scroll to bottom >> "+" to create a new global short cut with 'F12' keybinding and comand 'guake-toggle'. 
 
 You may notice the style may have some error. You can fix this by installing and apply custom theme. 
 

--- a/docs/source/user/installing.rst
+++ b/docs/source/user/installing.rst
@@ -15,8 +15,35 @@ Ubuntu and Debian users will use ``sudo apt install guake``.
 Fedora
 ------
 
-TBD: Want to help fill this section? Please submit your suggestion on
-`GitHub <https://github.com/Guake/guake>`_.
+Tested in 29: 
+We can use dnf to install it. 
+
+```bash 
+sudo dnf install -y guake
+```
+
+Then you can open it via:
+
+```bash
+guake
+```
+
+To allow global 'F12' to open the guake, go to Setting >> Device >> Keyboard >> Scroll to bottom >> "+" to create a new global short cut with 'F12' keybinding and comand 'guake'. 
+
+You may notice the style may have some error. You can fix this by installing and apply custom theme. 
+
+```bash 
+sudo dnf install -y arc-theme gnome-tweaks 
+```
+
+Then use 
+
+```bash 
+gnome-tweaks
+```
+
+to change theme to change theme to one of the yakuake will fix this. 
+
 
 Arch Linux
 ----------

--- a/docs/source/user/installing.rst
+++ b/docs/source/user/installing.rst
@@ -28,7 +28,7 @@ Then you can open it via:
 guake
 ```
 
-To allow global 'F12' to open the guake, go to Setting >> Device >> Keyboard >> Scroll to bottom >> "+" to create a new global short cut with 'F12' keybinding and comand 'guake-toggle'. 
+To allow global 'F12' to open the guake, go to Setting >> Device >> Keyboard >> Scroll to bottom >> "+" to create a new global short cut with 'F12' keybinding and comand 'guake'. 
 
 You may notice the style may have some error. You can fix this by installing and apply custom theme. 
 


### PR DESCRIPTION
A way to successful install guake in fedora 29, not tested in 28.

Just a simple update of documents. Nothing changed in code of guake.