### PR TITLE
Fix ineffective override of GDK_BACKEND envvar

### DIFF
--- a/guake/main.py
+++ b/guake/main.py
@@ -36,6 +36,9 @@ from optparse import OptionParser
 
 log = logging.getLogger(__name__)
 
+# Force use X11 backend under wayland before any import of GDK through dependencies
+os.environ["GDK_BACKEND"] = "x11"
+
 from guake.globals import NAME
 from guake.globals import bindtextdomain
 from guake.support import print_support
@@ -62,9 +65,6 @@ def main():
     """
     # Force to xterm-256 colors for compatibility with some old command line programs
     os.environ["TERM"] = "xterm-256color"
-
-    # Force use X11 backend underwayland
-    os.environ["GDK_BACKEND"] = "x11"
 
     # do not use version keywords here, pbr might be slow to find the version of Guake module
     parser = OptionParser()

--- a/releasenotes/notes/fix-gdk-backend-override-8772f455954e702c.yaml
+++ b/releasenotes/notes/fix-gdk-backend-override-8772f455954e702c.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - Fix ineffective override of the GDK_BACKEND environement variable causing invalid pointer location and display detection (#1820)
+  


### PR DESCRIPTION
https://github.com/Guake/guake/blob/9c213270767687b30108a7206ac4f4bb913385cd/guake/main.py#L57-L67 does attempt to override the `GDK_BACKEND` environement variable at line 67 in main.py but it is already too late since `Gdk` is imported through earlier imports from `guake.support` and `guake.utils` https://github.com/Guake/guake/blob/9c213270767687b30108a7206ac4f4bb913385cd/guake/main.py#L39-L43

As a result, on a wayland session, the pointer position used to get window geometry is always (0,0) resulting in the wrong display being used for window placement and sizing.

See #1820 
