### PR TITLE
Prefs: Add an option to use the last dir on the path as the tab name.

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -19,6 +19,8 @@ Bug Fixes
 
 - Fix fullscreen/unfullscreen not handle correctly when trigger by wm
 
+- Fix search revealer causing terminal unclickable at bottom right
+
 - Remove no need window draw callback
 
 - Update some dependencies for build environment

--- a/guake/data/org.guake.gschema.xml
+++ b/guake/data/org.guake.gschema.xml
@@ -246,10 +246,10 @@
             <summary>#TODO PORT max-tab-name-length</summary>
             <description>#TODO PORT max-tab-name-length</description>
         </key>
-        <key name="abbreviate-tab-names" type="b">
-            <default>false</default>
-            <summary>#TODO PORT abbreviate-tab-names</summary>
-            <description>#TODO PORT abbreviate-tab-names</description>
+        <key name="display-tab-names" type="i">
+            <default>0</default>
+            <summary>How to display tab names.</summary>
+            <description>Controls how the tab names are displayed. 0: Full Path, 1: Abbreviated Path, 2: Only display the last segment of the path</description>
         </key>
         <key name="gtk-theme-name" type="s">
             <default>''</default>

--- a/guake/data/prefs.glade
+++ b/guake/data/prefs.glade
@@ -727,20 +727,46 @@
                                           </packing>
                                         </child>
                                         <child>
-                                          <object class="GtkCheckButton" id="abbreviate_tab_names">
-                                            <property name="label" translatable="yes">Abbreviate directories in tab names</property>
+                                          <object class="GtkBox" id="hbox_tab_name_display">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="halign">start</property>
-                                            <property name="use_underline">True</property>
-                                            <property name="active">True</property>
-                                            <property name="draw_indicator">True</property>
-                                            <signal name="toggled" handler="on_abbreviate_tab_names_toggled" swapped="no"/>
+                                            <property name="can_focus">False</property>
+                                            <property name="spacing">6</property>
+                                            <child>
+                                              <object class="GtkLabel" id="lbl_tab_name_display">
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="valign">center</property>
+                                                <property name="label" translatable="yes">Display as tab names:</property>
+                                                <property name="use_markup">True</property>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">False</property>
+                                                <property name="position">0</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkComboBoxText" id="tab_name_display">
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">True</property>
+                                                <items>
+                                                  <item translatable="yes" >Full Path</item>
+                                                  <item translatable="yes">Abbreviated Path</item>
+                                                  <item translatable="yes">Last Segment</item>
+                                                </items>
+                                                <signal name="changed" handler="on_tab_name_display_changed" swapped="no"/>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">1</property>
+                                              </packing>
+                                            </child>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">1</property>
-                                            <property name="top_attach">3</property>
+                                            <property name="left_attach">0</property>
+                                            <property name="top_attach">5</property>
+                                            <property name="width">2</property>
                                           </packing>
                                         </child>
                                         <child>
@@ -784,7 +810,7 @@
                                           </object>
                                           <packing>
                                             <property name="left_attach">0</property>
-                                            <property name="top_attach">5</property>
+                                            <property name="top_attach">6</property>
                                             <property name="width">2</property>
                                           </packing>
                                         </child>

--- a/guake/gsettings.py
+++ b/guake/gsettings.py
@@ -89,7 +89,7 @@ class GSettingHandler():
         settings.general.onChangedValue('compat-delete', self.delete_changed)
         settings.general.onChangedValue('custom-command_file', self.custom_command_file_changed)
         settings.general.onChangedValue('max-tab-name-length', self.max_tab_name_length_changed)
-        settings.general.onChangedValue('abbreviate-tab-names', self.abbreviate_tab_names_changed)
+        settings.general.onChangedValue('display-tab-names', self.display_tab_names_changed)
 
     def custom_command_file_changed(self, settings, key, user_data):
         self.guake.load_custom_commands()
@@ -327,10 +327,9 @@ class GSettingHandler():
 
         self.guake.recompute_tabs_titles()
 
-    def abbreviate_tab_names_changed(self, settings, key, user_data):
-        """If the gconf var abbreviate_tab_names be changed, this method will
+    def display_tab_names_changed(self, settings, key, user_data):
+        """If the gconf var display-tab-names was changed, this method will
         be called and will update tab names.
         """
-        abbreviate_tab_names = settings.get_boolean('abbreviate-tab-names')
-        self.guake.abbreviate = abbreviate_tab_names
+        self.guake.display_tab_names = settings.get_int('display-tab-names')
         self.guake.recompute_tabs_titles()

--- a/guake/prefs.py
+++ b/guake/prefs.py
@@ -498,10 +498,10 @@ class PrefsCallbacks():
         """
         self.settings.general.set_boolean('set-window-title', chk.get_active())
 
