### PR TITLE
Fix colors resetting on 'New Tab' or 'Split Terminal' commands.

### DIFF
--- a/guake/gsettings.py
+++ b/guake/gsettings.py
@@ -154,20 +154,29 @@ class GSettingHandler():
     def cursor_blink_mode_changed(self, settings, key, user_data):
         """Called when cursor blink mode settings has been changed
         """
-        for term in self.guake.notebook_manager.iter_terminals():
+        terminal = self.guake.notebook_manager.get_terminal_by_uuid(user_data.get('terminal_uuid'))\
+            if user_data else None
+        terminals = (terminal, ) if terminal else self.guake.notebook_manager.iter_terminals()
+        for term in terminals:
             term.set_property("cursor-blink-mode", settings.get_int(key))
 
     def cursor_shape_changed(self, settings, key, user_data):
         """Called when the cursor shape settings has been changed
         """
-        for term in self.guake.notebook_manager.iter_terminals():
+        terminal = self.guake.notebook_manager.get_terminal_by_uuid(user_data.get('terminal_uuid'))\
+            if user_data else None
+        terminals = (terminal, ) if terminal else self.guake.notebook_manager.iter_terminals()
+        for term in terminals:
             term.set_property("cursor-shape", settings.get_int(key))
 
     def scrollbar_toggled(self, settings, key, user_data):
         """If the gconf var use_scrollbar be changed, this method will
         be called and will show/hide scrollbars of all terminals open.
         """
-        for term in self.guake.notebook_manager.iter_terminals():
+        terminal = self.guake.notebook_manager.get_terminal_by_uuid(user_data.get('terminal_uuid'))\
+            if user_data else None
+        terminals = (terminal, ) if terminal else self.guake.notebook_manager.iter_terminals()
+        for term in terminals:
             # There is an hbox in each tab of the main notebook and it
             # contains a Terminal and a Scrollbar. Since only have the
             # Terminal here, we're going to use this to get the
@@ -187,7 +196,10 @@ class GSettingHandler():
         terminals open.
         """
         lines = settings.get_int(key)
-        for i in self.guake.notebook_manager.iter_terminals():
+        terminal = self.guake.notebook_manager.get_terminal_by_uuid(user_data.get('terminal_uuid'))\
+            if user_data else None
+        terminals = (terminal, ) if terminal else self.guake.notebook_manager.iter_terminals()
+        for i in terminals:
             i.set_scrollback_lines(lines)
 
     def infinite_history_changed(self, settings, key, user_data):
@@ -195,7 +207,10 @@ class GSettingHandler():
             lines = -1
         else:
             lines = self.settings.general.get_int("history-size")
-        for i in self.guake.notebook_manager.iter_terminals():
+        terminal = self.guake.notebook_manager.get_terminal_by_uuid(user_data.get('terminal_uuid'))\
+            if user_data else None
+        terminals = (terminal, ) if terminal else self.guake.notebook_manager.iter_terminals()
+        for i in terminals:
             i.set_scrollback_lines(lines)
 
     def keystroke_output(self, settings, key, user_data):
@@ -203,7 +218,10 @@ class GSettingHandler():
         be called and will set the scroll_on_output in all terminals
         open.
         """
-        for i in self.guake.notebook_manager.iter_terminals():
+        terminal = self.guake.notebook_manager.get_terminal_by_uuid(user_data.get('terminal_uuid'))\
+            if user_data else None
+        terminals = (terminal, ) if terminal else self.guake.notebook_manager.iter_terminals()
+        for i in terminals:
             i.set_scroll_on_output(settings.get_boolean(key))
 
     def keystroke_toggled(self, settings, key, user_data):
