### PR TITLE
fix:Fix trailing punctuation in URLs being included in the URL

### DIFF
--- a/guake/globals.py
+++ b/guake/globals.py
@@ -79,7 +79,7 @@ TERMINAL_MATCH_TAGS = ("schema", "http", "https", "email", "ftp")
 TERMINAL_MATCH_EXPRS = [
     r"(news:|telnet:|nntp:|file:\/|https?:|ftps?:|webcal:)\/\/([-[:alnum:]]+"
     r"(:[-[:alnum:],?;.:\/!%$^\*&~\"#']+)?\@)?[-[:alnum:]]+(\.[-[:alnum:]]+)*"
-    r"(:[0-9]{1,5})?(\/[-[:alnum:]_$.+!*(),;:@&=?\/~#'%]*[^].> \t\r\n,\\\"])?",
+    r"(:[0-9]{1,5})?(\/[-[:alnum:]_$.+!*(),;:@&=?\/~#%]*[^]'.>) \t\r\n,\\\"])?",
     r"(www|ftp)[-[:alnum:]]*\.[-[:alnum:]]+(\.[-[:alnum:]]+)*(:[0-9]{1,5})?"
     r"(\/[-[:alnum:]_$.+!*(),;:@&=?\/~#%]*[^]'.>) \t\r\n,\\\"])?",
     r"(mailto:)?[-[:alnum:]][-[:alnum:].]*@[-[:alnum:]]+\.[-[:alnum:]]+(\\.[-[:alnum:]]+)*",

--- a/releasenotes/notes/fix_trailing_punctuation_in_urls-5d9903dc2005bf2f.yaml
+++ b/releasenotes/notes/fix_trailing_punctuation_in_urls-5d9903dc2005bf2f.yaml
@@ -1,0 +1,6 @@
+release_summary: >
+    Fix trailing punctuation in URLs being included in the URL
+
+fixes:
+  - |
+      - Open with URL includes trailing single quote (invalid URL) #1624 


### PR DESCRIPTION
Fixes #1624. There was fortunately a regex two lines down that did the same thing, but correctly that I used