### PR TITLE
Fix Guake cannot transparent after composited changed

### DIFF
--- a/releasenotes/notes/fix-composited-changed-didnot-update-visual-9387a8ae28d33c5d.yaml
+++ b/releasenotes/notes/fix-composited-changed-didnot-update-visual-9387a8ae28d33c5d.yaml
@@ -1,0 +1,2 @@
+fixes:
+    - When composited changed, it will update Guake window visual to make it transparent


### PR DESCRIPTION
Fix #1523

It is possible for user to start its display without compositor, then start the compositor after it.
(e.g. start LXDE (w/o compositor), then start xcompmgr. start awesome (w/o compositor), then start compton)

In this scenario, Gtk.Widget / Gdk.Screen will emit a `composited-changed` signal, will indicate the compositor
has changed, we can then update window visual for it.

It is important to mention that `set_visual` should unrealize the window and realize it again, since it should
only call before window is realized.
(ref: https://lazka.github.io/pgi-docs/index.html#Gtk-3.0/classes/Widget.html#Gtk.Widget.set_visual)
