### PR TITLE
remove duplicate event bind that causes issues with quick_open

### DIFF
--- a/guake/terminal.py
+++ b/guake/terminal.py
@@ -96,7 +96,6 @@ class GuakeTerminal(Vte.Terminal):
         self.configure_terminal()
         self.add_matches()
         self.connect('button-press-event', self.button_press)
-        self.connect('button-press-event', self.button_press)
         self.connect('child-exited', self.on_child_exited)
         self.matched_value = ''
         self.font_scale_index = 0

--- a/releasenotes/notes/double_event_fix-c49129c68ead0b6b.yaml
+++ b/releasenotes/notes/double_event_fix-c49129c68ead0b6b.yaml
@@ -1,0 +1,48 @@
+release_summary: >
+  quick fix/bring up issue of double quick_open event firing
+
+features:
+  - |
+    List new features here followed by the ticket number, for example::
+
+      - new exiting feature #1234
+
+known_issues:
+  - |
+    List know issue introduced by the change here, followed if possible by a
+    ticket number, for example::
+
+      - such other feature is broken #1234
+
+upgrade:
+  - |
+    List upgrade note for end users here
+
+deprecations:
+  - |
+    List deprecations notes heres, ie, feature that are being removed by the
+    change.
+
+security:
+  - |
+    Add security notes here.
+
+fixes:
+  - |
+    removed duplicate event bind? previously I had issue where quick-open event would be fired 
+twice because of this.
+
+translations:
+  - Only put a list of updated 2 letters language code, for example::
+
+        translations:
+          - fr
+          - de
+
+notes_for_package_maintainers:
+  - |
+    Add notes for package maintainers here.
+
+other:
+  - |
+    Add other notes here.


### PR DESCRIPTION
previously, 2 events were firing for every single click which meant that a quick open cmd would be run twice for every one click. e.g. I had 'xdg-open %(file_path)s' for the quick_open command but this would get executed twice for every one ctrl+click.