### PR TITLE
fix:Fix right click menu not populating when custom commands is malformed

### DIFF
--- a/guake/customcommands.py
+++ b/guake/customcommands.py
@@ -65,8 +65,11 @@ class CustomCommands:
         cust_comms = self._load_json(self.get_file_path())
         if not cust_comms:
             return None
-        for obj in cust_comms:
-            self._parse_custom_commands(obj, menu)
+        try:
+            for obj in cust_comms:
+                self._parse_custom_commands(obj, menu)
+        except AttributeError:
+            return None
         return menu
 
     def _parse_custom_commands(self, json_object, menu):

--- a/releasenotes/notes/fix_right_click_with_invalid_custom_commands-a3fa9541ea3f894b.yaml
+++ b/releasenotes/notes/fix_right_click_with_invalid_custom_commands-a3fa9541ea3f894b.yaml
@@ -1,0 +1,6 @@
+release_summary: >
+    Fix right click menu not populating when custom commands is malformed
+
+fixes:
+  - |
+      - Minimal Right Click Menu, no copy or split screen #1845 


### PR DESCRIPTION
Fixes #1845

Catch a type error with trying to treat a string like a dict