### PR TITLE
Implement option for 8-bit bright text

### DIFF
--- a/data/org.guake.gschema.xml
+++ b/data/org.guake.gschema.xml
@@ -282,6 +282,11 @@
             <summary>Allow displaying bold font in Guake terminal.</summary>
             <description>When allow_bold is disabled, any text in Guake terminal intended to print as bold text will be instead rendered as normal text.</description>
         </key>
+        <key name="bold-is-bright" type="b">
+            <default>false</default>
+            <summary>Use bright colors for bold text</summary>
+            <description>If true, text from the first 8 colors that is formatted as bold will also be switched to its bright variant.</description>
+        </key>
     </schema>
     <schema id="guake.style.background" path="/apps/guake/style/background/">
         <key name="transparency" type="i">

--- a/data/prefs.glade
+++ b/data/prefs.glade
@@ -1677,6 +1677,22 @@
                                     <property name="top_attach">2</property>
                                   </packing>
                                 </child>
+                                <child>
+                                  <object class="GtkCheckButton" id="bold_is_bright">
+                                    <property name="label" translatable="yes">Bold text is also bright</property>
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">True</property>
+                                    <property name="receives_default">False</property>
+                                    <property name="halign">start</property>
+                                    <property name="use_underline">True</property>
+                                    <property name="draw_indicator">True</property>
+                                    <signal name="toggled" handler="on_bold_is_bright_toggled" swapped="no"/>
+                                  </object>
+                                  <packing>
+                                    <property name="left_attach">0</property>
+                                    <property name="top_attach">3</property>
+                                  </packing>
+                                </child>
                               </object>
                             </child>
                           </object>

--- a/guake/gsettings.py
+++ b/guake/gsettings.py
@@ -79,6 +79,7 @@ class GSettingHandler():
         settings.styleFont.onChangedValue('style', self.fstyle_changed)
         settings.styleFont.onChangedValue('palette', self.fpalette_changed)
         settings.styleFont.onChangedValue('allow-bold', self.allow_bold_toggled)
+        settings.styleFont.onChangedValue('bold-is-bright', self.bold_is_bright_toggled)
         settings.styleBackground.onChangedValue('transparency', self.bgtransparency_changed)
 
         settings.general.onChangedValue('compat-backspace', self.backspace_changed)
@@ -229,6 +230,13 @@ class GSettingHandler():
         """
         for term in self.guake.notebook_manager.iter_terminals():
             term.set_allow_bold(settings.get_boolean(key))
+
+    def bold_is_bright_toggled(self, settings, key, user_data):
+        """If the dconf var bold_is_bright is changed, this method will be called
+        and will change the VTE terminal to toggle auto-brightened bold text.
+        """
+        for term in self.guake.notebook_manager.iter_terminals():
+            term.set_bold_is_bright(settings.get_boolean(key))
 
     def palette_font_and_background_color_toggled(self, settings, key, user_data):
         """If the gconf var use_palette_font_and_background_color be changed, this method

--- a/guake/prefs.py
+++ b/guake/prefs.py
@@ -606,6 +606,11 @@ class PrefsCallbacks():
         """
         self.settings.styleFont.set_boolean('allow-bold', chk.get_active())
 
+    def on_bold_is_bright_toggled(self, chk):
+        """Changes the value of bold_is_bright in dconf
+        """
+        self.settings.styleFont.set_boolean('bold-is-bright', chk.get_active())
+
     def on_font_style_font_set(self, fbtn):
         """Changes the value of font_style in dconf
         """
@@ -1233,6 +1238,10 @@ class PrefsDialog(SimpleGladeApp):
         # allow bold font
         value = self.settings.styleFont.get_boolean('allow-bold')
         self.get_widget('allow_bold').set_active(value)
+
+        # use bold is bright
+        value = self.settings.styleFont.get_boolean('bold-is-bright')
+        self.get_widget('bold_is_bright').set_active(value)
 
         # palette
         self.fill_palette_names()

--- a/guake/terminal.py
+++ b/guake/terminal.py
@@ -156,6 +156,9 @@ class GuakeTerminal(Vte.Terminal):
         if (Vte.MAJOR_VERSION, Vte.MINOR_VERSION) >= (0, 50):
             self.set_allow_hyperlink(True)
 
+        if (Vte.MAJOR_VERSION, Vte.MINOR_VERSION) >= (0, 56):
+            self.set_bold_is_bright(self.guake.settings.styleFont.get_boolean('bold-is-bright'))
+
         # TODO PORT is this still the case with the newer vte version?
         # -- Ubuntu has a patch to libvte which disables mouse scrolling in apps
         # -- like vim and less by default. If this is the case, enable it back.


### PR DESCRIPTION
In vte 0.52, a new option was added to emit only bold when bold text is emitted, and made the default behavior in vte 0.56.

The motivation for the change is to allow better 256-bit color in applications and colorschemes. However, traditionally, applications assumed that bold text would also be bright, and many applications look quite bad with this setting. It is therefore useful to allow users to decide whether to utilize this behavior.

Fixes #1507
Closes #1089