### PR TITLE
#1798 - added regex to support spaces in quick-open-links

### DIFF
--- a/guake/globals.py
+++ b/guake/globals.py
@@ -94,6 +94,11 @@ QUICK_OPEN_MATCHERS = [
     ),
     ("Python pytest report", r"^\s.*\:\:[a-zA-Z0-9\_]+\s", r"^\s*(.*\:\:[a-zA-Z0-9\_]+)\s",),
     (
+        "line starts by 'ERROR in Filename:line' pattern (GCC/make). File path should exists.",
+        r"\s.\S[^\s\s].[a-zA-Z0-9\/\_\-\.\ ]+\.?[a-zA-Z0-9]+\:[0-9]+",
+        r"\s.\S[^\s\s].(.*)\:([0-9]+)",
+    ),
+    (
         "line starts by 'Filename:line' pattern (GCC/make). File path should exists.",
         r"^\s*[a-zA-Z0-9\/\_\-\.\ ]+\.?[a-zA-Z0-9]+\:[0-9]+",
         r"^\s*(.*)\:([0-9]+)",

--- a/releasenotes/notes/bugfix-quick-open-link-44861b51e524ca44.yaml
+++ b/releasenotes/notes/bugfix-quick-open-link-44861b51e524ca44.yaml
@@ -1,0 +1,2 @@
+fixes:
+  - Added regex for line start by <word> <word>. Refer Issue #1798


### PR DESCRIPTION
Fixes #1798 

`Issue`:
 `QUICK_OPEN_MATCHERS` regex pattern `r"^\s*[a-zA-Z0-9\/\_\-\.\ ]+\.?[a-zA-Z0-9]+\:[0-9]+"` matches line start by something:line_no., but the text has spaces. Therefore, the link becomes unusable.

`Fix`:
I've added another regex for line start by `<word> <word> `

`Result`:
![Screenshot from 2020-10-10 14-42-31](https://user-images.githubusercontent.com/8335453/95651294-07e42180-0b07-11eb-98b3-070eb8271d5b.png)
