### PR TITLE
Fix multiple block on notebook on_button_press

### DIFF
--- a/guake/guake_app.py
+++ b/guake/guake_app.py
@@ -733,7 +733,6 @@ class Guake(SimpleGladeApp):
                 # The box was showed, but out of focus
                 # Don't hide it, re-grab the focus to search entry
                 box.search_entry.grab_focus()
-                box.block_notebook_on_button_press_id()
         else:
             box.show_search_box()
 


### PR DESCRIPTION
Reproduce:

* Ctrl+Shift+F show the search box (block)
* Click the terminal so search entry focus-out (unblock)
* Ctrl+Shift+F re-focus on search entry (block & block)
* Ctrl+Shift+F close the search box (unblock)

Additional block cause notebook on_button_press remain blocked