### PR TITLE
Fix Vte-WARNING about regex flags

### DIFF
--- a/guake/terminal.py
+++ b/guake/terminal.py
@@ -177,12 +177,18 @@ class GuakeTerminal(Vte.Terminal):
         highlight text that matches them.
         """
         try:
+            # NOTE: PCRE2_UTF | PCRE2_NO_UTF_CHECK | PCRE2_MULTILINE
+            # reference from vte/bindings/vala/app.vala, flags = 0x40080400u
+            # also ref: https://mail.gnome.org/archives/commits-list/2016-September/msg06218.html
+            VTE_REGEX_FLAGS = 0x40080400
             for expr in TERMINAL_MATCH_EXPRS:
-                tag = self.match_add_regex(Vte.Regex.new_for_match(expr, len(expr), 0), 0)
+                tag = self.match_add_regex(
+                    Vte.Regex.new_for_match(expr, len(expr), VTE_REGEX_FLAGS), 0)
                 self.match_set_cursor_type(tag, Gdk.CursorType.HAND2)
 
             for _useless, match, _otheruseless in QUICK_OPEN_MATCHERS:
-                tag = self.match_add_regex(Vte.Regex.new_for_match(match, len(match), 0), 0)
+                tag = self.match_add_regex(
+                    Vte.Regex.new_for_match(match, len(match), VTE_REGEX_FLAGS), 0)
                 self.match_set_cursor_type(tag, Gdk.CursorType.HAND2)
         except (GLib.Error, AttributeError) as e:  # pylint: disable=catching-non-exception
             try:

--- a/releasenotes/notes/fix-vte-warning-ae9a71b84c4fedf3.yaml
+++ b/releasenotes/notes/fix-vte-warning-ae9a71b84c4fedf3.yaml
@@ -1,0 +1,3 @@
+fixes:
+    - Fix vte-warning when using Vte.Regex.new_for_match
+


### PR DESCRIPTION
Vte.Regex.new_from_match keep warning with:

    (guake:29728): Vte-WARNING **: 19:36:56.760: (vtegtk.cc:1964):int
    vte_terminal_match_add_regex(VteTerminal*, VteRegex*, guint32): runtime check failed:
    (_vte_regex_get_compile_flags(regex) & PCRE2_MULTILINE)

In Vte source code, it will check the flags have contain PCRE2_MULTILINE:

    g_warn_if_fail(_vte_regex_get_compile_flags(regex) & PCRE2_MULTILINE);

But, Vte nor GLib didn't provide the MULTILINE flag value:

    GLib.RegexCompileFlags.MULTILINE = 2
    Vte.REGEX_FLAGS_DEFAULT = 0x40180000

Vte source code in vte/bindings/vala/app.vala give out the value

    flags = 0x40080400u /* PCRE2_UTF | PCRE2_NO_UTF_CHECK | PCRE2_MULTILINE */;

from Vte commit list, we can found that PCRE2_MULTILINE value is 0x400:
(https://mail.gnome.org/archives/commits-list/2016-September/msg06218.html)

    flags |= 0x00000400u; /* PCRE2_MULTILINE */

Fix it with providing 0x40080400u as flag value
