### PR TITLE
fix: hidden scrollbar reappears after new tab

### DIFF
--- a/guake/notebook.py
+++ b/guake/notebook.py
@@ -333,6 +333,11 @@ class TerminalNotebook(Gtk.Notebook):
         )
         self.set_tab_reorderable(root_terminal_box, True)
         self.show_all()  # needed to show newly added tabs and pages
+        # this is needed because self.window.show_all() results in showing every
+        # thing which includes the scrollbar too
+        self.guake.settings.general.triggerOnChangedValue(
+            self.guake.settings.general, "use-scrollbar"
+        )
         # this is needed to initially set the last_terminal_focused,
         # one could also call terminal.get_parent().on_terminal_focus()
         self.terminal_attached(terminal)

--- a/releasenotes/notes/fix_scrollbar_on_new_tab-990934fbc6e44ccd.yaml
+++ b/releasenotes/notes/fix_scrollbar_on_new_tab-990934fbc6e44ccd.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+      - adding a new tab no longer shows the hidden scrollbars on other tabs


### PR DESCRIPTION
This fixes a small bug, where creating a new tab would temporarily show the scroll bars on other tabs, even when the "Show scrollbar" option is unchecked.