### PR TITLE
Custom terminal colors

### DIFF
--- a/guake/boxes.py
+++ b/guake/boxes.py
@@ -15,7 +15,7 @@ from gi.repository import Vte
 
 from guake.callbacks import MenuHideCallback
 from guake.callbacks import TerminalContextMenuCallbacks
-from guake.dialogs import RenameDialog
+from guake.dialogs import RenameDialog, PromptResetColorsDialog
 from guake.menus import mk_tab_context_menu
 from guake.menus import mk_terminal_context_menu
 from guake.utils import HidePrevention
@@ -696,6 +696,18 @@ class TabLabelEventBox(Gtk.EventBox):
             page_num = self.notebook.find_tab_index_by_label(self)
             self.notebook.rename_page(page_num, new_text, True)
         dialog.destroy()
+        HidePrevention(self.get_toplevel()).allow()
+
+        self.grab_focus_on_last_focused_terminal()
+
+    @save_tabs_when_changed
+    def on_reset_custom_colors(self, user_data):
+        HidePrevention(self.get_toplevel()).prevent()
+        if PromptResetColorsDialog(self.notebook.guake.window).reset_tab_custom_colors():
+            page_num = self.notebook.find_tab_index_by_label(self)
+            for t in self.notebook.get_nth_page(page_num).iter_terminals():
+                t.reset_custom_colors()
+            self.notebook.guake.set_colors_from_settings_on_page(page_num=page_num)
         HidePrevention(self.get_toplevel()).allow()
 
         self.grab_focus_on_last_focused_terminal()

--- a/guake/boxes.py
+++ b/guake/boxes.py
@@ -220,7 +220,9 @@ class RootTerminalBox(Gtk.Overlay, TerminalHolder):
         elif isinstance(box, TerminalBox):
             btype = 'term'
             directory = box.terminal.get_current_directory()
-            panes.append({'type': btype, 'directory': directory})
+            panes.append({'type': btype, 'directory': directory,
+                          'custom_colors': box.terminal.get_custom_colors_dict(),
+                          })
 
     def restore_box_layout(self, box, panes: list):
         """Restore box layout by `panes`
@@ -278,6 +280,7 @@ class RootTerminalBox(Gtk.Overlay, TerminalHolder):
 
             # Replace term in the TerminalBox
             term = self.get_notebook().terminal_spawn(cur['directory'])
+            term.set_custom_colors_from_dict(cur.get('custom_colors', None))
             box.set_terminal(term)
             self.get_notebook().terminal_attached(term)
 

--- a/guake/boxes.py
+++ b/guake/boxes.py
@@ -15,7 +15,8 @@ from gi.repository import Vte
 
 from guake.callbacks import MenuHideCallback
 from guake.callbacks import TerminalContextMenuCallbacks
-from guake.dialogs import RenameDialog, PromptResetColorsDialog
+from guake.dialogs import PromptResetColorsDialog
+from guake.dialogs import RenameDialog
 from guake.menus import mk_tab_context_menu
 from guake.menus import mk_terminal_context_menu
 from guake.utils import HidePrevention
@@ -220,9 +221,11 @@ class RootTerminalBox(Gtk.Overlay, TerminalHolder):
         elif isinstance(box, TerminalBox):
             btype = 'term'
             directory = box.terminal.get_current_directory()
-            panes.append({'type': btype, 'directory': directory,
-                          'custom_colors': box.terminal.get_custom_colors_dict(),
-                          })
+            panes.append({
+                'type': btype,
+                'directory': directory,
+                'custom_colors': box.terminal.get_custom_colors_dict(),
+            })
 
     def restore_box_layout(self, box, panes: list):
         """Restore box layout by `panes`

--- a/guake/dbusiface.py
+++ b/guake/dbusiface.py
@@ -137,10 +137,12 @@ class DbusManager(dbus.service.Object):
 
     @dbus.service.method(DBUS_NAME)
     def reset_colors(self):
