### PR TITLE
Support customize prefix for make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 PYTHON_INTERPRETER?=python3
 MODULE:=guake
 DESTDIR:=/
-prefix:=/usr/local
+prefix?=/usr/local
 exec_prefix:=$(prefix)
 bindir = $(exec_prefix)/bin
 

--- a/releasenotes/notes/fix-make-prefix-161844c63e1cd2b7.yaml
+++ b/releasenotes/notes/fix-make-prefix-161844c63e1cd2b7.yaml
@@ -1,0 +1,2 @@
+fixes:
+    - Support customize prefix for make


### PR DESCRIPTION
If user using different python interpreter with customize prefix,
it can then install Guake with customize prefix now:

    $ make
    $ PYTHON_INTERPRETER=python3.7 prefix=~/.local/pythons/3.7 make install
    $ which guake
      ~/.local/pythons/3.7/bin/guake