### PR TITLE
Moving window to correct coordinates before maximizing

### DIFF
--- a/guake/utils.py
+++ b/guake/utils.py
@@ -260,6 +260,7 @@ class RectCalculator:
 
         if width_percents == 100 and height_percents == 100:
             log.debug("MAXIMIZING MAIN WINDOW")
+            window.move(window_rect.x, window_rect.y)
             window.maximize()
         elif not FullscreenManager(settings, window).is_fullscreen():
             log.debug("RESIZING MAIN WINDOW TO THE FOLLOWING VALUES:")

--- a/releasenotes/notes/fix_move_window_to_correct_coordinates_before_maximising-b5f124f36ff8d796.yaml
+++ b/releasenotes/notes/fix_move_window_to_correct_coordinates_before_maximising-b5f124f36ff8d796.yaml
@@ -1,0 +1,15 @@
+release_summary: >
+    Move window to correct coordinates before maximizing
+
+features:
+  - |
+    Move the window to the correct coordinates, in the correct display, before
+    attempting to maximize the window.
+
+fixes:
+  - |
+      - Guake always appears on mouse display regardless of Guake Preferences #1689
+      - guake follows mouse focus when have 2 monitors #1761
+      - Multiple monitors issue with Fedora 31 #1745
+      - Guake window follows mouse across monitors till it loses focus #1735
+      - And possibly more


### PR DESCRIPTION
Using issue  #1689, specifically the one comment about setting height and width to anything less than 100% (https://github.com/Guake/guake/issues/1689#issuecomment-570792301) I managed to track down the condition that deals with maximized windows, but not fullscreen:

```python
         # lines 265-267
         if width_percents == 100 and height_percents == 100:
             log.debug("MAXIMIZING MAIN WINDOW")
             window.maximize()
```

According to [this answer on stackoverflow](https://stackoverflow.com/a/39386341/3476100), you should move the window to the correct coordinates, in the correct display, before attempting to maximize the window. I just replicated this with the correct coordinates calculated beforehand and in my machine it seems to have fixed the issue.

EDIT:
seems like it should also fix:

#1761
#1745
#1738