### PR TITLE
Fix for search not working with vte 0.6+ (issue #1752)

### DIFF
--- a/guake/boxes.py
+++ b/guake/boxes.py
@@ -18,6 +18,7 @@ from guake.callbacks import MenuHideCallback
 from guake.callbacks import TerminalContextMenuCallbacks
 from guake.dialogs import PromptResetColorsDialog
 from guake.dialogs import RenameDialog
+from guake.globals import PCRE2_MULTILINE
 from guake.menus import mk_tab_context_menu
 from guake.menus import mk_terminal_context_menu
 from guake.utils import HidePrevention
@@ -363,7 +364,7 @@ class RootTerminalBox(Gtk.Overlay, TerminalHolder):
                 self.search_prev = True
 
     def reset_term_search(self, term):
-        term.search_set_gregex(GLib.Regex("", 0, 0), 0)
+        term.search_set_regex(None, 0)
         term.search_find_next()
 
     def set_search(self, widget):
@@ -378,9 +379,10 @@ class RootTerminalBox(Gtk.Overlay, TerminalHolder):
 
             # Set search regex on term
             self.searchstring = text
-            self.searchre = GLib.Regex(text, 0, 0)
-            term.search_set_gregex(self.searchre, 0)
-
+            self.searchre = Vte.Regex.new_for_search(
+                text, -1, Vte.REGEX_FLAGS_DEFAULT | PCRE2_MULTILINE
+            )
+            term.search_set_regex(self.searchre, 0)
         self.do_search(None)
 
     def do_search(self, widget):

--- a/guake/globals.py
+++ b/guake/globals.py
@@ -110,3 +110,7 @@ MAX_TRANSPARENCY = 100
 
 # Tabs session schema version
 TABS_SESSION_SCHEMA_VERSION = 2
+
+# Constants for vte regex matching are documented in the pcre2 api:
+#   https://www.pcre.org/current/doc/html/pcre2api.html
+PCRE2_MULTILINE = 0x00000400

--- a/releasenotes/notes/fix_search_vte0.46-b92145bc1e572521.yaml
+++ b/releasenotes/notes/fix_search_vte0.46-b92145bc1e572521.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    Update search box to work with updated regex vte apis for v0.46+, #1752


### PR DESCRIPTION
Fix for issue: #1752 Search not working anymore after vte libraries update to 0.60. As you can see from: https://lazka.github.io/pgi-docs/Vte-2.91/classes/Terminal.html#Vte.Terminal.search_set_gregex, this function is deprecated: "This function does nothing since version 0.60."