### PR TITLE
fix: #1761 guake follows mouse focus when have 2 monitors

### DIFF
--- a/guake/utils.py
+++ b/guake/utils.py
@@ -170,7 +170,8 @@ class FullscreenManager:
             if self.is_fullscreen():
                 self.fullscreen()
             else:
-                self.unfullscreen()
+                if window_state & Gdk.WindowState.FOCUSED:
+                    self.unfullscreen()
 
     def fullscreen(self):
         self.window.fullscreen()


### PR DESCRIPTION
Fix #1761 When `Appear on mouse display` open for Version 3.7.0 on a dual-screen desktop, the Guake window moves to the other screen if lost focus. This pr is to avoid this annoying situation.