@@ -211,7 +229,10 @@ class GSettingHandler():
         will be called and will set the scroll_on_keystroke in all
         terminals open.
         """
-        for i in self.guake.notebook_manager.iter_terminals():
+        terminal = self.guake.notebook_manager.get_terminal_by_uuid(user_data.get('terminal_uuid'))\
+            if user_data else None
+        terminals = (terminal, ) if terminal else self.guake.notebook_manager.iter_terminals()
+        for i in terminals:
             i.set_scroll_on_keystroke(settings.get_boolean(key))
 
     def default_font_toggled(self, settings, key, user_data):
@@ -233,7 +254,10 @@ class GSettingHandler():
         if not font:
             log.error("Error: unable to load font (%s)", font_name)
             return
-        for i in self.guake.notebook_manager.iter_terminals():
+        terminal = self.guake.notebook_manager.get_terminal_by_uuid(user_data.get('terminal_uuid'))\
+            if user_data else None
+        terminals = (terminal, ) if terminal else self.guake.notebook_manager.iter_terminals()
+        for i in terminals:
             i.set_font(font)
 
     def allow_bold_toggled(self, settings, key, user_data):
@@ -241,7 +265,10 @@ class GSettingHandler():
         and will change the VTE terminal o.
         displaying characters in bold font.
         """
-        for term in self.guake.notebook_manager.iter_terminals():
+        terminal = self.guake.notebook_manager.get_terminal_by_uuid(user_data.get('terminal_uuid'))\
+            if user_data else None
+        terminals = (terminal, ) if terminal else self.guake.notebook_manager.iter_terminals()
+        for term in terminals:
             term.set_allow_bold(settings.get_boolean(key))
 
     def bold_is_bright_toggled(self, settings, key, user_data):
@@ -249,7 +276,11 @@ class GSettingHandler():
         and will change the VTE terminal to toggle auto-brightened bold text.
         """
         try:
-            for term in self.guake.notebook_manager.iter_terminals():
+            terminal = self.guake.notebook_manager.get_terminal_by_uuid(
+                user_data.get('terminal_uuid')
+            )
+            terminals = (terminal, ) if terminal else self.guake.notebook_manager.iter_terminals()
+            for term in terminals:
                 term.set_bold_is_bright(settings.get_boolean(key))
         except:  # pylint: disable=bare-except
             log.error("set_bold_is_bright not supported by your version of VTE")
@@ -266,8 +297,16 @@ class GSettingHandler():
         will be called and will change the font style in all terminals
         open.
         """
+        terminal_uuid = user_data.get('terminal_uuid')
+
+        if terminal_uuid:
+            terminal = self.guake.notebook_manager.get_terminal_by_uuid(terminal_uuid)
+            terminals = (terminal, ) if terminal else tuple()
+        else:
+            terminals = self.guake.notebook_manager.iter_terminals()
+
         font = Pango.FontDescription(settings.get_string(key))
-        for i in self.guake.notebook_manager.iter_terminals():
+        for i in terminals:
             i.set_font(font)
 
     def fpalette_changed(self, settings, key, user_data):
@@ -275,14 +314,16 @@ class GSettingHandler():
         will be called and will change the color scheme in all terminals
         open.
         """
-        self.guake.set_colors_from_settings()
+        self.guake.set_colors_from_settings(terminal_uuid=user_data.get('terminal_uuid'))
 
     def bgtransparency_changed(self, settings, key, user_data):
         """If the gconf var style/background/transparency be changed, this
         method will be called and will set the saturation and transparency
         properties in all terminals open.
         """
-        self.guake.set_background_color_from_settings()
+        self.guake.set_background_color_from_settings(
+            terminal_uuid=user_data.get('terminal_uuid') if user_data else None
+        )
 
     def getEraseBinding(self, str):
         if str == "auto":
@@ -301,7 +342,10 @@ class GSettingHandler():
         will be called and will change the binding configuration in
         all terminals open.
         """
-        for i in self.guake.notebook_manager.iter_terminals():
+        terminal = self.guake.notebook_manager.get_terminal_by_uuid(user_data.get('terminal_uuid'))\
+            if user_data else None
+        terminals = (terminal, ) if terminal else self.guake.notebook_manager.iter_terminals()
+        for i in terminals:
             i.set_backspace_binding(self.getEraseBinding(settings.get_string(key)))
 
     def delete_changed(self, settings, key, user_data):
