### PR TITLE
Make restore-tabs-startup default as true

### DIFF
--- a/data/org.guake.gschema.xml
+++ b/data/org.guake.gschema.xml
@@ -27,7 +27,7 @@
             <description>Path to the default shell. Set to empty to use default user shell. If invalid path is set here, guake will fallback to user shell.</description>
         </key>
 		<key name="restore-tabs-startup" type="b">
-		    <default>false</default>
+		    <default>true</default>
 		    <summary>Restore tabs when startup</summary>
 		    <description>If true, when guake startup, it will restore tabs from previous session</description>
 		</key>


### PR DESCRIPTION
#1546 make `save-tabs-when-changed` default as True, but `restore-tabs-startup` still default as False, casing user losing tabs session when restarting the Guake. 

(because, it will not restore session file, and when startup Guake, it will then cover the session file as fresh one) 