### PR TITLE
On runtime, require setuptools, not the entire pbr

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -15,6 +15,7 @@ typed-ast = "*"
 astroid = "*"
 fiximports = ">=0.1.18"
 mock = ">=2.0.0"
+pbr = "*"
 pytest-mock = "*"
 pyflakes = "*"
 pytest = "*"
@@ -35,5 +36,5 @@ black = "==19.10b0"
 dephell = "*"
 
 [packages]
-pbr = "*"
+setuptools = "*"
 typing = {markers = "python_version < '3.5'"}


### PR DESCRIPTION
Hello. I've noticed that guake/paths.py imports from pkg_resources, hence setuptools is required **on runtime**.
When I tried to understand where are the runtime requirements defined, I've noticed a weird to me "Pipfile -> requires.txt -> pbr" chain and I have no idea if I am doing it right.
I've also noticed pbr is required on runtime, which I believe should not be the case.

I have not completed any steps described in your PR template, becase I have just clicked on the GitHub edit button and it does not let me do any of the stuff described here. I am sorry about that, consider this a issue report with a possible fix attached.

Feel free to rework this entirely or just reject it, if that is an issue, however I believe this is the right thing to do.

Thanks for considering.
