### PR TITLE
Save tabs when directory changed, not `on_terminal_title_changed` (#1633)

### DIFF
--- a/guake/guake_app.py
+++ b/guake/guake_app.py
@@ -1097,7 +1097,17 @@ class Guake(SimpleGladeApp):
             pass
         return TabNameUtils.shorten(vte_title, self.settings)
 
-    @save_tabs_when_changed
+    def check_if_terminal_directory_changed(self, term):
+        @save_tabs_when_changed
+        def terminal_directory_changed(self):
+            # Yep, just used for save tabs when changed
+            pass
+
+        current_directory = term.get_current_directory()
+        if current_directory != term.directory:
+            term.directory = current_directory
+            terminal_directory_changed(self)
+
     def on_terminal_title_changed(self, vte, term):
         # box must be a page
         if not term.get_parent():
@@ -1124,6 +1134,9 @@ class Guake(SimpleGladeApp):
             text = nb.get_tab_text_page(box)
             if text:
                 self.update_window_title(text)
+
+        # Check if terminal directory has changed
+        self.check_if_terminal_directory_changed(term)
 
     def update_window_title(self, title):
         if self.settings.general.get_boolean("set-window-title") is True:
@@ -1161,6 +1174,9 @@ class Guake(SimpleGladeApp):
         terminal.handler_ids.append(
             terminal.connect("window-title-changed", self.on_terminal_title_changed, terminal)
         )
+
+        # Use to detect if directory has changed
+        terminal.directory = terminal.get_current_directory()
 
     @save_tabs_when_changed
     def add_tab(self, directory=None):

--- a/guake/guake_app.py
+++ b/guake/guake_app.py
@@ -1112,6 +1112,10 @@ class Guake(SimpleGladeApp):
         # box must be a page
         if not term.get_parent():
             return
+
+        # Check if terminal directory has changed
+        self.check_if_terminal_directory_changed(term)
+
         box = term.get_parent().get_root_box()
         use_vte_titles = self.settings.general.get_boolean("use-vte-titles")
         if not use_vte_titles:
@@ -1134,9 +1138,6 @@ class Guake(SimpleGladeApp):
             text = nb.get_tab_text_page(box)
             if text:
                 self.update_window_title(text)
-
-        # Check if terminal directory has changed
-        self.check_if_terminal_directory_changed(term)
 
     def update_window_title(self, title):
         if self.settings.general.get_boolean("set-window-title") is True:

--- a/guake/guake_app.py
+++ b/guake/guake_app.py
@@ -562,7 +562,7 @@ class Guake(SimpleGladeApp):
             self.set_terminal_focus()
             return
 
-        should_refocus = self.settings.general.get_boolean('window-refocus')
+        should_refocus = self.settings.general.get_boolean("window-refocus")
         has_focus = self.window.get_window().get_state() & Gdk.WindowState.FOCUSED
         if should_refocus and not has_focus:
             log.info("Refocussing the terminal")

--- a/releasenotes/notes/fragment_name-9338b9eaa7544152.yaml
+++ b/releasenotes/notes/fragment_name-9338b9eaa7544152.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+      - Update `session.json` when directory changed, not terminal title changed #1633


### PR DESCRIPTION
This should fix #1633.

This commit remove `@save_tabs_when_changed` on `on_terminal_title_changed`,
and put the terminal directory into ther instance. This is because
`vte:current-directory-uri-changed` is not worked, and `current-directory-uri`
always return `None`.

When `on_terminal_title_changed` called, it will check if the directory
changed for this terminal, if so, then save the tabs by the setting.

