### PR TITLE
fix: double click in tmux/vim

### DIFF
--- a/guake/notebook.py
+++ b/guake/notebook.py
@@ -115,9 +115,6 @@ class TerminalNotebook(Gtk.Notebook):
                 # Gtk 3.18 fallback ("'Menu' object has no attribute 'popup_at_pointer'")
                 menu.popup(None, None, None, None, event.button, event.time)
 
-        elif event.type == Gdk.EventType.DOUBLE_BUTTON_PRESS and event.button == 1:
-            self.new_page_with_focus()
-
         return False
 
     @save_tabs_when_changed

--- a/releasenotes/notes/fix_double_click_new_tab-5cafb9738e3a9218.yaml
+++ b/releasenotes/notes/fix_double_click_new_tab-5cafb9738e3a9218.yaml
@@ -1,0 +1,7 @@
+known_issues:
+  - |
+      - removes the broken feature, where double-clicking on the tab bar opened a new tab #1439
+
+fixes:
+  - |
+      - fixes an issue, where double-clicking in certain CLI apps would instead open a new tab #1697


### PR DESCRIPTION
This fix temporarily removes the broken "double-click on tab bar to open new tab" feature. For further discussion, see #1697.

This pull request closes #1697 if it gets merged.
This pull request closes #1627 if it gets merged.