### PR TITLE
feat:Add copy on select option

### DIFF
--- a/guake/data/org.guake.gschema.xml
+++ b/guake/data/org.guake.gschema.xml
@@ -291,6 +291,11 @@
             <summary>Show close buttons for tabs</summary>
             <description>Show close buttons next to tab titles</description>
         </key>
+        <key name="copy-on-select" type="b">
+            <default>false</default>
+            <summary>Copy selected text if enabled.</summary>
+            <description>Copy the selected text.</description>
+        </key>
     </schema>
     <schema id="guake.style" path="/apps/guake/style/">
         <key name="cursor-blink-mode" type="i">

--- a/guake/data/prefs.glade
+++ b/guake/data/prefs.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.22.2 -->
 <interface domain="guake">
   <requires lib="gtk+" version="3.18"/>
   <object class="GtkImage" id="image1">
@@ -468,7 +468,19 @@
                                           </packing>
                                         </child>
                                         <child>
-                                          <placeholder/>
+                                          <object class="GtkCheckButton" id="copy_on_select">
+                                            <property name="label" translatable="yes">Copy on select</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="halign">start</property>
+                                            <property name="draw_indicator">True</property>
+                                            <signal name="toggled" handler="on_copy_on_select_toggled" swapped="no"/>
+                                          </object>
+                                          <packing>
+                                            <property name="left_attach">1</property>
+                                            <property name="top_attach">4</property>
+                                          </packing>
                                         </child>
                                       </object>
                                     </child>
@@ -809,7 +821,7 @@
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">True</property>
                                                 <items>
-                                                  <item translatable="yes" >Full Path</item>
+                                                  <item translatable="yes">Full Path</item>
                                                   <item translatable="yes">Abbreviated Path</item>
                                                   <item translatable="yes">Last Segment</item>
                                                 </items>

--- a/guake/prefs.py
+++ b/guake/prefs.py
@@ -366,6 +366,10 @@ class PrefsCallbacks:
         """Save `set_window_title` property value in dconf"""
         self.settings.general.set_boolean("set-window-title", chk.get_active())
 
+    def on_copy_on_select_toggled(self, chk):
+        """Changes the value of copy_on_select in dconf"""
+        self.settings.general.set_boolean("copy-on-select", chk.get_active())
+
     def on_tab_name_display_changed(self, combo):
         """Save `display-tab-names` property value in dconf"""
         self.settings.general.set_int("display-tab-names", combo.get_active())
@@ -1139,6 +1143,10 @@ class PrefsDialog(SimpleGladeApp):
         value = self.settings.general.get_boolean("use-default-font")
         self.get_widget("use_default_font").set_active(value)
         self.get_widget("font_style").set_sensitive(not value)
+
+        # use copy on select
+        value = self.settings.general.get_boolean("copy-on-select")
+        self.get_widget("copy_on_select").set_active(value)
 
         # font
         value = self.settings.styleFont.get_string("style")

--- a/guake/terminal.py
+++ b/guake/terminal.py
@@ -105,6 +105,7 @@ class GuakeTerminal(Vte.Terminal):
         self.handler_ids = []
         self.handler_ids.append(self.connect("button-press-event", self.button_press))
         self.connect("child-exited", self.on_child_exited)  # Call on_child_exited, don't remove it
+        self.connect("selection-changed", self.copy_on_select)
         self.matched_value = ""
         self.font_scale_index = 0
         self._pid = None
@@ -162,6 +163,10 @@ class GuakeTerminal(Vte.Terminal):
         elif self.matched_value:
             guake_clipboard = Gtk.Clipboard.get_default(self.guake.window.get_display())
             guake_clipboard.set_text(self.matched_value, len(self.matched_value))
+
+    def copy_on_select(self, event):
+        if self.guake.settings.general.get_boolean("copy-on-select") and self.get_has_selection():
+            self.copy_clipboard()
 
     def configure_terminal(self):
         """Sets all customized properties on the terminal"""

--- a/releasenotes/notes/add_copy_on_select-ab84ad18a0576207.yaml
+++ b/releasenotes/notes/add_copy_on_select-ab84ad18a0576207.yaml
@@ -1,0 +1,11 @@
+release_summary: >
+    Add copy on select option to copy to regular clipboard
+
+features:
+  - |
+      - "copy on selection" option even if the desktop doesn't do it #43 
+      - copy text on selection #1898 
+
+upgrade:
+  - |
+    Will be disabled by default


### PR DESCRIPTION
Add an option to make selecting text copy it to the os wide clipboard instead of just the inside guake clipboard.

Resolves #43 and #1898