### PR TITLE
fix:Regenerate guake schema if old schema file found

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,6 @@ bindir = $(exec_prefix)/bin
 PYTHON_SITEDIRS_FOR_PREFIX="env PREFIX=$(PREFIX) $(PYTHON_INTERPRETER) scripts/all-sitedirs-in-prefix.py"
 ROOT_DIR=$(shell pwd)
 DATA_DIR=$(ROOT_DIR)/guake/data
-COMPILE_SCHEMA:=1
 
 datarootdir:=$(PREFIX)/share
 datadir:=$(datarootdir)
@@ -142,7 +141,7 @@ install-schemas:
 	install -Dm644 "$(DEV_DATA_DIR)/org.guake.gschema.xml" "$(DESTDIR)$(SCHEMA_DIR)/"
 
 compile-shemas:
-	if [ $(COMPILE_SCHEMA) = 1 ]; then glib-compile-schemas $(DESTDIR)$(gsettingsschemadir); fi
+	glib-compile-schemas $(DESTDIR)$(gsettingsschemadir)
 
 
 uninstall-system: uninstall-schemas uninstall-locale

--- a/guake/data/org.guake.gschema.xml
+++ b/guake/data/org.guake.gschema.xml
@@ -6,6 +6,11 @@
         <child name="keybindings" schema="guake.keybindings"/>
     </schema>
     <schema id="guake.general" path="/apps/guake/general/">
+        <key name="schema-version" type="s">
+            <default>''</default>
+            <summary>Last used schema version</summary>
+            <description>If schema version is not equal to current guake version, the schema file is regenerated and this flag is set to the current guake version.</description>
+        </key>
         <key name="debug-mode" type="b">
             <default>false</default>
             <summary>Enable debug mode</summary>

--- a/guake/guake_app.py
+++ b/guake/guake_app.py
@@ -101,6 +101,7 @@ class Guake(SimpleGladeApp):
     def __init__(self):
         def load_schema():
             log.info("Loading Gnome schema from: %s", SCHEMA_DIR)
+
             return Gio.SettingsSchemaSource.new_from_directory(
                 SCHEMA_DIR, Gio.SettingsSchemaSource.get_default(), False
             )
@@ -112,6 +113,16 @@ class Guake(SimpleGladeApp):
             try_to_compile_glib_schemas()
             schema_source = load_schema()
         self.settings = Settings(schema_source)
+
+        if (
+            "schema-version" not in self.settings.general.keys()
+            or self.settings.general.get_string("schema-version") != guake_version()
+        ):
+            log.exception("Schema from old guake version detected, regenerating schema")
+            try_to_compile_glib_schemas()
+            schema_source = load_schema()
+            self.settings = Settings(schema_source)
+            self.settings.general.set_string("schema-version", guake_version())
 
         log.info("Language previously loaded from: %s", LOCALE_DIR)
 

--- a/releasenotes/notes/fix_missing_schema_on_upgrade-7820ae1e4af570e5.yaml
+++ b/releasenotes/notes/fix_missing_schema_on_upgrade-7820ae1e4af570e5.yaml
@@ -1,0 +1,25 @@
+release_summary: >
+    Fix missing or malformed schema files when upgrading guake
+
+upgrade:
+  - |
+    Should fix the errors with malformed schema files when upgrading guake.
+
+fixes:
+  - |
+      - Does not start after upgrade to 3.7.0 with pip3 due to faulty schema #1718
+      - (Potentially) Guake 3.6.3 missing gschemas.compiled in PyPi #1621
+
+notes_for_package_maintainers:
+  - |
+    Should resolve issues with the gschemas.compiled file. Make sure that the location
+    org.guake.gschema.xml is being saved to is user executable if guake is installed in
+    userspace so that guake can compile and create gschemas.compiled.
+    
+    If the destination for org.guake.gschema.xml cannot be user executable, make sure to
+    include:
+
+    glib-compile-schemas [schema directory]
+
+    In the installation script, replacing [schema directory] with the place
+    org.guake.gschema.xml is being saved.


### PR DESCRIPTION
Currently guake only generates a schema file if there is no schema file present. If there is a schema file from an older version of guake present, glib will attempt to use that file, segfault and never return execution back to python. Do manual version recording and checking ourselves to regenerate the file instead of relying on exception handling on glibc.

Fixes #1718, and I think should resolve #1621 as well.