+        self.guake.reset_terminal_custom_colors(current_page=True)
         self.guake.set_colors_from_settings_on_current_page()
 
     @dbus.service.method(DBUS_NAME)
     def reset_colors_current(self):
+        self.guake.reset_terminal_custom_colors(current_terminal=True)
         self.guake.set_colors_from_settings_on_current_page(current_terminal_only=True)
 
     @dbus.service.method(DBUS_NAME, in_signature='s')

--- a/guake/dbusiface.py
+++ b/guake/dbusiface.py
@@ -138,12 +138,12 @@ class DbusManager(dbus.service.Object):
     @dbus.service.method(DBUS_NAME)
     def reset_colors(self):
         self.guake.reset_terminal_custom_colors(current_page=True)
-        self.guake.set_colors_from_settings_on_current_page()
+        self.guake.set_colors_from_settings_on_page()
 
     @dbus.service.method(DBUS_NAME)
     def reset_colors_current(self):
         self.guake.reset_terminal_custom_colors(current_terminal=True)
-        self.guake.set_colors_from_settings_on_current_page(current_terminal_only=True)
+        self.guake.set_colors_from_settings_on_page(current_terminal_only=True)
 
     @dbus.service.method(DBUS_NAME, in_signature='s')
     def execute_command(self, command):

--- a/guake/dialogs.py
+++ b/guake/dialogs.py
@@ -87,6 +87,33 @@ class PromptQuitDialog(Gtk.MessageDialog):
         return response
 
 
+class PromptResetColorsDialog(Gtk.MessageDialog):
+
+    """Prompts the user whether to reset tab colors.
+    """
+
+    def __init__(self, parent):
+        super(PromptResetColorsDialog, self).__init__(
+            parent, Gtk.DialogFlags.MODAL | Gtk.DialogFlags.DESTROY_WITH_PARENT,
+            Gtk.MessageType.QUESTION, Gtk.ButtonsType.YES_NO
+        )
+
+        primary_msg = _("Do you want to reset custom colors for this tab?")
+
+        self.set_markup(primary_msg)
+
+    def reset_tab_custom_colors(self):
+        """Run the "are you sure" dialog for resetting tab colors
+        """
+        # Stop an open "close tab" dialog from obstructing a quit
+        response = self.run() == Gtk.ResponseType.YES
+        self.destroy()
+        # Keep Guake focussed after dismissing tab-close prompt
+        # if tab == -1:
+        #     self.window.present()
+        return response
+
+
 class SaveTerminalDialog(Gtk.FileChooserDialog):
 
     def __init__(self, terminal, window):

--- a/guake/guake_app.py
+++ b/guake/guake_app.py
@@ -429,11 +429,11 @@ class Guake(SimpleGladeApp):
         log.debug("setting background color to: %r", fgcolor)
 
         if current_terminal_only:
-            self.get_notebook().get_current_terminal().set_color_foreground(fgcolor)
+            self.get_notebook().get_current_terminal().set_color_foreground_custom(fgcolor)
         else:
             page_num = self.get_notebook().get_current_page()
             for terminal in self.get_notebook().get_nth_page(page_num).iter_terminals():
-                terminal.set_color_foreground(fgcolor)
+                terminal.set_color_foreground_custom(fgcolor)
 
     def change_palette_name(self, palette_name):
         if isinstance(palette_name, str):

--- a/guake/guake_app.py
+++ b/guake/guake_app.py
@@ -1401,8 +1401,9 @@ class Guake(SimpleGladeApp):
                             directory, tab['label'], tab['custom_label_set']
                         )
                         if tab.get('panes', False):
-                            if directory:
-                                continue
+                            # ToDo: Is it safe to delete this?
+                            # if directory:
+                            #     continue
                             box.restore_box_layout(box.child, tab['panes'])
 
                     # Remove original pages in notebook

--- a/guake/guake_app.py
+++ b/guake/guake_app.py
@@ -378,8 +378,9 @@ class Guake(SimpleGladeApp):
                 terminal.set_color_bold(font_color)
                 terminal.set_colors(font_color, bg_color, palette_list[:16])
 
