### PR TITLE
Manage colors

### DIFF
--- a/guake/dbusiface.py
+++ b/guake/dbusiface.py
@@ -99,6 +99,10 @@ class DbusManager(dbus.service.Object):
     def change_palette_name(self, palette_name):
         self.guake.change_palette_name(palette_name)
 
+    @dbus.service.method(DBUS_NAME)
+    def reset_colors(self):
+        self.guake.set_colors_from_settings_on_current_page()
+
     @dbus.service.method(DBUS_NAME, in_signature='s')
     def execute_command(self, command):
         self.guake.execute_command(command)

--- a/guake/dbusiface.py
+++ b/guake/dbusiface.py
@@ -96,12 +96,24 @@ class DbusManager(dbus.service.Object):
         return self.guake.set_fgcolor(fgcolor)
 
     @dbus.service.method(DBUS_NAME, in_signature='s')
+    def set_bgcolor_focused_terminal(self, bgcolor):
+        return self.guake.set_bgcolor(bgcolor, focused_only=True)
+
+    @dbus.service.method(DBUS_NAME, in_signature='s')
+    def set_fgcolor_focused_terminal(self, fgcolor):
+        return self.guake.set_fgcolor(fgcolor, focused_only=True)
+
+    @dbus.service.method(DBUS_NAME, in_signature='s')
     def change_palette_name(self, palette_name):
         self.guake.change_palette_name(palette_name)
 
     @dbus.service.method(DBUS_NAME)
     def reset_colors(self):
         self.guake.set_colors_from_settings_on_current_page()
+
+    @dbus.service.method(DBUS_NAME)
+    def reset_colors_focused(self):
+        self.guake.set_colors_from_settings_on_current_page(focused_only=True)
 
     @dbus.service.method(DBUS_NAME, in_signature='s')
     def execute_command(self, command):

--- a/guake/guake_app.py
+++ b/guake/guake_app.py
@@ -355,18 +355,20 @@ class Guake(SimpleGladeApp):
             i.set_color_bold(font_color)
             i.set_colors(font_color, bg_color, palette_list[:16])
 
-    def set_colors_from_settings_on_current_page(self):
+    def set_colors_from_settings_on_current_page(self, focused_only=False):
         bg_color = self.get_bgcolor()
         font_color = self.get_fgcolor()
         palette_list = self._load_palette()
 
         page_num = self.get_notebook().get_current_page()
         for terminal in self.get_notebook().get_nth_page(page_num).iter_terminals():
+            if focused_only and not terminal.has_focus():
+                continue
             terminal.set_color_foreground(font_color)
             terminal.set_color_bold(font_color)
             terminal.set_colors(font_color, bg_color, palette_list[:16])
 
-    def set_bgcolor(self, bgcolor):
+    def set_bgcolor(self, bgcolor, focused_only=False):
         if isinstance(bgcolor, str):
             c = Gdk.RGBA(0, 0, 0, 0)
             log.debug("Building Gdk Color from: %r", bgcolor)
@@ -378,9 +380,11 @@ class Guake(SimpleGladeApp):
         log.debug("setting background color to: %r", bgcolor)
         page_num = self.get_notebook().get_current_page()
         for terminal in self.get_notebook().get_nth_page(page_num).iter_terminals():
+            if focused_only and not terminal.has_focus():
+                continue
             terminal.set_color_background(bgcolor)
 
-    def set_fgcolor(self, fgcolor):
+    def set_fgcolor(self, fgcolor, focused_only=False):
         if isinstance(fgcolor, str):
             c = Gdk.RGBA(0, 0, 0, 0)
             log.debug("Building Gdk Color from: %r", fgcolor)
@@ -391,6 +395,8 @@ class Guake(SimpleGladeApp):
         log.debug("setting background color to: %r", fgcolor)
         page_num = self.get_notebook().get_current_page()
         for terminal in self.get_notebook().get_nth_page(page_num).iter_terminals():
+            if focused_only and not terminal.has_focus():
+                continue
             terminal.set_color_foreground(fgcolor)
 
     def change_palette_name(self, palette_name):

--- a/guake/guake_app.py
+++ b/guake/guake_app.py
@@ -355,6 +355,17 @@ class Guake(SimpleGladeApp):
             i.set_color_bold(font_color)
             i.set_colors(font_color, bg_color, palette_list[:16])
 
