### PR TITLE
Add drag-n-drop for terminal (text & uris)

### DIFF
--- a/releasenotes/notes/add-drag-and-drop-7b977070e8427a67.yaml
+++ b/releasenotes/notes/add-drag-and-drop-7b977070e8427a67.yaml
@@ -1,0 +1,2 @@
+features:
+    - Add drag-n-drop to terminal (text & uris)


### PR DESCRIPTION
Implement #708, dnd support UTF-8 & locale charset.

([FeatHub: Drag and drop text](https://feathub.com/Guake/guake/+35))