### PR TITLE
Search in terminal

### DIFF
--- a/data/org.guake.gschema.xml
+++ b/data/org.guake.gschema.xml
@@ -328,6 +328,11 @@
         </key>
     </schema>
     <schema id="guake.keybindings.local" path="/apps/guake/keybindings/local/">
+        <key name="search-terminal" type="s">
+            <default>'&lt;Control&gt;&lt;Shift&gt;f'</default>
+            <summary>Search terminal</summary>
+            <description>Show search box to search text inside the terminal</description>
+        </key>
         <key name="quit" type="s">
             <default>'&lt;Control&gt;&lt;Shift&gt;q'</default>
             <summary>Quit</summary>

--- a/guake/boxes.py
+++ b/guake/boxes.py
@@ -10,6 +10,7 @@ from gi.repository import Gio
 from gi.repository import Gtk
 from gi.repository import Vte
 from gi.repository import GLib
+from gi.repository import GObject
 
 from guake.callbacks import MenuHideCallback
 from guake.callbacks import TerminalContextMenuCallbacks
@@ -213,12 +214,18 @@ class RootTerminalBox(Gtk.Overlay, TerminalHolder):
             # gtk_widget_event: assertion 'WIDGET_REALIZED_FOR_EVENT (widget, event)' failed
             self.search_entry.realize()
             self.search_entry.grab_focus()
+            GObject.signal_handler_block(
+                self.get_notebook(),
+                self.get_notebook().notebook_on_button_press_id)
 
     def hide_search_box(self):
         if self.search_revealer.get_reveal_child():
             self.search_revealer.set_reveal_child(False)
             self.last_terminal_focused.grab_focus()
             self.last_terminal_focused.unselect_all()
+            GObject.signal_handler_unblock(
+                self.get_notebook(),
+                self.get_notebook().notebook_on_button_press_id)
 
     def on_search_entry_focus_out_event(self, event, user_data):
         self.hide_search_box()

--- a/guake/guake_app.py
+++ b/guake/guake_app.py
@@ -213,6 +213,9 @@ class Guake(SimpleGladeApp):
 
         self.window.connect('draw', draw_callback)
 
+        # Debounce accel_search_terminal
+        self.prev_accel_search_terminal_time = 0.0
+
         # holds the timestamp of the losefocus event
         self.losefocus_time = 0
 
@@ -712,6 +715,22 @@ class Guake(SimpleGladeApp):
         self.settings.general.triggerOnChangedValue(self.settings.general, 'use-default-font')
         self.settings.general.triggerOnChangedValue(self.settings.general, 'compat-backspace')
         self.settings.general.triggerOnChangedValue(self.settings.general, 'compat-delete')
