### PR TITLE
implemented custom themes folder prototype

### DIFF
--- a/guake/palettes.py
+++ b/guake/palettes.py
@@ -17,6 +17,11 @@ License along with this program; if not, write to the
 Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
 Boston, MA 02110-1301 USA
 """
+import json
+import os
+import logging
+
+log = logging.getLogger(__name__)
 
 # index 00: Host
 # index 01: Syntax string
@@ -1053,3 +1058,21 @@ PALETTES = {
         "#CFCFCFCFCFCF:#D9D9E6E6F2F2:#19191F1F1D1D"
     ),
 }
+
+themes_folder = os.path.expandvars("$HOME/.config/guake/themes")
+
+if os.path.isdir(themes_folder):
+    try:
+        theme_filenames = next(os.walk(themes_folder))[2]
+        for theme_filename in theme_filenames:
+            with open(os.path.join(themes_folder, theme_filename), encoding="utf-8") as theme_file:
+                try:
+                    theme_to_load = json.load(theme_file)
+                    PALETTES = {**PALETTES, **theme_to_load}
+                    log.debug("Loaded themes %s", ", ".join(theme_to_load.keys()))
+                except json.JSONDecodeError:
+                    log.debug("Unable to load theme from file %s", theme_file)
+    except StopIteration:
+        log.debug("Empty themes folder")
+else:
+    log.debug("Could not find themes folder %s", themes_folder)

--- a/releasenotes/notes/add_custom_themes_folder-22021b3af416137c.yaml
+++ b/releasenotes/notes/add_custom_themes_folder-22021b3af416137c.yaml
@@ -1,0 +1,25 @@
+release_summary: >
+    Custom themes folder
+
+features:
+  - |
+      - User defined colour palettes #1766 
+
+known_issues:
+  - |
+    List know issue introduced by the change here, followed if possible by a
+    ticket number, for example::
+
+      - such other feature is broken #1234
+
+upgrade:
+  - |
+    List upgrade note for end users here
+
+notes_for_package_maintainers:
+  - |
+    Add notes for package maintainers here.
+
+other:
+  - |
+    Add other notes here.


### PR DESCRIPTION
Following #1766, in this PR I propose a possible implementation for user defined colour schemes.

I placed the following JSON under `$HOME/.config/guake/themes/snazzy.json`:

```json
{"Snazzy": "#28282a2a3838:#ffff5c5c5757:#5a5af7f78e8d:#f3f3f9f99d9d:#5757c7c6ffff:#ffff6a6ac1c1:#9a9aededfefe:#f1f1f1f1f0f0:#686868686868:#f5f58b8b7f7f:#f3f3f9f99d9d:#f3f3f9f99d9d:#a5a5c7c7ffff:#ddddaaaaffff:#b6b6fffff9f9:#fefefffffefe:#efeff0f0ebeb:#28282a2a3838"}
```

And I have it under the Appearances menu:
![image](https://user-images.githubusercontent.com/9471861/83197787-6db1ad00-a114-11ea-86b4-fbe3a5856a04.png)

The themes however, won't get loaded untill a full restart. That could be improved, but I think this PR is a successful proof of concept and base for discussion.

Note that:

- multiple themes can be loaded in a single JSON. They are parsed as such and injected in `PALETTES` using object spread.
- as implemented, user defined schemes take precedence over build-in, allowing for overriding and customization

This also makes saving custom schemes / overriding existing ones over the GUI possible.