### PR TITLE
Re-implement Refocus

### DIFF
--- a/guake/guake_app.py
+++ b/guake/guake_app.py
@@ -540,6 +540,7 @@ class Guake(SimpleGladeApp):
         """Toggles the main window visibility
         """
         log.debug("Show_hide called")
+        
         if self.forceHide:
             self.forceHide = False
             return
@@ -553,36 +554,19 @@ class Guake(SimpleGladeApp):
         if not self.window.get_property('visible'):
             log.info("Showing the terminal")
             self.show()
+            self.window.get_window().focus(0)
             self.set_terminal_focus()
             return
 
-        # Disable the focus_if_open feature
-        #  - if doesn't work seamlessly on all system
-        #  - self.window.window.get_state doesn't provides us the right information on all
-        #    systems, especially on MATE/XFCE
-        #
-        # if self.client.get_bool(KEY('/general/focus_if_open')):
-        #     restore_focus = False
-        #     if self.window.window:
-        #         state = int(self.window.window.get_state())
-        #         if ((state & GDK_WINDOW_STATE_STICKY or
-        #                 state & GDK_WINDOW_STATE_WITHDRAWN
-        #              )):
-        #             restore_focus = True
-        #     else:
-        #         restore_focus = True
-        # if not self.hidden:
-        # restore_focus = True
-        #     if restore_focus:
-        #         log.debug("DBG: Restoring the focus to the terminal")
-        #         self.hide()
-        #         self.show()
-        #         self.window.window.focus()
-        #         self.set_terminal_focus()
-        #         return
-
-        log.info("Hiding the terminal")
-        self.hide()
+        should_refocus = self.settings.general.get_boolean('window-refocus')
+        has_focus = self.window.get_window().get_state() & Gdk.WindowState.FOCUSED
+        if should_refocus and not has_focus:
+            log.info("Refocussing the terminal")
+            self.window.get_window().focus(0)
+            self.set_terminal_focus()
+        else:
+            log.info("Hiding the terminal")
+            self.hide()
 
     def show_focus(self, *args):
         self.win_prepare()

--- a/guake/guake_app.py
+++ b/guake/guake_app.py
@@ -540,7 +540,6 @@ class Guake(SimpleGladeApp):
         """Toggles the main window visibility
         """
         log.debug("Show_hide called")
-        
         if self.forceHide:
             self.forceHide = False
             return

--- a/releasenotes/notes/Reimplemented-Refocus-6fdd3242caf8b388.yaml
+++ b/releasenotes/notes/Reimplemented-Refocus-6fdd3242caf8b388.yaml
@@ -1,7 +1,0 @@
-release_summary: >
-  Re-implemented the refocus functionality.
-
-  This functionality allows the user to return the focus to an open guake window.
-  It happened to be partially be maintained but faced issues in the migration to Gtk3.
-
-  The functionality was revived, partially based on commented-out code found in Guake.show_hide().

--- a/releasenotes/notes/Reimplemented-Refocus-6fdd3242caf8b388.yaml
+++ b/releasenotes/notes/Reimplemented-Refocus-6fdd3242caf8b388.yaml
@@ -1,0 +1,7 @@
+release_summary: >
+  Re-implemented the refocus functionality.
+
+  This functionality allows the user to return the focus to an open guake window.
+  It happened to be partially be maintained but faced issues in the migration to Gtk3.
+
+  The functionality was revived, partially based on commented-out code found in Guake.show_hide().

--- a/releasenotes/notes/reimplement-refocus-6fdd3242caf8b388.yaml
+++ b/releasenotes/notes/reimplement-refocus-6fdd3242caf8b388.yaml
@@ -1,0 +1,8 @@
+features: 
+  - |
+    Re-implemented the refocus functionality.
+        
+    This functionality allows the user to return the focus to an open guake window.
+    It happened to be partially be maintained but faced issues in the migration to Gtk3.
+        
+    The functionality was revived, partially based on commented-out code found in Guake.show_hide().


### PR DESCRIPTION
This **PR** modifies the `Guake.show_hide` method in order to re-enable the refocus function.
It works perfectly well on my Linux Mint 19.3 with Cinnamon. 

In #1698 @gsemet suggested to test a large range of different desktop environments with this modification.
In absence of automatic stets alleviating the extraordinary manual effort required to do so, I am instead suggestion an alternative approach:
**Marking this feature as experimental / test via pre-release.**
Any bug issues could then be solved as they occur.

Also the code base could use some overhaul, as I have suggested in #1710 - regarding the **PR** at hand I have not dared to examine a possible unification of the different focus methods such as:
- `self.window.get_window().focus(0)`
- `self.set_terminal_focus()`
- `show_focus`

I have not followed the usual steps described for making **PR**s, such as generating a slug file, as I find them difficult to do.

Closes: #1698