@@ -309,7 +353,10 @@ class GSettingHandler():
         will be called and will change the binding configuration in
         all terminals open.
         """
-        for i in self.guake.notebook_manager.iter_terminals():
+        terminal = self.guake.notebook_manager.get_terminal_by_uuid(user_data.get('terminal_uuid'))\
+            if user_data else None
+        terminals = (terminal, ) if terminal else self.guake.notebook_manager.iter_terminals()
+        for i in terminals:
             i.set_delete_binding(self.getEraseBinding(settings.get_string(key)))
 
     def max_tab_name_length_changed(self, settings, key, user_data):

--- a/guake/gsettings.py
+++ b/guake/gsettings.py
@@ -277,7 +277,7 @@ class GSettingHandler():
         """
         try:
             terminal = self.guake.notebook_manager.get_terminal_by_uuid(
-                user_data.get('terminal_uuid')
+                user_data.get('terminal_uuid') if user_data else None
             )
             terminals = (terminal, ) if terminal else self.guake.notebook_manager.iter_terminals()
             for term in terminals:
@@ -297,7 +297,7 @@ class GSettingHandler():
         will be called and will change the font style in all terminals
         open.
         """
-        terminal_uuid = user_data.get('terminal_uuid')
+        terminal_uuid = user_data.get('terminal_uuid') if user_data else None
 
         if terminal_uuid:
             terminal = self.guake.notebook_manager.get_terminal_by_uuid(terminal_uuid)
@@ -314,7 +314,9 @@ class GSettingHandler():
         will be called and will change the color scheme in all terminals
         open.
         """
