### PR TITLE
Manage colors

### DIFF
--- a/guake/dbusiface.py
+++ b/guake/dbusiface.py
@@ -100,12 +100,12 @@ class DbusManager(dbus.service.Object):
         return self.guake.set_fgcolor(fgcolor)
 
     @dbus.service.method(DBUS_NAME, in_signature='s')
-    def set_bgcolor_focused_terminal(self, bgcolor):
-        return self.guake.set_bgcolor(bgcolor, focused_only=True)
+    def set_bgcolor_current_terminal(self, bgcolor):
+        return self.guake.set_bgcolor(bgcolor, current_terminal_only=True)
 
     @dbus.service.method(DBUS_NAME, in_signature='s')
-    def set_fgcolor_focused_terminal(self, fgcolor):
-        return self.guake.set_fgcolor(fgcolor, focused_only=True)
+    def set_fgcolor_current_terminal(self, fgcolor):
+        return self.guake.set_fgcolor(fgcolor, current_terminal_only=True)
 
     @dbus.service.method(DBUS_NAME, in_signature='s')
     def change_palette_name(self, palette_name):
@@ -116,8 +116,8 @@ class DbusManager(dbus.service.Object):
         self.guake.set_colors_from_settings_on_current_page()
 
     @dbus.service.method(DBUS_NAME)
-    def reset_colors_focused(self):
-        self.guake.set_colors_from_settings_on_current_page(focused_only=True)
+    def reset_colors_current(self):
+        self.guake.set_colors_from_settings_on_current_page(current_terminal_only=True)
 
     @dbus.service.method(DBUS_NAME, in_signature='s')
     def execute_command(self, command):

--- a/guake/guake_app.py
+++ b/guake/guake_app.py
@@ -355,20 +355,24 @@ class Guake(SimpleGladeApp):
             i.set_color_bold(font_color)
             i.set_colors(font_color, bg_color, palette_list[:16])
 
-    def set_colors_from_settings_on_current_page(self, focused_only=False):
+    def set_colors_from_settings_on_current_page(self, current_terminal_only=False):
         bg_color = self.get_bgcolor()
         font_color = self.get_fgcolor()
         palette_list = self._load_palette()
 
-        page_num = self.get_notebook().get_current_page()
-        for terminal in self.get_notebook().get_nth_page(page_num).iter_terminals():
-            if focused_only and not terminal.has_focus():
-                continue
+        if current_terminal_only:
+            terminal = self.get_notebook().get_current_terminal()
             terminal.set_color_foreground(font_color)
             terminal.set_color_bold(font_color)
             terminal.set_colors(font_color, bg_color, palette_list[:16])
+        else:
+            page_num = self.get_notebook().get_current_page()
+            for terminal in self.get_notebook().get_nth_page(page_num).iter_terminals():
+                terminal.set_color_foreground(font_color)
+                terminal.set_color_bold(font_color)
+                terminal.set_colors(font_color, bg_color, palette_list[:16])
 
-    def set_bgcolor(self, bgcolor, focused_only=False):
+    def set_bgcolor(self, bgcolor, current_terminal_only=False):
         if isinstance(bgcolor, str):
             c = Gdk.RGBA(0, 0, 0, 0)
             log.debug("Building Gdk Color from: %r", bgcolor)
@@ -378,13 +382,15 @@ class Guake(SimpleGladeApp):
             raise TypeError("color should be Gdk.RGBA, is: {!r}".format(bgcolor))
         bgcolor = self._apply_transparency_to_color(bgcolor)
         log.debug("setting background color to: %r", bgcolor)
-        page_num = self.get_notebook().get_current_page()
-        for terminal in self.get_notebook().get_nth_page(page_num).iter_terminals():
-            if focused_only and not terminal.has_focus():
-                continue
-            terminal.set_color_background(bgcolor)
 
-    def set_fgcolor(self, fgcolor, focused_only=False):
+        if current_terminal_only:
+            self.get_notebook().get_current_terminal().set_color_background(bgcolor)
+        else:
+            page_num = self.get_notebook().get_current_page()
+            for terminal in self.get_notebook().get_nth_page(page_num).iter_terminals():
+                terminal.set_color_background(bgcolor)
+
+    def set_fgcolor(self, fgcolor, current_terminal_only=False):
         if isinstance(fgcolor, str):
             c = Gdk.RGBA(0, 0, 0, 0)
             log.debug("Building Gdk Color from: %r", fgcolor)
