### PR TITLE
Attempt to continue if schema file is in a protected location

### DIFF
--- a/guake/guake_app.py
+++ b/guake/guake_app.py
@@ -120,7 +120,10 @@ class Guake(SimpleGladeApp):
             or self.settings.general.get_string("schema-version") != guake_version()
         ):
             log.exception("Schema from old guake version detected, regenerating schema")
-            try_to_compile_glib_schemas()
+            try:
+                try_to_compile_glib_schemas()
+            except subprocess.CalledProcessError:
+                log.exception("Schema in non user-editable location, attempting to continue")
             schema_source = load_schema()
             self.settings = Settings(schema_source)
             self.settings.general.set_string("schema-version", guake_version())


### PR DESCRIPTION
While purging my environment and reinstalling, I realised that if the schema file is in a protected location, this still fails on the first run because the version doesn't match and it'll try to recompile and fail. This probably will happen with packaged versions that put the schema in a protected place too. sudo make install and package managers should be compiling the file properly for us before this, so we can go ahead and keep going. This makes `sudo make install` work from a `make purge` and should also work for a distro package if they made the schema file right.