-        self.guake.set_colors_from_settings(terminal_uuid=user_data.get('terminal_uuid'))
+        self.guake.set_colors_from_settings(
+            terminal_uuid=user_data.get('terminal_uuid') if user_data else None
+        )
 
     def bgtransparency_changed(self, settings, key, user_data):
         """If the gconf var style/background/transparency be changed, this

--- a/guake/guake_app.py
+++ b/guake/guake_app.py
@@ -330,8 +330,8 @@ class Guake(SimpleGladeApp):
             bg_color.alpha = 1
         return bg_color
 
-    def set_background_color_from_settings(self):
-        self.set_colors_from_settings()
+    def set_background_color_from_settings(self, terminal_uuid=None):
+        self.set_colors_from_settings(terminal_uuid)
 
     def get_bgcolor(self):
         palette_list = self._load_palette()
@@ -345,12 +345,16 @@ class Guake(SimpleGladeApp):
             font_color = Gdk.RGBA(0, 0, 0, 0)
         return font_color
 
-    def set_colors_from_settings(self):
+    def set_colors_from_settings(self, terminal_uuid=None):
         bg_color = self.get_bgcolor()
         font_color = self.get_fgcolor()
         palette_list = self._load_palette()
 
-        for i in self.get_notebook().iter_terminals():
+        terminals = self.get_notebook().iter_terminals()
+        if terminal_uuid:
+            terminals = [t for t in terminals if t.uuid == terminal_uuid]
+
+        for i in terminals:
             i.set_color_foreground(font_color)
             i.set_color_bold(font_color)
             i.set_colors(font_color, bg_color, palette_list[:16])
@@ -732,43 +736,98 @@ class Guake(SimpleGladeApp):
 
     # -- configuration --
 
-    def load_config(self):
+    def load_config(self, terminal_uuid=None):
         """"Just a proxy for all the configuration stuff.
         """
+        user_data = {}
+        if terminal_uuid:
+            user_data['terminal_uuid'] = terminal_uuid
 
-        self.settings.general.triggerOnChangedValue(self.settings.general, 'use-trayicon')
-        self.settings.general.triggerOnChangedValue(self.settings.general, 'prompt-on-quit')
-        self.settings.general.triggerOnChangedValue(self.settings.general, 'prompt-on-close-tab')
-        self.settings.general.triggerOnChangedValue(self.settings.general, 'window-tabbar')
-        self.settings.general.triggerOnChangedValue(self.settings.general, 'fullscreen-hide-tabbar')
-        self.settings.general.triggerOnChangedValue(self.settings.general, 'mouse-display')
-        self.settings.general.triggerOnChangedValue(self.settings.general, 'display-n')
-        self.settings.general.triggerOnChangedValue(self.settings.general, 'window-ontop')
-        if not self.fullscreen_manager.is_fullscreen():
-            self.settings.general.triggerOnChangedValue(self.settings.general, 'window-height')
-            self.settings.general.triggerOnChangedValue(self.settings.general, 'window-width')
-        self.settings.general.triggerOnChangedValue(self.settings.general, 'use-scrollbar')
-        self.settings.general.triggerOnChangedValue(self.settings.general, 'history-size')
-        self.settings.general.triggerOnChangedValue(self.settings.general, 'infinite-history')
-        self.settings.general.triggerOnChangedValue(self.settings.general, 'use-vte-titles')
-        self.settings.general.triggerOnChangedValue(self.settings.general, 'set-window-title')
-        self.settings.general.triggerOnChangedValue(self.settings.general, 'display-tab-names')
-        self.settings.general.triggerOnChangedValue(self.settings.general, 'max-tab-name-length')
-        self.settings.general.triggerOnChangedValue(self.settings.general, 'quick-open-enable')
         self.settings.general.triggerOnChangedValue(
-            self.settings.general, 'quick-open-command-line'
+            self.settings.general, 'use-trayicon', user_data=user_data
         )
-        self.settings.style.triggerOnChangedValue(self.settings.style, 'cursor-shape')
-        self.settings.styleFont.triggerOnChangedValue(self.settings.styleFont, 'style')
-        self.settings.styleFont.triggerOnChangedValue(self.settings.styleFont, 'palette')
-        self.settings.styleFont.triggerOnChangedValue(self.settings.styleFont, 'palette-name')
-        self.settings.styleFont.triggerOnChangedValue(self.settings.styleFont, 'allow-bold')
+        self.settings.general.triggerOnChangedValue(
+            self.settings.general, 'prompt-on-quit', user_data=user_data
+        )
+        self.settings.general.triggerOnChangedValue(
+            self.settings.general, 'prompt-on-close-tab', user_data=user_data
+        )
+        self.settings.general.triggerOnChangedValue(
+            self.settings.general, 'window-tabbar', user_data=user_data
+        )
+        self.settings.general.triggerOnChangedValue(
+            self.settings.general, 'fullscreen-hide-tabbar', user_data=user_data
+        )
+        self.settings.general.triggerOnChangedValue(
+            self.settings.general, 'mouse-display', user_data=user_data
+        )
+        self.settings.general.triggerOnChangedValue(
+            self.settings.general, 'display-n', user_data=user_data
+        )
+        self.settings.general.triggerOnChangedValue(
+            self.settings.general, 'window-ontop', user_data=user_data
+        )
+        if not self.fullscreen_manager.is_fullscreen():
+            self.settings.general.triggerOnChangedValue(
+                self.settings.general, 'window-height', user_data=user_data
+            )
+            self.settings.general.triggerOnChangedValue(
+                self.settings.general, 'window-width', user_data=user_data
+            )
+        self.settings.general.triggerOnChangedValue(
+            self.settings.general, 'use-scrollbar', user_data=user_data
+        )
+        self.settings.general.triggerOnChangedValue(
+            self.settings.general, 'history-size', user_data=user_data
+        )
+        self.settings.general.triggerOnChangedValue(
+            self.settings.general, 'infinite-history', user_data=user_data
+        )
+        self.settings.general.triggerOnChangedValue(
+            self.settings.general, 'use-vte-titles', user_data=user_data
+        )
+        self.settings.general.triggerOnChangedValue(
+            self.settings.general, 'set-window-title', user_data=user_data
+        )
+        self.settings.general.triggerOnChangedValue(
+            self.settings.general, 'display-tab-names', user_data=user_data
+        )
+        self.settings.general.triggerOnChangedValue(
+            self.settings.general, 'max-tab-name-length', user_data=user_data
+        )
+        self.settings.general.triggerOnChangedValue(
+            self.settings.general, 'quick-open-enable', user_data=user_data
+        )
+        self.settings.general.triggerOnChangedValue(
+            self.settings.general, 'quick-open-command-line', user_data=user_data
+        )
+        self.settings.style.triggerOnChangedValue(
+            self.settings.style, 'cursor-shape', user_data=user_data
+        )
+        self.settings.styleFont.triggerOnChangedValue(
+            self.settings.styleFont, 'style', user_data=user_data
+        )
+        self.settings.styleFont.triggerOnChangedValue(
+            self.settings.styleFont, 'palette', user_data=user_data
+        )
+        self.settings.styleFont.triggerOnChangedValue(
+            self.settings.styleFont, 'palette-name', user_data=user_data
+        )
+        self.settings.styleFont.triggerOnChangedValue(
+            self.settings.styleFont, 'allow-bold', user_data=user_data
+        )
         self.settings.styleBackground.triggerOnChangedValue(
-            self.settings.styleBackground, 'transparency'
+            self.settings.styleBackground, 'transparency', user_data=user_data
         )
-        self.settings.general.triggerOnChangedValue(self.settings.general, 'use-default-font')
-        self.settings.general.triggerOnChangedValue(self.settings.general, 'compat-backspace')
-        self.settings.general.triggerOnChangedValue(self.settings.general, 'compat-delete')
+        self.settings.general.triggerOnChangedValue(
+            self.settings.general, 'use-default-font', user_data=user_data
+        )
+        self.settings.general.triggerOnChangedValue(
+            self.settings.general, 'compat-backspace', user_data=user_data
+        )
+        self.settings.general.triggerOnChangedValue(
+            self.settings.general, 'compat-delete', user_data=user_data
+        )
 
     def accel_search_terminal(self, *args):
         nb = self.get_notebook()
@@ -1076,7 +1135,7 @@ class Guake(SimpleGladeApp):
         self.get_notebook().rename_page(page_num, new_text, user_set)
 
     def terminal_spawned(self, notebook, terminal, pid):
-        self.load_config()
+        self.load_config(terminal_uuid=terminal.uuid)
         terminal.handler_ids.append(
             terminal.connect('window-title-changed', self.on_terminal_title_changed, terminal)
         )

--- a/guake/notebook.py
+++ b/guake/notebook.py
@@ -526,6 +526,12 @@ class NotebookManager(GObject.Object):
             for t in self.notebooks[k].iter_terminals():
                 yield t
 
+    def get_terminal_by_uuid(self, terminal_uuid):
+        for t in self.iter_terminals():
+            if t.uuid == terminal_uuid:
+                return t
+        return None
+
     def iter_pages(self):
         for k in self.notebooks:
             for t in self.notebooks[k].iter_pages():

--- a/releasenotes/notes/bugfix-6247eee74843266a.yaml
+++ b/releasenotes/notes/bugfix-6247eee74843266a.yaml
@@ -1,0 +1,5 @@
+release_summary: >
+    Fixes the bug when "New Tab" or "Split Terminal" resets colors set by "--bgcolor" command.
+
+fixes:
+    Fixes the bug when "New Tab" or "Split Terminal" resets colors set by "--bgcolor" command. #1437


### PR DESCRIPTION
sem-ver: bugfix
closes #1437

This pull request fixes bug https://github.com/Guake/guake/issues/1437.
The bug is that adding a new tab or splitting a terminal resets terminal colors to the settings colors.

Implementation details
-------------------------------

I added `terminal_uuid` argument to the `load_config()` function in `guake_app.py`. The terminal UUID is then passed to the settings triggers via the `user_data` argument.
All this somewhat complicates the code but the settings trigger handlers get the terminal UUID, which gives the option to update settings of a needed terminal only.

The [mlouielu](https://github.com/mlouielu)'s comments on the issue page (https://github.com/Guake/guake/issues/1437#issuecomment-483925165, https://github.com/Guake/guake/issues/1437#issuecomment-483930997) were very useful.
Thanks mlouielu!