### PR TITLE
Fix Crash (TypeError) when common keys are found in config

### DIFF
--- a/guake/prefs.py
+++ b/guake/prefs.py
@@ -1435,7 +1435,7 @@ class PrefsDialog(SimpleGladeApp):
                     "Please try with a key such as "
                     "Control, Alt or Shift at the same "
                     "time.\n"
-                ) % html_escape(key)
+                ) % html_escape(chr(key))
             )
             dialog.run()
             dialog.destroy()

--- a/releasenotes/notes/bugfix-43bafb402b26f8c8.yaml
+++ b/releasenotes/notes/bugfix-43bafb402b26f8c8.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    Fix Crash (TypeError) when common keys are found in config #1713


### PR DESCRIPTION
Hello

I got this error:

    prefs.py:323:html_escape:TypeError: 'int' object is not iterable

    Traceback (most recent call last):
      File "/usr/lib/python3.7/site-packages/guake/prefs.py", line 1424, in on_accel_edited
        ) % html_escape(key)
      File "/usr/lib/python3.7/site-packages/guake/prefs.py", line 323, in html_escape
        return "".join(html_escape_table.get(c, c) for c in text)
    TypeError: 'int' object is not iterable

    Local variables in innermost frame:
    text: 49

`key` in `prefs.py:on_accel_edited()` seems to be an int.

--
Hope I did that all correctly.
Had some problems creating the build environment but I'll open an extra issue for that.