### PR TITLE
fix:Fix prompt on close tab

### DIFF
--- a/guake/notebook.py
+++ b/guake/notebook.py
@@ -294,7 +294,7 @@ class TerminalNotebook(Gtk.Notebook):
         procs = self.get_running_fg_processes_count_page(page_num)
         if prompt == 2 or (prompt == 1 and procs > 0):
             # TODO NOTEBOOK remove call to guake
-            if not PromptQuitDialog(self.guake.window, procs, -1).close_tab():
+            if not PromptQuitDialog(self.guake.window, procs, -1, None).close_tab():
                 return
 
         page = self.get_nth_page(page_num)

--- a/releasenotes/notes/fix_prompt_when_close_tab-c808afd378a1b33a.yaml
+++ b/releasenotes/notes/fix_prompt_when_close_tab-c808afd378a1b33a.yaml
@@ -1,0 +1,6 @@
+release_summary: >
+  Fixes prompting when closing a tab.
+
+fixes:
+  - |
+      - Fixes #1863


### PR DESCRIPTION
PromptQuitDialog creation was passed wrong number of arguments, last argument is unused in this situation so passed None into it.

Fixes #1863 and possibly #1812