+
+    def accel_search_terminal(self, *args):
+        nb = self.get_notebook()
+        term = nb.get_current_terminal()
+        box = nb.get_nth_page(nb.find_page_index_by_terminal(term))
+
+        # Debounce it
+        current_time = pytime.time()
+        if current_time - self.prev_accel_search_terminal_time < 0.3:
+            return
+
+        self.prev_accel_search_terminal_time = current_time
+        if box.search_revealer.get_reveal_child():
+            box.hide_search_box()
+        else:
+            box.show_search_box()
 
     def accel_quit(self, *args):
         """Callback to prompt the user whether to quit Guake or not.

--- a/guake/keybindings.py
+++ b/guake/keybindings.py
@@ -64,11 +64,11 @@ class Keybindings():
             'switch-tab10', 'switch-tab-last', 'reset-terminal', 'split-tab-vertical',
             'split-tab-horizontal', 'close-terminal', 'focus-terminal-up', 'focus-terminal-down',
             'focus-terminal-right', 'focus-terminal-left', 'move-terminal-split-up',
-            'move-terminal-split-down', 'move-terminal-split-left', 'move-terminal-split-right'
+            'move-terminal-split-down', 'move-terminal-split-left', 'move-terminal-split-right',
+            'search-terminal'
         ]
         for key in keys:
             guake.settings.keybindingsLocal.onChangedValue(key, self.reload_accelerators)
-
             self.reload_accelerators()
 
     def reload_global(self, settings, key, user_data):
@@ -364,4 +364,10 @@ class Keybindings():
                     lambda *args:  # keep make style from concat this lines
                     SplitMover.move_right(self.guake.get_notebook().get_current_terminal()) or True
                 )
+            )
+
+        key, mask = Gtk.accelerator_parse(getk('search-terminal'))
+        if key > 0:
+            self.accel_group.connect(
+                key, mask, Gtk.AccelFlags.VISIBLE, self.guake.accel_search_terminal
             )

--- a/guake/notebook.py
+++ b/guake/notebook.py
@@ -77,7 +77,8 @@ class TerminalNotebook(Gtk.Notebook):
         self.scroll_callback = NotebookScrollCallback(self)
         self.add_events(Gdk.EventMask.SCROLL_MASK)
         self.connect('scroll-event', self.scroll_callback.on_scroll)
-        self.connect("button-press-event", self.on_button_press, None)
+        self.notebook_on_button_press_id = self.connect(
+            "button-press-event", self.on_button_press, None)
 
         self.new_page_button = Gtk.Button(
             image=Gtk.Image.new_from_icon_name("tab-new", Gtk.IconSize.MENU), visible=True
@@ -100,8 +101,6 @@ class TerminalNotebook(Gtk.Notebook):
                 menu.popup(None, None, None, None, event.button, event.time)
 
         elif event.type == Gdk.EventType.DOUBLE_BUTTON_PRESS and event.button == 1:
-            # XXX: WTF is this?
-            return
             self.new_page_with_focus()
 
         return False

--- a/guake/notebook.py
+++ b/guake/notebook.py
@@ -100,6 +100,8 @@ class TerminalNotebook(Gtk.Notebook):
                 menu.popup(None, None, None, None, event.button, event.time)
 
         elif event.type == Gdk.EventType.DOUBLE_BUTTON_PRESS and event.button == 1:
+            # XXX: WTF is this?
+            return
             self.new_page_with_focus()
 
         return False

--- a/guake/prefs.py
+++ b/guake/prefs.py
@@ -115,6 +115,10 @@ HOTKEYS = [
                 'key': 'reset-terminal',
                 'label': _('Reset terminal')
             },
+            {
+                'key': 'search-terminal',
+                'label': _('Search terminal')
+            }
         ]
     },
     {

--- a/releasenotes/notes/add-search-terminal-43a0aa5950e79a74.yaml
+++ b/releasenotes/notes/add-search-terminal-43a0aa5950e79a74.yaml
@@ -1,0 +1,2 @@
+features:
+    - Add search box for terminal


### PR DESCRIPTION
For #116, currently we have two ways to implement it, one is the search dialog (we have search.glade), another is like gedit or iterm using a small search box to search the terminal.

This PR trying to implement the latter, this is how it work to float the search box on the page:

* RootTerminalBox: Gtk.Box -> Gtk.Overlay
* RootTerminalBox.child (TerminalBox/DualTerminalBox) -> `add` into overlay
* Search box -> `add_overlay` into overlay

In this way, we can then implement the search function base on `vte.Terminal`.

Some problem:
- [x] Not test in different scenario
- [x] Search box will not hide in focus-out-event (this is tricky... we cannot hide the box and show it out, it will let the search fall back to first item)
- [x] Next/Prev button didn't set sensitive correctly
- [x] It will only search in last focus terminal (if you split, it will not search in all terminal in same RootTerminalBox)

VTE problem:
- [ ] It cannot highlight all match item (long time feature request)

TODO:

- [x] Prefs setting
- [x] Prev search with SHIFT
- [x] Cleanup RootTerminalBox other related method (from Gtk.Box to Gtk.Overlay) and check if somewhere breakup by this

Feel free to test it, you can test it with `CTRL+SHIFT+F` to search 