### PR TITLE
Add --select-terminal and --selected-terminal options in CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 # Linux, IDE and Editors
 
-#    pycharm
+#    pycharm & IntelliJ
 .idea
+*.iml
 
 #    kde
 .directory

--- a/guake/dbusiface.py
+++ b/guake/dbusiface.py
@@ -91,6 +91,30 @@ class DbusManager(dbus.service.Object):
     def get_tab_count(self):
         return len(self.guake.notebook_manager.get_terminals())
 
+    @dbus.service.method(DBUS_NAME, in_signature='i')
+    def select_terminal(self, term_index=0):
+        notebook = self.guake.get_notebook()
+        current_page_index = notebook.get_current_page()
+        terminals = notebook.get_terminals_for_page(current_page_index)
+        return terminals[term_index].grab_focus()
+
+    @dbus.service.method(DBUS_NAME, out_signature='i')
+    def get_selected_terminal(self):
+        notebook = self.guake.get_notebook()
+        current_page_index = notebook.get_current_page()
+        terminals = notebook.get_terminals_for_page(current_page_index)
+        for i, term in enumerate(terminals, 0):
+            if term.is_focus():
+                return i
+        return -1
+
+    @dbus.service.method(DBUS_NAME, out_signature='i')
+    def get_term_count(self):
+        notebook = self.guake.get_notebook()
+        current_page_index = notebook.get_current_page()
+        terminals = notebook.get_terminals_for_page(current_page_index)
+        return len(terminals)
+
     @dbus.service.method(DBUS_NAME, in_signature='s')
     def set_bgcolor(self, bgcolor):
         return self.guake.set_bgcolor(bgcolor)

--- a/guake/main.py
+++ b/guake/main.py
@@ -179,6 +179,27 @@ def main():
     )
 
     parser.add_option(
+        '-S',
+        '--select-terminal',
+        dest='select_terminal',
+        metavar='TERMINAL_INDEX',
+        action='store',
+        default='',
+        help=_(
+            'Select a specific terminal in a split tab. ' +
+            'Only useful with split terminals (TERMINAL_INDEX is the index of the tab)'
+        )
+    )
+
+    parser.add_option(
+        '--selected-terminal',
+        dest='selected_terminal',
+        action='store_true',
+        default=False,
+        help=_('Return the selected terminal index.')
+    )
+
+    parser.add_option(
         '--split-vertical',
         dest='split_vertical',
         action='store_true',
@@ -494,6 +515,20 @@ def main():
 
     if options.split_horizontal:
         remote_object.h_split_current_terminal()
+        only_show_hide = options.show
+
+    if options.selected_terminal:
+        selected = remote_object.get_selected_terminal()
+        sys.stdout.write('%d\n' % selected)
+        only_show_hide = options.show
+
+    if options.select_terminal:
+        selected = int(options.select_terminal)
+        term_count = int(remote_object.get_term_count())
+        if 0 <= selected < term_count:
+            remote_object.select_terminal(selected)
+        else:
+            sys.stderr.write('invalid index: %d\n' % selected)
         only_show_hide = options.show
 
     if options.command:

--- a/releasenotes/notes/select-split-terminal-235cc40fdc3dd598.yaml
+++ b/releasenotes/notes/select-split-terminal-235cc40fdc3dd598.yaml
@@ -1,0 +1,2 @@
+features:
+  - Add --select-terminal and --selected-terminal options to Guake CLI


### PR DESCRIPTION
Resolves issue #1680

`--split-vertical` and `--split-horizontal` are really nice ! But it feels to me that a select terminal feature is missing.

Typically, if you want to make a 2x2 grid, you currently can't because the first terminal cannot be selected. Hence you can only split it vertically or horizontally, but not both.

Proposal:
```bash
 guake --select-terminal INDEX
```
Where INDEX would be an auto-incremented value, very much like the tabs work.

Example for a 2x2 grid :
```bash
# Main terminal has index 0
guake --split-horizontally # Right terminal has index 1
guake --split-vertically # Bottom-Right terminal has index 2, Top-Right keeps index 1
guake --select-terminal 0 # Back to left terminal
guake --split-vertically # Bottom-Left terminal has index 3, Top-Left keeps index 0
```

We end up with this layout:
```
|---|---|
| 0 | 1 |
|---|---|
| 3 | 2 |
|---|---|
```