### PR TITLE
Add libwnck to bootstrap scripts

### DIFF
--- a/releasenotes/notes/add-libwnck-dep-a64492dc9d26d03e.yaml
+++ b/releasenotes/notes/add-libwnck-dep-a64492dc9d26d03e.yaml
@@ -1,0 +1,2 @@
+fixes:
+    - Add libwnck to bootstrap scripts

--- a/scripts/bootstrap-dev-arch.sh
+++ b/scripts/bootstrap-dev-arch.sh
@@ -36,6 +36,7 @@ fi
 if [[ $RUN == "1" ]]; then
     echo "Install packages needed for execution"
     sudo pacman -S \
+		libwnck3 \
         libkeybinder3 \
         libnotify \
         python-cairo \

--- a/scripts/bootstrap-dev-debian.sh
+++ b/scripts/bootstrap-dev-debian.sh
@@ -39,6 +39,7 @@ if [[ $RUN == "1" ]]; then
         gir1.2-keybinder-3.0 \
         gir1.2-notify-0.7 \
         gir1.2-vte-2.91 \
+		gir1.2-wnck-3.0 \
         libkeybinder-3.0-0 \
         libutempter0 \
         python3 \

--- a/scripts/bootstrap-dev-fedora.sh
+++ b/scripts/bootstrap-dev-fedora.sh
@@ -40,7 +40,8 @@ if [[ $RUN == "1" ]]; then
         python3-cairo \
         python3-dbus \
         python3-pip \
-        keybinder3
+        keybinder3 \
+		libwnck
 fi
 
 if [[ $MAKE == "1" ]]; then


### PR DESCRIPTION
As #1481 introduce NotebookManager, it require Wnck as dependency,
add libwnck to bootstrap scripts to make sure user properly deal
with it.

Fix #1511
