### PR TITLE
 fix data path in paths.py

### DIFF
--- a/guake/paths.py.in
+++ b/guake/paths.py.in
@@ -35,7 +35,7 @@ def get_default_package_root():
 
 
 def get_data_files_dir():
-    d = os.path.dirname(os.path.dirname(sys.modules["guake"].__file__))
+    d = os.path.dirname(sys.modules["guake"].__file__)
     p = os.path.basename(os.path.abspath(os.path.join(d, "..")))
     if p in ["site-packages", "dist-packages"]:
         # current "guake" package has been installed in a prefix structure (/usr, /usr/local or


### PR DESCRIPTION
Issue on Guake Terminal 3.4.0

I tracked it down to `ab7b44a`.
 If I undo this change, guake will start.