-    def reset_terminal_custom_colors(self, current_terminal=False, current_page=False,
-                                     terminal_uuid=None):
+    def reset_terminal_custom_colors(
+        self, current_terminal=False, current_page=False, terminal_uuid=None
+    ):
         """Resets terminal(s) colors to the settings colors.
         If current_terminal == False and current_page == False and terminal_uuid is None,
         resets colors of all terminals.
@@ -1403,7 +1404,6 @@ class Guake(SimpleGladeApp):
                             directory, tab['label'], tab['custom_label_set']
                         )
                         if tab.get('panes', False):
-                            # ToDo: Is it safe to delete this?
                             # if directory:
                             #     continue
                             box.restore_box_layout(box.child, tab['panes'])

--- a/guake/guake_app.py
+++ b/guake/guake_app.py
@@ -376,6 +376,30 @@ class Guake(SimpleGladeApp):
                 terminal.set_color_bold(font_color)
                 terminal.set_colors(font_color, bg_color, palette_list[:16])
 
+    def reset_terminal_custom_colors(self, current_terminal=False, current_page=False,
+                                     terminal_uuid=None):
+        """Resets terminal(s) colors to the settings colors.
+        If current_terminal == False and current_page == False and terminal_uuid is None,
+        resets colors of all terminals.
+        """
+        terminals = []
+
+        if current_terminal:
+            terminals.append(self.get_notebook().get_current_terminal())
+        if current_page:
+            page_num = self.get_notebook().get_current_page()
+            for t in self.get_notebook().get_nth_page(page_num).iter_terminals():
+                terminals.append(t)
+        if terminal_uuid:
+            for t in self.get_notebook().iter_terminals():
+                if t.uuid == terminal_uuid:
+                    terminals.append(t)
+        if not current_terminal and not current_page and not terminal_uuid:
+            terminals = list(self.get_notebook().iter_terminals())
+
+        for i in terminals:
+            i.reset_custom_colors()
+
     def set_bgcolor(self, bgcolor, current_terminal_only=False):
         if isinstance(bgcolor, str):
             c = Gdk.RGBA(0, 0, 0, 0)
@@ -388,11 +412,11 @@ class Guake(SimpleGladeApp):
         log.debug("setting background color to: %r", bgcolor)
 
         if current_terminal_only:
-            self.get_notebook().get_current_terminal().set_color_background(bgcolor)
+            self.get_notebook().get_current_terminal().set_color_background_custom(bgcolor)
         else:
             page_num = self.get_notebook().get_current_page()
             for terminal in self.get_notebook().get_nth_page(page_num).iter_terminals():
-                terminal.set_color_background(bgcolor)
+                terminal.set_color_background_custom(bgcolor)
 
     def set_fgcolor(self, fgcolor, current_terminal_only=False):
         if isinstance(fgcolor, str):

--- a/guake/guake_app.py
+++ b/guake/guake_app.py
@@ -359,7 +359,8 @@ class Guake(SimpleGladeApp):
             i.set_color_bold(font_color)
             i.set_colors(font_color, bg_color, palette_list[:16])
 
-    def set_colors_from_settings_on_current_page(self, current_terminal_only=False):
+    def set_colors_from_settings_on_page(self, current_terminal_only=False, page_num=None):
+        """If page_num is None, sets colors on the current page."""
         bg_color = self.get_bgcolor()
         font_color = self.get_fgcolor()
         palette_list = self._load_palette()
@@ -370,7 +371,8 @@ class Guake(SimpleGladeApp):
             terminal.set_color_bold(font_color)
             terminal.set_colors(font_color, bg_color, palette_list[:16])
         else:
-            page_num = self.get_notebook().get_current_page()
+            if page_num is None:
+                page_num = self.get_notebook().get_current_page()
             for terminal in self.get_notebook().get_nth_page(page_num).iter_terminals():
                 terminal.set_color_foreground(font_color)
                 terminal.set_color_bold(font_color)

--- a/guake/menus.py
+++ b/guake/menus.py
@@ -17,15 +17,18 @@ def mk_tab_context_menu(callback_object):
     #   https://stackoverflow.com/questions/28465956/
     callback_object.context_menu = Gtk.Menu()
     menu = callback_object.context_menu
-    mi1 = Gtk.MenuItem(_("New Tab"))
-    mi1.connect("activate", callback_object.on_new_tab)
-    menu.add(mi1)
-    mi2 = Gtk.MenuItem(_("Rename"))
-    mi2.connect("activate", callback_object.on_rename)
-    menu.add(mi2)
-    mi3 = Gtk.MenuItem(_("Close"))
-    mi3.connect("activate", callback_object.on_close)
-    menu.add(mi3)
+    mi_new_tab = Gtk.MenuItem(_("New Tab"))
+    mi_new_tab.connect("activate", callback_object.on_new_tab)
+    menu.add(mi_new_tab)
+    mi_rename = Gtk.MenuItem(_("Rename"))
+    mi_rename.connect("activate", callback_object.on_rename)
+    menu.add(mi_rename)
+    mi_reset_custom_colors = Gtk.MenuItem(_("Reset custom colors"))
+    mi_reset_custom_colors.connect("activate", callback_object.on_reset_custom_colors)
+    menu.add(mi_reset_custom_colors)
+    mi_close = Gtk.MenuItem(_("Close"))
+    mi_close.connect("activate", callback_object.on_close)
+    menu.add(mi_close)
     menu.show_all()
     return menu
 

--- a/guake/terminal.py
+++ b/guake/terminal.py
@@ -614,23 +614,23 @@ class GuakeTerminal(Vte.Terminal):
         }
 
     def set_custom_colors_from_dict(self, colors_dict):
-        if type(colors_dict) != dict:
+        if not isinstance(colors_dict, dict):
             return
 
         bg_color = colors_dict.get('bg_color', None)
-        if type(bg_color) == list:
+        if isinstance(bg_color, list):
             self.custom_bgcolor = self._color_from_list(bg_color)
         else:
             self.custom_bgcolor = None
 
         fg_color = colors_dict.get('fg_color', None)
-        if type(fg_color) == list:
+        if isinstance(fg_color, list):
             self.custom_fgcolor = self._color_from_list(fg_color)
         else:
             self.custom_fgcolor = None
 
         palette = colors_dict.get('palette', None)
-        if type(palette) == list:
+        if isinstance(palette, list):
             self.custom_palette = [self._color_from_list(col) for col in palette]
         else:
             self.custom_palette = None

--- a/guake/terminal.py
+++ b/guake/terminal.py
@@ -118,6 +118,7 @@ class GuakeTerminal(Vte.Terminal):
         # Custom colors
         self.custom_bgcolor = None
         self.custom_fgcolor = None
+        self.custom_palette = None
 
         self.setup_drag_and_drop()
 
@@ -555,23 +556,35 @@ class GuakeTerminal(Vte.Terminal):
         return pid
 
     def set_color_foreground(self, font_color, *args, **kwargs):
-        super(GuakeTerminal, self).set_color_foreground(font_color, *args, **kwargs)
+        real_fgcolor = self.custom_fgcolor if self.custom_fgcolor else font_color
+        super(GuakeTerminal, self).set_color_foreground(real_fgcolor, *args, **kwargs)
 
     def set_color_background(self, bgcolor, *args, **kwargs):
         real_bgcolor = self.custom_bgcolor if self.custom_bgcolor else bgcolor
         super(GuakeTerminal, self).set_color_background(real_bgcolor, *args, **kwargs)
 
     def set_color_bold(self, font_color, *args, **kwargs):
-        super(GuakeTerminal, self).set_color_bold(font_color, *args, **kwargs)
+        real_fgcolor = self.custom_fgcolor if self.custom_fgcolor else font_color
+        super(GuakeTerminal, self).set_color_bold(real_fgcolor, *args, **kwargs)
 
     def set_colors(self, font_color, bg_color, palette_list, *args, **kwargs):
         real_bgcolor = self.custom_bgcolor if self.custom_bgcolor else bg_color
-        super(GuakeTerminal, self).set_colors(font_color, real_bgcolor, palette_list, *args, **kwargs)
+        real_fgcolor = self.custom_fgcolor if self.custom_fgcolor else font_color
+        real_palette = self.custom_palette if self.custom_palette else palette_list
+        super(GuakeTerminal, self).set_colors(real_fgcolor, real_bgcolor, real_palette, *args, **kwargs)
+
+    def set_color_foreground_custom(self, fgcolor, *args, **kwargs):
+        """Sets custom foreground color for this terminal"""
+        print('set_color_foreground_custom: %s' % self.uuid)
+        self.custom_fgcolor = fgcolor
+        super(GuakeTerminal, self).set_color_foreground(self.custom_fgcolor, *args, **kwargs)
 
     def set_color_background_custom(self, bgcolor, *args, **kwargs):
-        """Sets custom color for this terminal"""
+        """Sets custom background color for this terminal"""
         self.custom_bgcolor = bgcolor
         super(GuakeTerminal, self).set_color_background(self.custom_bgcolor, *args, **kwargs)
 
     def reset_custom_colors(self):
+        self.custom_fgcolor = None
         self.custom_bgcolor = None
+        self.custom_palette = None

--- a/guake/terminal.py
+++ b/guake/terminal.py
@@ -588,3 +588,47 @@ class GuakeTerminal(Vte.Terminal):
         self.custom_fgcolor = None
         self.custom_bgcolor = None
         self.custom_palette = None
+
+    @staticmethod
+    def _color_to_list(color):
+        """This method is used for serialization."""
+        if color is None:
+            return None
+        return [color.red, color.green, color.blue, color.alpha]
+
+    @staticmethod
+    def _color_from_list(color_list):
+        """This method is used for deserialization."""
+        return Gdk.RGBA(red=color_list[0], green=color_list[1], blue=color_list[2],\
+                         alpha=color_list[3])
+
+    def get_custom_colors_dict(self):
+        """Returns dictionary of custom colors."""
+        return {
+            'fg_color': self._color_to_list(self.custom_fgcolor),
+            'bg_color': self._color_to_list(self.custom_bgcolor),
+            'palette': [self._color_to_list(col) for col in self.custom_palette]
+                if self.custom_palette else None,
+        }
+
+    def set_custom_colors_from_dict(self, colors_dict):
+        if type(colors_dict) != dict:
+            return
+
+        bg_color = colors_dict.get('bg_color', None)
+        if type(bg_color) == list:
+            self.custom_bgcolor = self._color_from_list(bg_color)
+        else:
+            self.custom_bgcolor = None
+
+        fg_color = colors_dict.get('fg_color', None)
+        if type(fg_color) == list:
+            self.custom_fgcolor = self._color_from_list(fg_color)
+        else:
+            self.custom_fgcolor = None
+
+        palette = colors_dict.get('palette', None)
+        if type(palette) == list:
+            self.custom_palette = [self._color_from_list(col) for col in palette]
+        else:
+            self.custom_palette = None

--- a/guake/terminal.py
+++ b/guake/terminal.py
@@ -110,10 +110,14 @@ class GuakeTerminal(Vte.Terminal):
         self.matched_value = ''
         self.font_scale_index = 0
         self._pid = None
-        self.custom_bgcolor = None
-        self.custom_fgcolor = None
+        # self.custom_bgcolor = None
+        # self.custom_fgcolor = None
         self.found_link = None
         self.uuid = uuid.uuid4()
+
+        # Custom colors
+        self.custom_bgcolor = None
+        self.custom_fgcolor = None
 
         self.setup_drag_and_drop()
 
@@ -549,3 +553,25 @@ class GuakeTerminal(Vte.Terminal):
             libutempter.utempter_add_record(self.get_pty().get_fd(), os.uname()[1])
         self.pid = pid
         return pid
+
+    def set_color_foreground(self, font_color, *args, **kwargs):
+        super(GuakeTerminal, self).set_color_foreground(font_color, *args, **kwargs)
+
+    def set_color_background(self, bgcolor, *args, **kwargs):
+        real_bgcolor = self.custom_bgcolor if self.custom_bgcolor else bgcolor
+        super(GuakeTerminal, self).set_color_background(real_bgcolor, *args, **kwargs)
+
+    def set_color_bold(self, font_color, *args, **kwargs):
+        super(GuakeTerminal, self).set_color_bold(font_color, *args, **kwargs)
+
+    def set_colors(self, font_color, bg_color, palette_list, *args, **kwargs):
+        real_bgcolor = self.custom_bgcolor if self.custom_bgcolor else bg_color
+        super(GuakeTerminal, self).set_colors(font_color, real_bgcolor, palette_list, *args, **kwargs)
+
+    def set_color_background_custom(self, bgcolor, *args, **kwargs):
+        """Sets custom color for this terminal"""
+        self.custom_bgcolor = bgcolor
+        super(GuakeTerminal, self).set_color_background(self.custom_bgcolor, *args, **kwargs)
+
+    def reset_custom_colors(self):
+        self.custom_bgcolor = None

--- a/guake/terminal.py
+++ b/guake/terminal.py
@@ -571,7 +571,8 @@ class GuakeTerminal(Vte.Terminal):
         real_bgcolor = self.custom_bgcolor if self.custom_bgcolor else bg_color
         real_fgcolor = self.custom_fgcolor if self.custom_fgcolor else font_color
         real_palette = self.custom_palette if self.custom_palette else palette_list
-        super(GuakeTerminal, self).set_colors(real_fgcolor, real_bgcolor, real_palette, *args, **kwargs)
+        super(GuakeTerminal,
+              self).set_colors(real_fgcolor, real_bgcolor, real_palette, *args, **kwargs)
 
     def set_color_foreground_custom(self, fgcolor, *args, **kwargs):
         """Sets custom foreground color for this terminal"""
@@ -599,16 +600,17 @@ class GuakeTerminal(Vte.Terminal):
     @staticmethod
     def _color_from_list(color_list):
         """This method is used for deserialization."""
-        return Gdk.RGBA(red=color_list[0], green=color_list[1], blue=color_list[2],\
-                         alpha=color_list[3])
+        return Gdk.RGBA(
+            red=color_list[0], green=color_list[1], blue=color_list[2], alpha=color_list[3]
+        )
 
     def get_custom_colors_dict(self):
         """Returns dictionary of custom colors."""
         return {
             'fg_color': self._color_to_list(self.custom_fgcolor),
             'bg_color': self._color_to_list(self.custom_bgcolor),
-            'palette': [self._color_to_list(col) for col in self.custom_palette]
-                if self.custom_palette else None,
+            'palette': [self._color_to_list(col)
+                        for col in self.custom_palette] if self.custom_palette else None,
         }
 
     def set_custom_colors_from_dict(self, colors_dict):

--- a/releasenotes/notes/feature-custom_terminal_colors-f68215b30bcb61b3.yaml
+++ b/releasenotes/notes/feature-custom_terminal_colors-f68215b30bcb61b3.yaml
@@ -1,0 +1,12 @@
+release_summary: >
+    Custom colors for every terminal added.
+    Colors are saved alongside with another tab info.
+    "Reset custom colors" menu item added to hte tab context menu.
+
+known_issues:
+  - |
+    When a user changes a background color of a terminal or a tab, this color is saved, and cannot
+    be reset by changing settings. This is OK.
+    The issue is that the user cannot set color transparency, and the transparency becomes fixed
+    until the terminal colors are reset by the user (with a --reset* command or via the tab
+    context menu.


### PR DESCRIPTION
Added custom color settings to every terminal.
If a terminal does not have custom color settings, it would use global color settings.
Colors are saved in session.json alongside with other tabs info.
Added "Reset custom colors" item to the tab context menu.