-    def on_abbreviate_tab_names_toggled(self, chk):
-        """Save `abbreviate_tab_names` property value in dconf
+    def on_tab_name_display_changed(self, combo):
+        """Save `display-tab-names` property value in dconf
         """
-        self.settings.general.set_boolean('abbreviate-tab-names', chk.get_active())
+        self.settings.general.set_int('display-tab-names', combo.get_active())
 
     def on_max_tab_name_length_changed(self, spin):
         """Changes the value of max_tab_name_length in dconf
@@ -895,10 +895,10 @@ class PrefsDialog(SimpleGladeApp):
 
     def update_vte_subwidgets_states(self):
         do_use_vte_titles = self.get_widget('use_vte_titles').get_active()
-        max_tab_name_length_wdg = self.get_widget('max_tab_name_length')
-        max_tab_name_length_wdg.set_sensitive(do_use_vte_titles)
+        self.get_widget('tab_name_display').set_sensitive(do_use_vte_titles)
+        self.get_widget('lbl_tab_name_display').set_sensitive(do_use_vte_titles)
+        self.get_widget('max_tab_name_length').set_sensitive(do_use_vte_titles)
         self.get_widget('lbl_max_tab_name_length').set_sensitive(do_use_vte_titles)
-        self.get_widget('abbreviate_tab_names').set_sensitive(do_use_vte_titles)
 
     def on_reset_compat_defaults_clicked(self, bnt):
         """Reset default values to compat_{backspace,delete} dconf
@@ -1154,10 +1154,10 @@ class PrefsDialog(SimpleGladeApp):
         value = self.settings.general.get_boolean('set-window-title')
         self.get_widget('set_window_title').set_active(value)
 
-        # abbreviate tab names
-        self.get_widget('abbreviate_tab_names').set_sensitive(value)
-        value = self.settings.general.get_boolean('abbreviate-tab-names')
-        self.get_widget('abbreviate_tab_names').set_active(value)
+        # set tab name display method
+        self.get_widget('tab_name_display').set_sensitive(value)
+        value = self.settings.general.get_int('display-tab-names')
+        self.get_widget('tab_name_display').set_active(value)
 
         # max tab name length
         value = self.settings.general.get_int('max-tab-name-length')

--- a/po/ca.po
+++ b/po/ca.po
@@ -213,10 +213,6 @@ msgstr ""
 msgid "0 means no size limit"
 msgstr ""
 
-#: ../guake/data/prefs.glade.h:35
-msgid "Abbreviate directories in tab names"
-msgstr ""
-
 #: ../guake/data/prefs.glade.h:36
 msgid "Hide on lose focus"
 msgstr "Amaga-la en perdre el focus"
@@ -1407,6 +1403,22 @@ msgstr ""
 
 #: guake/data/prefs.glade:809
 msgid "Hide tabbar when fullscreen"
+msgstr ""
+
+#: guake/data/prefs.glade:739
+msgid "Display as tab names:"
+msgstr ""
+
+#: guake/data/prefs.glade:753
+msgid "Full Path"
+msgstr ""
+
+#: guake/data/prefs.glade:754
+msgid "Abbreviated Path"
+msgstr ""
+
+#: guake/data/prefs.glade:755
+msgid "Last Segment"
 msgstr ""
 
 #~ msgid "key binding error"

--- a/po/cs.po
+++ b/po/cs.po
@@ -217,10 +217,6 @@ msgstr "Maximální délka názvu karty:"
 msgid "0 means no size limit"
 msgstr "0 znamená žádný limit velikosti"
 
-#: ../guake/data/prefs.glade.h:35
-msgid "Abbreviate directories in tab names"
-msgstr "Zkrátit jména složek v názvech karet"
-
 #: ../guake/data/prefs.glade.h:36
 msgid "Hide on lose focus"
 msgstr "Skrýt při ztrátě zaměření okna"
@@ -1443,6 +1439,22 @@ msgstr ""
 
 #: guake/data/prefs.glade:809
 msgid "Hide tabbar when fullscreen"
+msgstr ""
+
+#: guake/data/prefs.glade:739
+msgid "Display as tab names:"
+msgstr ""
+
+#: guake/data/prefs.glade:753
+msgid "Full Path"
+msgstr ""
+
+#: guake/data/prefs.glade:754
+msgid "Abbreviated Path"
+msgstr ""
+
+#: guake/data/prefs.glade:755
+msgid "Last Segment"
 msgstr ""
 
 #~ msgid "key binding error"

--- a/po/de.po
+++ b/po/de.po
@@ -561,10 +561,6 @@ msgstr "Reiterleiste anzeigen"
 msgid "Use VTE titles for tab names"
 msgstr "VTE-Titel als Reiternamen benutzen"
 
-#: data/prefs.glade:618
-msgid "Abbreviate directories in tab names"
-msgstr "Verzeichnisnamen in Reitern abkürzen"
-
 #: data/prefs.glade:643
 msgid "Max tab name length:"
 msgstr "Max. Länge der Reiternamen:"
@@ -1210,4 +1206,20 @@ msgstr ""
 
 #: guake/data/prefs.glade:809
 msgid "Hide tabbar when fullscreen"
+msgstr ""
+
+#: guake/data/prefs.glade:739
+msgid "Display as tab names:"
+msgstr ""
+
+#: guake/data/prefs.glade:753
+msgid "Full Path"
+msgstr ""
+
+#: guake/data/prefs.glade:754
+msgid "Abbreviated Path"
+msgstr ""
+
+#: guake/data/prefs.glade:755
+msgid "Last Segment"
 msgstr ""

--- a/po/el.po
+++ b/po/el.po
@@ -210,10 +210,6 @@ msgstr ""
 msgid "0 means no size limit"
 msgstr ""
 
-#: ../guake/data/prefs.glade.h:35
-msgid "Abbreviate directories in tab names"
-msgstr ""
-
 #: ../guake/data/prefs.glade.h:36
 msgid "Hide on lose focus"
 msgstr "Απόκρυψη όταν χάνει εστίαση"
@@ -1404,6 +1400,22 @@ msgstr ""
 
 #: guake/data/prefs.glade:809
 msgid "Hide tabbar when fullscreen"
+msgstr ""
+
+#: guake/data/prefs.glade:739
+msgid "Display as tab names:"
+msgstr ""
+
+#: guake/data/prefs.glade:753
+msgid "Full Path"
+msgstr ""
+
+#: guake/data/prefs.glade:754
+msgid "Abbreviated Path"
+msgstr ""
+
+#: guake/data/prefs.glade:755
+msgid "Last Segment"
 msgstr ""
 
 #~ msgid "key binding error"

--- a/po/es.po
+++ b/po/es.po
@@ -223,10 +223,6 @@ msgstr ""
 msgid "0 means no size limit"
 msgstr ""
 
-#: ../guake/data/prefs.glade.h:35
-msgid "Abbreviate directories in tab names"
-msgstr ""
-
 #: ../guake/data/prefs.glade.h:36
 msgid "Hide on lose focus"
 msgstr "Esconder al perder el foco"
@@ -1435,6 +1431,22 @@ msgstr ""
 
 #: guake/data/prefs.glade:809
 msgid "Hide tabbar when fullscreen"
+msgstr ""
+
+#: guake/data/prefs.glade:739
+msgid "Display as tab names:"
+msgstr ""
+
+#: guake/data/prefs.glade:753
+msgid "Full Path"
+msgstr ""
+
+#: guake/data/prefs.glade:754
+msgid "Abbreviated Path"
+msgstr ""
+
+#: guake/data/prefs.glade:755
+msgid "Last Segment"
 msgstr ""
 
 #~ msgid "key binding error"

--- a/po/fa.po
+++ b/po/fa.po
@@ -207,10 +207,6 @@ msgstr ""
 msgid "0 means no size limit"
 msgstr ""
 
-#: ../guake/data/prefs.glade.h:35
-msgid "Abbreviate directories in tab names"
-msgstr ""
-
 #: ../guake/data/prefs.glade.h:36
 msgid "Hide on lose focus"
 msgstr "در صورت توجه کم پنهان شو"
@@ -1401,6 +1397,22 @@ msgstr ""
 
 #: guake/data/prefs.glade:809
 msgid "Hide tabbar when fullscreen"
+msgstr ""
+
+#: guake/data/prefs.glade:739
+msgid "Display as tab names:"
+msgstr ""
+
+#: guake/data/prefs.glade:753
+msgid "Full Path"
+msgstr ""
+
+#: guake/data/prefs.glade:754
+msgid "Abbreviated Path"
+msgstr ""
+
+#: guake/data/prefs.glade:755
+msgid "Last Segment"
 msgstr ""
 
 #~ msgid "key binding error"

--- a/po/fr.po
+++ b/po/fr.po
@@ -782,10 +782,6 @@ msgstr "Afficher la barre d'onglets"
 msgid "Use VTE titles for tab names"
 msgstr "Utiliser les titres VTE pour le nom des tabs"
 
-#: guake/data/prefs.glade:731
-msgid "Abbreviate directories in tab names"
-msgstr "Réduit des noms de dossiers dans les onglets"
-
 #: guake/data/prefs.glade:756
 msgid "Max tab name length:"
 msgstr "Longueur maximale du nom de l'onglet :"
@@ -1146,6 +1142,22 @@ msgstr "Configurer vos sessions Guake"
 #: guake/data/guake-prefs.template.desktop:13 guake/data/guake-prefs.desktop:68
 msgid "Terminal;Utility;"
 msgstr "Terminal;Utilitaires;"
+
+#: guake/data/prefs.glade:739
+msgid "Display as tab names:"
+msgstr ""
+
+#: guake/data/prefs.glade:753
+msgid "Full Path"
+msgstr ""
+
+#: guake/data/prefs.glade:754
+msgid "Abbreviated Path"
+msgstr ""
+
+#: guake/data/prefs.glade:755
+msgid "Last Segment"
+msgstr ""
 
 #~ msgid "Use workspace-specific tab sets (requires restart)"
 #~ msgstr "Utiliser les bureaux virtuels pour les onglets (redémarrage requis)"

--- a/po/gl.po
+++ b/po/gl.po
@@ -216,10 +216,6 @@ msgstr ""
 msgid "0 means no size limit"
 msgstr "Se é 0, significa que non existe límite algún"
 
-#: ../guake/data/prefs.glade.h:35
-msgid "Abbreviate directories in tab names"
-msgstr ""
-
 #: ../guake/data/prefs.glade.h:36
 msgid "Hide on lose focus"
 msgstr "Agochar ao perder o foco"
@@ -1418,6 +1414,22 @@ msgstr ""
 
 #: guake/data/prefs.glade:809
 msgid "Hide tabbar when fullscreen"
+msgstr ""
+
+#: guake/data/prefs.glade:739
+msgid "Display as tab names:"
+msgstr ""
+
+#: guake/data/prefs.glade:753
+msgid "Full Path"
+msgstr ""
+
+#: guake/data/prefs.glade:754
+msgid "Abbreviated Path"
+msgstr ""
+
+#: guake/data/prefs.glade:755
+msgid "Last Segment"
 msgstr ""
 
 #~ msgid "key binding error"

--- a/po/hr.po
+++ b/po/hr.po
@@ -213,10 +213,6 @@ msgstr ""
 msgid "0 means no size limit"
 msgstr ""
 
-#: ../guake/data/prefs.glade.h:35
-msgid "Abbreviate directories in tab names"
-msgstr ""
-
 #: ../guake/data/prefs.glade.h:36
 msgid "Hide on lose focus"
 msgstr "Sakrij pri gubitku fokusa"
@@ -1408,6 +1404,22 @@ msgstr ""
 
 #: guake/data/prefs.glade:809
 msgid "Hide tabbar when fullscreen"
+msgstr ""
+
+#: guake/data/prefs.glade:739
+msgid "Display as tab names:"
+msgstr ""
+
+#: guake/data/prefs.glade:753
+msgid "Full Path"
+msgstr ""
+
+#: guake/data/prefs.glade:754
+msgid "Abbreviated Path"
+msgstr ""
+
+#: guake/data/prefs.glade:755
+msgid "Last Segment"
 msgstr ""
 
 #~ msgid "key binding error"

--- a/po/hu.po
+++ b/po/hu.po
@@ -213,10 +213,6 @@ msgstr ""
 msgid "0 means no size limit"
 msgstr ""
 
-#: ../guake/data/prefs.glade.h:35
-msgid "Abbreviate directories in tab names"
-msgstr ""
-
 #: ../guake/data/prefs.glade.h:36
 msgid "Hide on lose focus"
 msgstr "Fókusz elvesztésekor elrejtés"
@@ -1406,6 +1402,22 @@ msgstr ""
 
 #: guake/data/prefs.glade:809
 msgid "Hide tabbar when fullscreen"
+msgstr ""
+
+#: guake/data/prefs.glade:739
+msgid "Display as tab names:"
+msgstr ""
+
+#: guake/data/prefs.glade:753
+msgid "Full Path"
+msgstr ""
+
+#: guake/data/prefs.glade:754
+msgid "Abbreviated Path"
+msgstr ""
+
+#: guake/data/prefs.glade:755
+msgid "Last Segment"
 msgstr ""
 
 #~ msgid "key binding error"

--- a/po/id.po
+++ b/po/id.po
@@ -206,10 +206,6 @@ msgstr ""
 msgid "0 means no size limit"
 msgstr ""
 
-#: ../guake/data/prefs.glade.h:35
-msgid "Abbreviate directories in tab names"
-msgstr ""
-
 #: ../guake/data/prefs.glade.h:36
 msgid "Hide on lose focus"
 msgstr ""
@@ -1355,6 +1351,22 @@ msgstr ""
 
 #: guake/data/prefs.glade:809
 msgid "Hide tabbar when fullscreen"
+msgstr ""
+
+#: guake/data/prefs.glade:739
+msgid "Display as tab names:"
+msgstr ""
+
+#: guake/data/prefs.glade:753
+msgid "Full Path"
+msgstr ""
+
+#: guake/data/prefs.glade:754
+msgid "Abbreviated Path"
+msgstr ""
+
+#: guake/data/prefs.glade:755
+msgid "Last Segment"
 msgstr ""
 
 #~ msgid "http://guake.org"

--- a/po/it.po
+++ b/po/it.po
@@ -218,10 +218,6 @@ msgstr "Lunghezza massima nome scheda:"
 msgid "0 means no size limit"
 msgstr "0 disabilita il limite di dimensioni"
 
-#: ../guake/data/prefs.glade.h:35
-msgid "Abbreviate directories in tab names"
-msgstr "Abbrevia le cartelle nei nomi delle schede"
-
 #: ../guake/data/prefs.glade.h:36
 msgid "Hide on lose focus"
 msgstr "Nascondere alla perdita del focus"
@@ -1435,6 +1431,22 @@ msgstr ""
 
 #: guake/data/prefs.glade:809
 msgid "Hide tabbar when fullscreen"
+msgstr ""
+
+#: guake/data/prefs.glade:739
+msgid "Display as tab names:"
+msgstr ""
+
+#: guake/data/prefs.glade:753
+msgid "Full Path"
+msgstr ""
+
+#: guake/data/prefs.glade:754
+msgid "Abbreviated Path"
+msgstr ""
+
+#: guake/data/prefs.glade:755
+msgid "Last Segment"
 msgstr ""
 
 #~ msgid "key binding error"

--- a/po/ja.po
+++ b/po/ja.po
@@ -644,10 +644,6 @@ msgstr "タブバーを表示する"
 msgid "Use VTE titles for tab names"
 msgstr "タブ名としてVTEのタイトルを使用する"
 
-#: data/prefs.glade:621
-msgid "Abbreviate directories in tab names"
-msgstr "タブ名のディレクトリを省略して表示する"
-
 #: data/prefs.glade:646
 msgid "Max tab name length:"
 msgstr "タブ名の最大長"
@@ -1150,4 +1146,20 @@ msgstr ""
 
 #: guake/data/prefs.glade:809
 msgid "Hide tabbar when fullscreen"
+msgstr ""
+
+#: guake/data/prefs.glade:739
+msgid "Display as tab names:"
+msgstr ""
+
+#: guake/data/prefs.glade:753
+msgid "Full Path"
+msgstr ""
+
+#: guake/data/prefs.glade:754
+msgid "Abbreviated Path"
+msgstr ""
+
+#: guake/data/prefs.glade:755
+msgid "Last Segment"
 msgstr ""

--- a/po/ko.po
+++ b/po/ko.po
@@ -217,10 +217,6 @@ msgstr "탭 이름 최대 길이:"
 msgid "0 means no size limit"
 msgstr ""
 
-#: ../guake/data/prefs.glade.h:35
-msgid "Abbreviate directories in tab names"
-msgstr ""
-
 #: ../guake/data/prefs.glade.h:36
 msgid "Hide on lose focus"
 msgstr "포커스를 잃을 때 감추기"
@@ -1401,6 +1397,22 @@ msgstr ""
 
 #: guake/data/prefs.glade:809
 msgid "Hide tabbar when fullscreen"
+msgstr ""
+
+#: guake/data/prefs.glade:739
+msgid "Display as tab names:"
+msgstr ""
+
+#: guake/data/prefs.glade:753
+msgid "Full Path"
+msgstr ""
+
+#: guake/data/prefs.glade:754
+msgid "Abbreviated Path"
+msgstr ""
+
+#: guake/data/prefs.glade:755
+msgid "Last Segment"
 msgstr ""
 
 #~ msgid "key binding error"

--- a/po/nb.po
+++ b/po/nb.po
@@ -229,10 +229,6 @@ msgstr "Maksimal fanenavnslengde:"
 msgid "0 means no size limit"
 msgstr "0 betyr ingen størrelsesgrense"
 
-#: ../guake/data/prefs.glade.h:35
-msgid "Abbreviate directories in tab names"
-msgstr "Forkort mappenavn i fanenavn"
-
 #: ../guake/data/prefs.glade.h:36
 msgid "Hide on lose focus"
 msgstr "Skjul når ikke fokusert"
@@ -1513,6 +1509,22 @@ msgstr ""
 
 #: guake/data/prefs.glade:809
 msgid "Hide tabbar when fullscreen"
+msgstr ""
+
+#: guake/data/prefs.glade:739
+msgid "Display as tab names:"
+msgstr ""
+
+#: guake/data/prefs.glade:753
+msgid "Full Path"
+msgstr ""
+
+#: guake/data/prefs.glade:754
+msgid "Abbreviated Path"
+msgstr ""
+
+#: guake/data/prefs.glade:755
+msgid "Last Segment"
 msgstr ""
 
 #~ msgid "key binding error"

--- a/po/nl.po
+++ b/po/nl.po
@@ -218,10 +218,6 @@ msgstr "In volledig scherm-modus starten"
 msgid "Use VTE titles for tab names"
 msgstr "VTE-titels gebruiken voor tabbladnamen"
 
-#: ../guake/data/prefs.glade.h:36
-msgid "Abbreviate directories in tab names"
-msgstr "Mapnamen inkorten in tabbladnamen"
-
 #: ../guake/data/prefs.glade.h:37
 msgid "Max tab name length:"
 msgstr "Max. lengte van tabbladnaam:"
@@ -1476,6 +1472,22 @@ msgstr ""
 
 #: guake/data/prefs.glade:809
 msgid "Hide tabbar when fullscreen"
+msgstr ""
+
+#: guake/data/prefs.glade:739
+msgid "Display as tab names:"
+msgstr ""
+
+#: guake/data/prefs.glade:753
+msgid "Full Path"
+msgstr ""
+
+#: guake/data/prefs.glade:754
+msgid "Abbreviated Path"
+msgstr ""
+
+#: guake/data/prefs.glade:755
+msgid "Last Segment"
 msgstr ""
 
 #~ msgid "key binding error"

--- a/po/pa.po
+++ b/po/pa.po
@@ -209,10 +209,6 @@ msgstr ""
 msgid "0 means no size limit"
 msgstr ""
 
-#: ../guake/data/prefs.glade.h:35
-msgid "Abbreviate directories in tab names"
-msgstr ""
-
 #: ../guake/data/prefs.glade.h:36
 msgid "Hide on lose focus"
 msgstr "ਫੋਕਸ ਖਤਮ ਹੋਣ ਉੱਤੇ ਓਹਲੇ ਕਰੋ"
@@ -1390,6 +1386,22 @@ msgstr ""
 
 #: guake/data/prefs.glade:809
 msgid "Hide tabbar when fullscreen"
+msgstr ""
+
+#: guake/data/prefs.glade:739
+msgid "Display as tab names:"
+msgstr ""
+
+#: guake/data/prefs.glade:753
+msgid "Full Path"
+msgstr ""
+
+#: guake/data/prefs.glade:754
+msgid "Abbreviated Path"
+msgstr ""
+
+#: guake/data/prefs.glade:755
+msgid "Last Segment"
 msgstr ""
 
 #~ msgid "key binding error"

--- a/po/pl.po
+++ b/po/pl.po
@@ -547,10 +547,6 @@ msgstr "Pasek kart"
 msgid "Use VTE titles for tab names"
 msgstr "Tytuły VTE dla nazw kart"
 
-#: data/prefs.glade:618
-msgid "Abbreviate directories in tab names"
-msgstr "Skracanie nazw katalogów w nazwach kart"
-
 #: data/prefs.glade:643
 msgid "Max tab name length:"
 msgstr "Maksymalna długość nazwy karty:"
@@ -1206,4 +1202,20 @@ msgstr ""
 
 #: guake/data/prefs.glade:809
 msgid "Hide tabbar when fullscreen"
+msgstr ""
+
+#: guake/data/prefs.glade:739
+msgid "Display as tab names:"
+msgstr ""
+
+#: guake/data/prefs.glade:753
+msgid "Full Path"
+msgstr ""
+
+#: guake/data/prefs.glade:754
+msgid "Abbreviated Path"
+msgstr ""
+
+#: guake/data/prefs.glade:755
+msgid "Last Segment"
 msgstr ""

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -221,10 +221,6 @@ msgstr "Tamanho máximo para nome da aba:"
 msgid "0 means no size limit"
 msgstr ""
 
-#: ../guake/data/prefs.glade.h:35
-msgid "Abbreviate directories in tab names"
-msgstr ""
-
 #: ../guake/data/prefs.glade.h:36
 msgid "Hide on lose focus"
 msgstr "Esconder ao perder o foco"
@@ -1426,6 +1422,22 @@ msgstr ""
 
 #: guake/data/prefs.glade:809
 msgid "Hide tabbar when fullscreen"
+msgstr ""
+
+#: guake/data/prefs.glade:739
+msgid "Display as tab names:"
+msgstr ""
+
+#: guake/data/prefs.glade:753
+msgid "Full Path"
+msgstr ""
+
+#: guake/data/prefs.glade:754
+msgid "Abbreviated Path"
+msgstr ""
+
+#: guake/data/prefs.glade:755
+msgid "Last Segment"
 msgstr ""
 
 #~ msgid "key binding error"

--- a/po/ru.po
+++ b/po/ru.po
@@ -195,10 +195,6 @@ msgstr "Запускать в полноэкранном режиме"
 msgid "Use VTE titles for tab names"
 msgstr "Использовать заголовки VTE для названий вкладок"
 
-#: ../guake/data/prefs.glade.h:25
-msgid "Abbreviate directories in tab names"
-msgstr "Сокращать пути в названиях вкладок"
-
 #: ../guake/data/prefs.glade.h:26
 msgid "Max tab name length:"
 msgstr "Макс. ширина вкладки:"
@@ -1457,6 +1453,22 @@ msgstr ""
 
 #: guake/data/prefs.glade:809
 msgid "Hide tabbar when fullscreen"
+msgstr ""
+
+#: guake/data/prefs.glade:739
+msgid "Display as tab names:"
+msgstr ""
+
+#: guake/data/prefs.glade:753
+msgid "Full Path"
+msgstr ""
+
+#: guake/data/prefs.glade:754
+msgid "Abbreviated Path"
+msgstr ""
+
+#: guake/data/prefs.glade:755
+msgid "Last Segment"
 msgstr ""
 
 #~ msgid "Path to script executed on Guake start:"

--- a/po/sv.po
+++ b/po/sv.po
@@ -619,10 +619,6 @@ msgstr "Visa flikrad"
 msgid "Use VTE titles for tab names"
 msgstr "Visa VTE-titel som fliknamn"
 
-#: data/prefs.glade:618
-msgid "Abbreviate directories in tab names"
-msgstr "Förkorta katalognamn i flikar"
-
 #: data/prefs.glade:643
 msgid "Max tab name length:"
 msgstr "Maxlängd för fliknamn:"
@@ -1189,4 +1185,20 @@ msgstr ""
 
 #: guake/data/prefs.glade:809
 msgid "Hide tabbar when fullscreen"
+msgstr ""
+
+#: guake/data/prefs.glade:739
+msgid "Display as tab names:"
+msgstr ""
+
+#: guake/data/prefs.glade:753
+msgid "Full Path"
+msgstr ""
+
+#: guake/data/prefs.glade:754
+msgid "Abbreviated Path"
+msgstr ""
+
+#: guake/data/prefs.glade:755
+msgid "Last Segment"
 msgstr ""

--- a/po/tr.po
+++ b/po/tr.po
@@ -212,10 +212,6 @@ msgstr ""
 msgid "0 means no size limit"
 msgstr ""
 
-#: ../guake/data/prefs.glade.h:35
-msgid "Abbreviate directories in tab names"
-msgstr ""
-
 #: ../guake/data/prefs.glade.h:36
 msgid "Hide on lose focus"
 msgstr "Focus kaybedildiğinde gizle"
@@ -1406,6 +1402,22 @@ msgstr ""
 
 #: guake/data/prefs.glade:809
 msgid "Hide tabbar when fullscreen"
+msgstr ""
+
+#: guake/data/prefs.glade:739
+msgid "Display as tab names:"
+msgstr ""
+
+#: guake/data/prefs.glade:753
+msgid "Full Path"
+msgstr ""
+
+#: guake/data/prefs.glade:754
+msgid "Abbreviated Path"
+msgstr ""
+
+#: guake/data/prefs.glade:755
+msgid "Last Segment"
 msgstr ""
 
 #~ msgid "key binding error"

--- a/po/uk.po
+++ b/po/uk.po
@@ -213,10 +213,6 @@ msgstr ""
 msgid "0 means no size limit"
 msgstr ""
 
-#: ../guake/data/prefs.glade.h:35
-msgid "Abbreviate directories in tab names"
-msgstr ""
-
 #: ../guake/data/prefs.glade.h:36
 msgid "Hide on lose focus"
 msgstr "Ховатися при втраті фокусу"
@@ -1408,6 +1404,22 @@ msgstr ""
 
 #: guake/data/prefs.glade:809
 msgid "Hide tabbar when fullscreen"
+msgstr ""
+
+#: guake/data/prefs.glade:739
+msgid "Display as tab names:"
+msgstr ""
+
+#: guake/data/prefs.glade:753
+msgid "Full Path"
+msgstr ""
+
+#: guake/data/prefs.glade:754
+msgid "Abbreviated Path"
+msgstr ""
+
+#: guake/data/prefs.glade:755
+msgid "Last Segment"
 msgstr ""
 
 #~ msgid "key binding error"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -221,10 +221,6 @@ msgstr "启动默认全屏"
 msgid "Use VTE titles for tab names"
 msgstr "使用VTE标题作为标签名"
 
-#: ../guake/data/prefs.glade.h:36
-msgid "Abbreviate directories in tab names"
-msgstr "在标签名中缩写目录"
-
 #: ../guake/data/prefs.glade.h:37
 msgid "Max tab name length:"
 msgstr "最大标签名长度:"
@@ -1420,6 +1416,22 @@ msgstr ""
 
 #: guake/data/prefs.glade:809
 msgid "Hide tabbar when fullscreen"
+msgstr ""
+
+#: guake/data/prefs.glade:739
+msgid "Display as tab names:"
+msgstr ""
+
+#: guake/data/prefs.glade:753
+msgid "Full Path"
+msgstr ""
+
+#: guake/data/prefs.glade:754
+msgid "Abbreviated Path"
+msgstr ""
+
+#: guake/data/prefs.glade:755
+msgid "Last Segment"
 msgstr ""
 
 #~ msgid "0 means no size limit"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -709,10 +709,6 @@ msgstr ""
 msgid "Use VTE titles for tab names"
 msgstr ""
 
-#: data/prefs.glade:731
-msgid "Abbreviate directories in tab names"
-msgstr ""
-
 #: data/prefs.glade:756
 msgid "Max tab name length:"
 msgstr ""
@@ -1080,4 +1076,20 @@ msgstr ""
 
 #: guake/data/prefs.glade:809
 msgid "Hide tabbar when fullscreen"
+msgstr ""
+
+#: guake/data/prefs.glade:739
+msgid "Display as tab names:"
+msgstr ""
+
+#: guake/data/prefs.glade:753
+msgid "Full Path"
+msgstr ""
+
+#: guake/data/prefs.glade:754
+msgid "Abbreviated Path"
+msgstr ""
+
+#: guake/data/prefs.glade:755
+msgid "Last Segment"
 msgstr ""

--- a/releasenotes/notes/tab-names-last-dir-567eefdb3da75113.yaml
+++ b/releasenotes/notes/tab-names-last-dir-567eefdb3da75113.yaml
@@ -1,0 +1,9 @@
+release_summary: >
+  Adds an option to display only the last directory on the current path as the tab name.
+
+features:
+  - Adds an option to display only the last directory on the current path as the tab name.
+  - Reworked the tab name selection to use a drop-down menu.
+
+deprecations:
+  - Translations need to be updated.


### PR DESCRIPTION
**Context**

This pull request introduces a feature that I wanted for quite some time to improve my workflow.

When I work with Guake, I open up multiple a tab for each project. It looks like this:

![Tabs_Before](https://user-images.githubusercontent.com/26232435/62827309-18340000-bbd5-11e9-89eb-2988b37d09ae.png)

A bit cramped and not very aesthetically pleasing. Scrolling is inconvenient too, especially since I might have up to 20 of these open.

**What this pull request introduces**

Preferences window now has an option to only display the last directory as a tab name (everything after the last '/' symbol, or (root) if the string is empty). I also merged this option with the abbreviate option into a drop-down menu instead of adding an another checkbox. Like this:

![Prefs](https://user-images.githubusercontent.com/26232435/62827305-11a58880-bbd5-11e9-8753-6d2ecbc5c356.png)

With this option on, the tabs look like this:

![Tabs_After](https://user-images.githubusercontent.com/26232435/62827303-09e5e400-bbd5-11e9-8e5a-faa40ba236e3.png)

Which might be less informative, but far more neat and tidy, in my opinion.

**Considerations**

- The translations should be redone for the preferences menu now.
- I just noticed the tab names aren't updated instantly after you change this option in the preferences menu and then go back to Guake, but rather after Guake is restarted. Was it like that before? I might take a look at this too.