### PR TITLE
Set window name for GTK CSS Selectors

### DIFF
--- a/guake/guake_app.py
+++ b/guake/guake_app.py
@@ -176,6 +176,7 @@ class Guake(SimpleGladeApp):
 
         # important widgets
         self.window = self.get_widget('window-root')
+        self.window.set_name('guake-terminal')
         self.window.set_keep_above(True)
         self.mainframe = self.get_widget('mainframe')
         self.mainframe.remove(self.get_widget('notebook-teminals'))


### PR DESCRIPTION
Enables selecting the Guake window for override by CSS Selectors.
This can offer users a workaround for #853 #390 #618 #827 by allowing users to provide custom CSS.
With this patch users may edit `~/.config/gtk-3.0/gtk.css` to include something like:

```
#guake-terminal {
  background-color: #333;
  font-size: 11px;
}

#guake-terminal box box scrolledwindow viewport widget {
  padding: 0px;
  margin: 0px;
  font-size: 11px;
}


#guake-terminal box box scrolledwindow viewport widget box.horizontal button {
  padding: 0px;
  margin: 2px 0px;
  border: 0px;
  border-radius: 0px;
  background-image: none;
}

#guake-terminal box box scrolledwindow viewport widget box.horizontal button label {
  padding: 0px 8px;
  background-color: #222;
  margin: 0px;
  border-radius: 4px;
  border: 1px solid #333;
  color: #eaeaea;
}
```

Please follow these steps before submitting a new Pull Request to Guake:

- rebase on latest HEAD:

  ```bash
  $ git pull --rebase upstream master
  ```

- hack your change

- to execute the code styling, checks and unit tests:

  ```bash
  $ make style check reno-lint test
  ```

- describe your change in a slug file for automatic release note
  generation, using:

  ```bash
  $ make reno SLUG=<short_name_of_my_feature>
  ```

  and edit the created file in `releasenotes/notes/`.
  You can see how `reno` works using `pipenv run reno --help`.

  Please use a generic slug (eg, for translation update,
  use `translation`, for bugfix use `bugfix`,...)

- create new commit message

  ```bash
  $ <hack the code>
  $ git commit --all
  ```

- If your change is related to a GitHub issue, you can add a reference
  using `#123` where 123 is the ID of the issue.
  You can use `closes #123` to have GitHub automatically close the issue
  when your contribution get merged

- Semantic commit is supported (and recommended). Add one of the following
  line in your commit messages:
  
  ```
  # For a bug fix, uses:
  sem-ver: bugfix
  
  # For a new feature, uses:
  sem-ver: feature
  
  # Please do not use the 'breaking change' syntax (`sem-ver: api-break`), 
  # it is reserved for really big reworks
  ```
