### PR TITLE
Add save/restore preferences to Guake CLI

### DIFF
--- a/guake/main.py
+++ b/guake/main.py
@@ -38,6 +38,8 @@ log = logging.getLogger(__name__)
 
 from guake.globals import NAME
 from guake.globals import bindtextdomain
+from guake.utils import save_preferences
+from guake.utils import restore_preferences
 
 # When we are in the document generation on readthedocs, we do not have paths.py generated
 try:
@@ -268,6 +270,22 @@ def main():
         help=_('Do not execute the start up script')
     )
 
+    parser.add_option(
+        '--save-preferences',
+        dest='save_preferences',
+        action='store',
+        default=None,
+        help=_('Save Guake preferences to this filename')
+    )
+
+    parser.add_option(
+        '--restore-preferences',
+        dest='restore_preferences',
+        action='store',
+        default=None,
+        help=_('Restore Guake preferences from this file')
+    )
+
     # checking mandatory dependencies
     import gi
 
@@ -300,6 +318,15 @@ def main():
         print('VTE: {}'.format(vte_version()))
         print('VTE runtime: {}'.format(vte_runtime_version()))
         print('Gtk: {}'.format(gtk_version()))
+        sys.exit(0)
+
+    if options.save_preferences and options.restore_preferences:
+        parser.error('options --save-preferences and --restore-preferences are mutually exclusive')
+    if options.save_preferences:
+        save_preferences(options.save_preferences)
+        sys.exit(0)
+    elif options.restore_preferences:
+        restore_preferences(options.restore_preferences)
         sys.exit(0)
 
     import dbus

--- a/guake/utils.py
+++ b/guake/utils.py
@@ -28,6 +28,7 @@ import time
 
 import gi
 gi.require_version('Gtk', '3.0')
+gi.require_version('Gdk', '3.0')
 
 from gi.repository import Gdk
 from gi.repository import GdkX11
@@ -80,6 +81,22 @@ def save_tabs_when_changed(func):
         if g and g.settings.general.get_boolean('save-tabs-when-changed'):
             g.save_tabs()
     return wrapper
+
+
+def save_preferences(filename):
+    # XXX: Hardcode?
+    prefs = subprocess.check_output(['dconf', 'dump', '/apps/guake/'])
+    with open(filename, 'wb') as f:
+        f.write(prefs)
+
+
+def restore_preferences(filename):
+    # XXX: Hardcode?
+    with open(filename, 'rb') as f:
+        prefs = f.read()
+    p = subprocess.Popen(['dconf', 'load', '/apps/guake/'],
+                         stdin=subprocess.PIPE)
+    p.communicate(input=prefs)
 
 
 class TabNameUtils():

--- a/releasenotes/notes/save-prefs-351292e24b6e6bea.yaml
+++ b/releasenotes/notes/save-prefs-351292e24b6e6bea.yaml
@@ -1,0 +1,7 @@
+release_summary: >
+    Add save/restore preferences to Guake CLI
+
+features:
+  - |
+    - Save preferences of Guake
+    - Restore preferences of Guake


### PR DESCRIPTION
Add save/restore preferences to Guake CLI

    $ guake --save-preferences prefs.guake
    $ guake --restore-preferences prefs.guake

**WARNING**

User will need to ensure the content inside the preferences file,
otherwise it may broke up the preferences, e.g. bad accel-key binding
