### PR TITLE
Add tab selection popover in each notebook

### DIFF
--- a/guake/guake_app.py
+++ b/guake/guake_app.py
@@ -693,6 +693,9 @@ class Guake(SimpleGladeApp):
         self.get_widget('window-root').unstick()
         self.window.hide()  # Don't use hide_all here!
 
+        # Hide popover
+        self.notebook_manager.get_current_notebook().popover.hide()
+
     def force_move_if_shown(self):
         if not self.hidden:
             # when displayed, GTK might refuse to move the window (X or Y position). Just hide and

--- a/releasenotes/notes/add-easy-tab-selection-cc8f354553bfade4.yaml
+++ b/releasenotes/notes/add-easy-tab-selection-cc8f354553bfade4.yaml
@@ -1,0 +1,2 @@
+features:
+    - Add tab selection popover in each notebook


### PR DESCRIPTION
Now, behind the new tab icon, there is a pan-down icon which will
popover a tab selection scrolled window for user, to select which
tab they like to jump to.

Impl "Quicker window select" https://feathub.com/Guake/guake/+6