### PR TITLE
Fix re-focus on terminal after rename dialog destroy

### DIFF
--- a/releasenotes/notes/fix-rename-terminal-focus-c33af663235ed0df.yaml
+++ b/releasenotes/notes/fix-rename-terminal-focus-c33af663235ed0df.yaml
@@ -1,0 +1,2 @@
+fixes:
+    - Fix re-focus on terminal after rename dialog destroy


### PR DESCRIPTION
Reproduce:

* CTRL + SHIFT + R (rename accel-key)
* Rename & OK (or ENTER)
* Focus is not on last focused terminal
