### PR TITLE
fix:Do not set GDK_BACKEND to x11 in terminals.

### DIFF
--- a/guake/terminal.py
+++ b/guake/terminal.py
@@ -121,6 +121,10 @@ class GuakeTerminal(Vte.Terminal):
 
         self.setup_drag_and_drop()
 
+        self.ENVV_EXCLUDE_LIST = ["GDK_BACKEND"]
+        self.envv = [f"{i}={os.environ[i]}" for i in os.environ if i not in self.ENVV_EXCLUDE_LIST]
+        self.envv.append(f"GUAKE_TAB_UUID={self.uuid}")
+
     def setup_drag_and_drop(self):
         self.targets = Gtk.TargetList()
         self.targets.add_uri_targets(DropTargets.URIS)
@@ -550,12 +554,13 @@ class GuakeTerminal(Vte.Terminal):
             Vte.PtyFlags.DEFAULT,
             directory,
             argv,
-            [f"GUAKE_TAB_UUID={self.uuid}"],
-            GLib.SpawnFlags.DO_NOT_REAP_CHILD,
+            self.envv,
+            GLib.SpawnFlags(Vte.SPAWN_NO_PARENT_ENVV | GLib.SpawnFlags.DO_NOT_REAP_CHILD),
             None,
             None,
             None,
         )
+
         try:
             tuple_type = gi._gi.ResultTuple  # pylint: disable=c-extension-no-member
         except:  # pylint: disable=bare-except

--- a/releasenotes/notes/fix_gdk_backend-be5c40f221c1e528.yaml
+++ b/releasenotes/notes/fix_gdk_backend-be5c40f221c1e528.yaml
@@ -1,0 +1,6 @@
+release_summary: >
+    Stopped setting GDK_BACKEND to x11 in terminals.
+
+fixes:
+  - |
+      - GDK_BACKEND is propagated to the shell in terminal #1871 


### PR DESCRIPTION
Do not set GDK_BACKEND to x11 in terminals.

Don't automatically inherit env variables and manually pass modified env

Fixes  #1871