### PR TITLE
Make `make` with different python interpreter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build dev
 
-PYTHON_INTERPRETER=python3
+PYTHON_INTERPRETER?=python3
 MODULE:=guake
 DESTDIR:=/
 prefix:=/usr/local


### PR DESCRIPTION
User can choice which python interpreter when using `make`, e.g.:

    $ PYTHON_INTERPRETER=python3.5 make dev