### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+Be sure to check the existing issues (both open and closed!), and make sure you are running the latest version of Guake.
+
+For how to run the latest Guake in your computer, please refer to [Install from source](https://guake.readthedocs.io/en/latest/user/installing.html#install-from-source).
+
+
+**Describe the bug**
+
+A clear and concise description of what the bug is.
+
+**Expected behavior**
+
+A clear and concise description of what you expected to happen.
+
+**Actual behavior**
+
+What you actually get.
+
+**To Reproduce**
+
+Provide the steps to reproduce the behavior
+
+-------------------------------------------------------------------------------
+
+Please run `$ guake --support`, and paste the results here. Don't put backticks (`` ` ``) around it! The output already contains Markdown formatting. And make sure you run the command **OUTSIDE** the Guake.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+Be sure to check the existing issues (both open and closed!), and make sure you are running the latest version of Guake.
+
+For how to run the latest Guake in your computer, please refer to [Install from source](https://guake.readthedocs.io/en/latest/user/installing.html#install-from-source).
+
+---------------------------------------
+
+Please use [FeatHub](https://feathub.com/Guake/guake) to fill-up a feature request.
+
+This allow us to spot directly which are the most requested features.
+


### PR DESCRIPTION
Update to latest GitHub issue templates that can provide the different template to different issue.

Also, update bug report template to mention `guake --support` and make sure user update to latest Guake before filing an issue.