### PR TITLE
Remove window draw callback

### DIFF
--- a/guake/guake_app.py
+++ b/guake/guake_app.py
@@ -196,21 +196,8 @@ class Guake(SimpleGladeApp):
         self.set_tab_position()
 
         # check and set ARGB for real transparency
-        color = self.window.get_style_context().get_background_color(Gtk.StateFlags.NORMAL)
-        self.window.set_app_paintable(True)
-
-        def draw_callback(widget, cr):
-            if widget.transparency:
-                cr.set_source_rgba(color.red, color.green, color.blue, 1)
-            else:
-                cr.set_source_rgb(0, 0, 0)
-            cr.set_operator(cairo.OPERATOR_SOURCE)
-            cr.paint()
-            cr.set_operator(cairo.OPERATOR_OVER)
-
         screen = self.window.get_screen()
         visual = screen.get_rgba_visual()
-
         if visual and screen.is_composited():
             self.window.set_visual(visual)
             self.window.transparency = True
@@ -218,8 +205,6 @@ class Guake(SimpleGladeApp):
             log.warn('System doesn\'t support transparency')
             self.window.transparency = False
             self.window.set_visual(screen.get_system_visual())
-
-        self.window.connect('draw', draw_callback)
 
         # Debounce accel_search_terminal
         self.prev_accel_search_terminal_time = 0.0

--- a/releasenotes/notes/remove-draw-callback-4c890ab1970512de.yaml
+++ b/releasenotes/notes/remove-draw-callback-4c890ab1970512de.yaml
@@ -1,0 +1,2 @@
+fixes:
+    - Remove no need window draw callback


### PR DESCRIPTION
It starts from commit: c7e3e8763, but it is no need on these days.

Guake transparent was done by 2 steps:

1. self.window.set_visual
2. Vte.Terminal.set_colors

We didn't paint/draw any other thing on Guake window, so it is
no need to add the draw callback to draw it on SOURCE. Plus, it will
cause some issue on popover (which will draw the square background below
the popover, can be reproduce on weston, and some old ubuntu 16.04)

NOTE: we may need this in future if we want to implement transparent
      scrollbar like tilix.
