### PR TITLE
Fix web search

### DIFF
--- a/guake/callbacks.py
+++ b/guake/callbacks.py
@@ -56,7 +56,7 @@ class TerminalContextMenuCallbacks:
             query = clipboard.wait_for_text()
             query = quote_plus(query)
             if query:
-                search_url = "https://www.google.com/#q={!s}&safe=off".format(query)
+                search_url = "https://www.google.com/search?q={!s}&safe=off".format(query)
                 Gtk.show_uri(self.window.get_screen(), search_url, get_server_time(self.window))
 
     def on_quick_open(self, *args):

--- a/guake/guake_app.py
+++ b/guake/guake_app.py
@@ -1265,7 +1265,7 @@ class Guake(SimpleGladeApp):
             if search_query:
                 # TODO search provider should be selectable (someone might
                 # prefer bing.com, the internet is a strange place ¯\_(ツ)_/¯ )
-                search_url = "https://www.google.com/#q={!s}&safe=off".format(search_query,)
+                search_url = "https://www.google.com/search?q={!s}&safe=off".format(search_query,)
                 Gtk.show_uri(self.window.get_screen(), search_url, get_server_time(self.window))
         return True
 


### PR DESCRIPTION
I'm using version 3.7.1.
Whenever I select a text and right-click "Serch on Web", Guake creates a
Google query that doesn't work.

This PR fix this by changing Google's URL.
