### PR TITLE
Fully respect the XDG Base Directory Specification

### DIFF
--- a/guake/guake_app.py
+++ b/guake/guake_app.py
@@ -1147,7 +1147,8 @@ class Guake(SimpleGladeApp):
         pass
 
     def get_xdg_config_directory(self):
-        return Path('~/.config/guake').expanduser()
+        xdg_config_home = os.environ.get('XDG_CONFIG_HOME', '~/.config')
+        return Path(xdg_config_home, 'guake').expanduser()
 
     def save_tabs(self, filename='session.json'):
         config = {'schema_version': 1, 'timestamp': int(pytime.time()), 'workspace': {}}


### PR DESCRIPTION
While using ~/.config to store application-specific configurations is an excellent first step, the specification requires that this can be overridden using the variable XDG_CONFIG_HOME. Implementing this is a trivial one-liner and does not require external dependencies, so this provides the best of both worlds while superseding commit 30fb26c2c6755449bb23e2d1be6eb25401ebe53d (that removed support for this by dropping the external dependency on pyxdg).