### PR TITLE
Avoid spurious resize event when showing fullscreened window

### DIFF
--- a/guake/guake_app.py
+++ b/guake/guake_app.py
@@ -581,7 +581,8 @@ class Guake(SimpleGladeApp):
             self.add_tab()
 
         self.window.set_keep_below(False)
-        self.window.show_all()
+        if not FullscreenManager(self.settings, self.window).is_fullscreen():
+            self.window.show_all()
         # this is needed because self.window.show_all() results in showing every
         # thing which includes the scrollbar too
         self.settings.general.triggerOnChangedValue(self.settings.general, "use-scrollbar")

--- a/releasenotes/notes/bugfix-avoid-spurious-fullscreen-resize-6f3345c7a4494b1f.yaml
+++ b/releasenotes/notes/bugfix-avoid-spurious-fullscreen-resize-6f3345c7a4494b1f.yaml
@@ -1,0 +1,2 @@
+fixes:
+  - Avoid spurious resize event when showing fullscreened window


### PR DESCRIPTION
In ncurses apps that handle SIGWINCH, a resize event is happening when guake shows in fullscreen mode.
The call to `self.window.show_all()` was added in 4f4ab35d5cb2363dd464e6b252d1c798bd01c2fb (2007-10-06) and when it might even be needed is not quite clear.