### PR TITLE
feature: new-tab-after option (#582)

### DIFF
--- a/guake/data/org.guake.gschema.xml
+++ b/guake/data/org.guake.gschema.xml
@@ -86,6 +86,11 @@
             <summary>Tab on top.</summary>
             <description>Makes tab bar on top of the Guake window. Per default, tabs appears bellow the terminal. Setting this to True will move the tab on top of the terminal. Requires a restart.</description>
         </key>
+        <key name="new-tab-after" type="b">
+            <default>false</default>
+            <summary>New tabs appear after the current tab.</summary>
+            <description>Makes new tabs appear after the currently selected tab, instead of at the end.</description>
+        </key>
         <key name="window-losefocus" type="b">
             <default>false</default>
             <summary>Determine if guake hides on lose focus.</summary>

--- a/guake/data/prefs.glade
+++ b/guake/data/prefs.glade
@@ -972,6 +972,22 @@
                                             <property name="top_attach">3</property>
                                           </packing>
                                         </child>
+                                        <child>
+                                          <object class="GtkCheckButton" id="new_tab_after">
+                                            <property name="label" translatable="yes">New tabs appear after the current tab</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="halign">start</property>
+                                            <property name="use_underline">True</property>
+                                            <property name="draw_indicator">True</property>
+                                            <signal name="toggled" handler="on_new_tab_after_toggled" swapped="no"/>
+                                          </object>
+                                          <packing>
+                                            <property name="left_attach">0</property>
+                                            <property name="top_attach">4</property>
+                                          </packing>
+                                        </child>
                                       </object>
                                     </child>
                                   </object>

--- a/guake/data/prefs.glade
+++ b/guake/data/prefs.glade
@@ -831,6 +831,22 @@
                                           </packing>
                                         </child>
                                         <child>
+                                          <object class="GtkCheckButton" id="new_tab_after">
+                                            <property name="label" translatable="yes">New tabs appear after the current tab</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="halign">start</property>
+                                            <property name="use_underline">True</property>
+                                            <property name="draw_indicator">True</property>
+                                            <signal name="toggled" handler="on_new_tab_after_toggled" swapped="no"/>
+                                          </object>
+                                          <packing>
+                                            <property name="left_attach">1</property>
+                                            <property name="top_attach">3</property>
+                                          </packing>
+                                        </child>
+                                        <child>
                                           <object class="GtkCheckButton" id="fullscreen_hide_tabbar">
                                             <property name="label" translatable="yes">Hide tabbar when fullscreen</property>
                                             <property name="visible">True</property>
@@ -970,22 +986,6 @@
                                           <packing>
                                             <property name="left_attach">0</property>
                                             <property name="top_attach">3</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkCheckButton" id="new_tab_after">
-                                            <property name="label" translatable="yes">New tabs appear after the current tab</property>
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="halign">start</property>
-                                            <property name="use_underline">True</property>
-                                            <property name="draw_indicator">True</property>
-                                            <signal name="toggled" handler="on_new_tab_after_toggled" swapped="no"/>
-                                          </object>
-                                          <packing>
-                                            <property name="left_attach">0</property>
-                                            <property name="top_attach">4</property>
                                           </packing>
                                         </child>
                                       </object>

--- a/guake/guake_app.py
+++ b/guake/guake_app.py
@@ -1172,7 +1172,10 @@ class Guake(SimpleGladeApp):
     def add_tab(self, directory=None):
         """Adds a new tab to the terminal notebook.
         """
-        self.get_notebook().new_page_with_focus(directory)
+        position = None
+        if self.settings.general.get_boolean('new-tab-after'):
+            position = 1 + self.get_notebook().get_current_page()
+        self.get_notebook().new_page_with_focus(directory, position=position)
 
     def find_tab(self, directory=None):
         log.debug("find")

--- a/guake/notebook.py
+++ b/guake/notebook.py
@@ -322,13 +322,15 @@ class TerminalNotebook(Gtk.Notebook):
     def delete_page_current(self, kill=True, prompt=0):
         self.delete_page(self.get_current_page(), kill, prompt)
 
-    def new_page(self, directory=None):
+    def new_page(self, directory=None, position=None):
         terminal = self.terminal_spawn(directory)
         terminal_box = TerminalBox()
         terminal_box.set_terminal(terminal)
         root_terminal_box = RootTerminalBox(self.guake, self)
         root_terminal_box.set_child(terminal_box)
-        page_num = self.append_page(root_terminal_box, None)
+        page_num = self.insert_page(
+            root_terminal_box, None, position if position is not None else -1
+        )
         self.set_tab_reorderable(root_terminal_box, True)
         self.show_all()  # needed to show newly added tabs and pages
         # this is needed to initially set the last_terminal_focused,
@@ -362,8 +364,8 @@ class TerminalNotebook(Gtk.Notebook):
         terminal.emit("focus", Gtk.DirectionType.TAB_FORWARD)
         self.emit('terminal-spawned', terminal, terminal.pid)
 
-    def new_page_with_focus(self, directory=None, label=None, user_set=False):
-        box, page_num, terminal = self.new_page(directory)
+    def new_page_with_focus(self, directory=None, label=None, user_set=False, position=None):
+        box, page_num, terminal = self.new_page(directory, position=position)
         self.set_current_page(page_num)
         if not label:
             self.rename_page(page_num, _("Terminal"), False)

--- a/guake/prefs.py
+++ b/guake/prefs.py
@@ -440,6 +440,11 @@ class PrefsCallbacks():
         """
         self.settings.general.set_boolean('tab-ontop', chk.get_active())
 
+    def on_new_tab_after_toggled(self, chk):
+        """Changes the activity of new_tab_after in dconf
+        """
+        self.settings.general.set_boolean('new-tab-after', chk.get_active())
+
     def on_quick_open_enable_toggled(self, chk):
         """Changes the activity of quick_open_enable in dconf
         """

--- a/releasenotes/notes/feature_new_tab_after-060d7990dc6f4473.yaml
+++ b/releasenotes/notes/feature_new_tab_after-060d7990dc6f4473.yaml
@@ -1,0 +1,5 @@
+features:
+  - |
+    List new features here followed by the ticket number, for example::
+
+      - RFE: Open new tab next to current tab #582


### PR DESCRIPTION
@krlmlr wanted the new tab hotkey to open the tab after the currently active one instead of at the end of the tab bar. This PR adds the "New tabs appear after the current tab" option.

![image](https://user-images.githubusercontent.com/3747318/71449939-00ff4480-2769-11ea-88dd-b011b7a4bf9b.png)

This pull request closes #582 if it gets merged.