### PR TITLE
Fix the license classifier in setup.cfg, guake is GPLv2+

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ home-page = https://github.com/Guake/guake
 classifier =
     Intended Audience :: Information Technology
     Intended Audience :: System Administrators
-    License :: OSI Approved :: GNU General Public License v2 (GPLv2)
+    License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)
     Operating System :: POSIX :: Linux
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6


### PR DESCRIPTION
Signed-off-by: Pierre-Yves Chibon <pingou@pingoured.fr>