+    def set_colors_from_settings_on_current_page(self):
+        bg_color = self.get_bgcolor()
+        font_color = self.get_fgcolor()
+        palette_list = self._load_palette()
+
+        page_num = self.get_notebook().get_current_page()
+        for terminal in self.get_notebook().get_nth_page(page_num).iter_terminals():
+            terminal.set_color_foreground(font_color)
+            terminal.set_color_bold(font_color)
+            terminal.set_colors(font_color, bg_color, palette_list[:16])
+
     def set_bgcolor(self, bgcolor):
         if isinstance(bgcolor, str):
             c = Gdk.RGBA(0, 0, 0, 0)

--- a/guake/main.py
+++ b/guake/main.py
@@ -231,6 +231,14 @@ def main():
     )
 
     parser.add_option(
+        '--reset-colors',
+        dest='reset_colors',
+        action='store_true',
+        default=False,
+        help=_('Set colors from settings.')
+    )
+
+    parser.add_option(
         '--rename-tab',
         dest='rename_tab',
         metavar='TITLE',
@@ -472,6 +480,10 @@ def main():
 
     if options.palette_name:
         remote_object.change_palette_name(options.palette_name)
+        only_show_hide = options.show
+
+    if options.reset_colors:
+        remote_object.reset_colors()
         only_show_hide = options.show
 
     if options.rename_current_tab:

--- a/guake/main.py
+++ b/guake/main.py
@@ -223,6 +223,24 @@ def main():
     )
 
     parser.add_option(
+        '--bgcolor-focused',
+        dest='bgcolor_focused',
+        action='store',
+        default='',
+        help=_('Set the hexadecimal (#rrggbb) background color of '
+               'the focused terminal.')
+    )
+
+    parser.add_option(
+        '--fgcolor-focused',
+        dest='fgcolor_focused',
+        action='store',
+        default='',
+        help=_('Set the hexadecimal (#rrggbb) foreground color of the '
+               'focused terminal.')
+    )
+
+    parser.add_option(
         '--change-palette',
         dest='palette_name',
         action='store',
@@ -236,6 +254,14 @@ def main():
         action='store_true',
         default=False,
         help=_('Set colors from settings.')
+    )
+
+    parser.add_option(
+        '--reset-colors-focused',
+        dest='reset_colors_focused',
+        action='store_true',
+        default=False,
+        help=_('Set colors of the focused terminal from settings.')
     )
 
     parser.add_option(
@@ -478,12 +504,24 @@ def main():
         remote_object.set_fgcolor(options.fgcolor)
         only_show_hide = options.show
 
+    if options.bgcolor_focused:
+        remote_object.set_bgcolor_focused_terminal(options.bgcolor_focused)
+        only_show_hide = options.show
+
+    if options.fgcolor_focused:
+        remote_object.set_fgcolor_focused_terminal(options.fgcolor_focused)
+        only_show_hide = options.show
+
     if options.palette_name:
         remote_object.change_palette_name(options.palette_name)
         only_show_hide = options.show
 
     if options.reset_colors:
         remote_object.reset_colors()
+        only_show_hide = options.show
+
+    if options.reset_colors_focused:
+        remote_object.reset_colors_focused()
         only_show_hide = options.show
 
     if options.rename_current_tab:

--- a/releasenotes/notes/feature_manage_colors-3c4e19b536430948.yaml
+++ b/releasenotes/notes/feature_manage_colors-3c4e19b536430948.yaml
@@ -1,0 +1,12 @@
+release_summary: >
+  Resetting colors of the current page.
+  Managing background and foreground colors of the current terminal.
+  --reset-colors, --bgcolor-focused, --fgcolor-focused and
+    --reset-colors-focused command line arguments added.
+
+features:
+  - |
+    List new features here followed by the ticket number, for example::
+
+      - Resetting colors of the current page.
+      - Setting of background and foreground colors and resetting colors of the focused terminal.


### PR DESCRIPTION
Hello there.

It can be useful some times to be able to change colors of the current terminal only (not only of the current tab of whole terminal app).
And I think it's good to have an option to reset colors to the current settings after changing them.

So I added several command line options for managing terminal colors:

**--reset-colors**: Lets the user to reset terminal colors after changing them via **--bgcolor** and **--fgcolor** arguments. Reverts colors to the settings colors.

**--bgcolor-focused**, **--fgcolor-focused**, **--reset-colors-focused**: Changes the background color, the foreground color and resets colors for the currently focused terminal.