@@ -393,11 +399,13 @@ class Guake(SimpleGladeApp):
         if not isinstance(fgcolor, Gdk.RGBA):
             raise TypeError("color should be Gdk.RGBA, is: {!r}".format(fgcolor))
         log.debug("setting background color to: %r", fgcolor)
-        page_num = self.get_notebook().get_current_page()
-        for terminal in self.get_notebook().get_nth_page(page_num).iter_terminals():
-            if focused_only and not terminal.has_focus():
-                continue
-            terminal.set_color_foreground(fgcolor)
+
+        if current_terminal_only:
+            self.get_notebook().get_current_terminal().set_color_foreground(fgcolor)
+        else:
+            page_num = self.get_notebook().get_current_page()
+            for terminal in self.get_notebook().get_nth_page(page_num).iter_terminals():
+                terminal.set_color_foreground(fgcolor)
 
     def change_palette_name(self, palette_name):
         if isinstance(palette_name, str):

--- a/guake/main.py
+++ b/guake/main.py
@@ -231,21 +231,21 @@ def main():
     )
 
     parser.add_option(
-        '--bgcolor-focused',
-        dest='bgcolor_focused',
+        '--bgcolor-current',
+        dest='bgcolor_current',
         action='store',
         default='',
         help=_('Set the hexadecimal (#rrggbb) background color of '
-               'the focused terminal.')
+               'the current terminal.')
     )
 
     parser.add_option(
-        '--fgcolor-focused',
-        dest='fgcolor_focused',
+        '--fgcolor-current',
+        dest='fgcolor_current',
         action='store',
         default='',
-        help=_('Set the hexadecimal (#rrggbb) foreground color of the '
-               'focused terminal.')
+        help=_('Set the hexadecimal (#rrggbb) foreground color of '
+               'the current terminal.')
     )
 
     parser.add_option(
@@ -265,11 +265,11 @@ def main():
     )
 
     parser.add_option(
-        '--reset-colors-focused',
-        dest='reset_colors_focused',
+        '--reset-colors-current',
+        dest='reset_colors_current',
         action='store_true',
         default=False,
-        help=_('Set colors of the focused terminal from settings.')
+        help=_('Set colors of the current terminal from settings.')
     )
 
     parser.add_option(
@@ -515,12 +515,12 @@ def main():
         remote_object.set_fgcolor(options.fgcolor)
         only_show_hide = options.show
 
-    if options.bgcolor_focused:
-        remote_object.set_bgcolor_focused_terminal(options.bgcolor_focused)
+    if options.bgcolor_current:
+        remote_object.set_bgcolor_current_terminal(options.bgcolor_current)
         only_show_hide = options.show
 
-    if options.fgcolor_focused:
-        remote_object.set_fgcolor_focused_terminal(options.fgcolor_focused)
+    if options.fgcolor_current:
+        remote_object.set_fgcolor_current_terminal(options.fgcolor_current)
         only_show_hide = options.show
 
     if options.palette_name:
@@ -531,8 +531,8 @@ def main():
         remote_object.reset_colors()
         only_show_hide = options.show
 
-    if options.reset_colors_focused:
-        remote_object.reset_colors_focused()
+    if options.reset_colors_current:
+        remote_object.reset_colors_current()
         only_show_hide = options.show
 
     if options.rename_current_tab:

--- a/releasenotes/notes/feature_manage_colors-a1cb608cb342d401.yaml
+++ b/releasenotes/notes/feature_manage_colors-a1cb608cb342d401.yaml
@@ -1,0 +1,7 @@
+release_summary: >
+    --bgcolor-focused, --fgcolor-focused and --reset-colors-focused command line arguments
+        renamed to --bgcolor-current, --fgcolor-current and --reset-colors-current respectively.
+
+features:
+    - Setting of background and foreground colors and resetting colors of the current terminal
+        (not the focused one).


### PR DESCRIPTION
Hi!

I renamed **--bgcolor-focused**, **--fgcolor-focused** and **--reset-colors-focused** command line arguments to **--bgcolor-current**, **--fgcolor-current** and **--reset-colors-current** respectively.
Since these commands were added just 2 days ago (https://github.com/Guake/guake/pull/1675), so it seems to be safe to rename them.

Also made above commands to change colors of the **current** terminal, **not** the **focused** one, as they are not the same sometimes (for example in case when these commands are executed within a shell script, and the whole terminal is not focused at the moment).