### PR TITLE
Install required package only

### DIFF
--- a/scripts/bootstrap-dev-debian.sh
+++ b/scripts/bootstrap-dev-debian.sh
@@ -35,7 +35,7 @@ fi
 
 if [[ $RUN == "1" ]]; then
     echo "Install packages needed for execution"
-    sudo apt install -y \
+    sudo apt-get install --no-install-recommends -y \
         gir1.2-keybinder-3.0 \
         gir1.2-notify-0.7 \
         gir1.2-vte-2.91 \
@@ -53,7 +53,7 @@ fi
 
 if [[ $MAKE == "1" ]]; then
     echo "Install packages needed for making guake"
-    sudo apt install -y \
+    sudo apt-get install --no-install-recommends -y \
         gettext \
         gsettings-desktop-schemas \
         make \
@@ -62,7 +62,7 @@ fi
 
 if [[ $DEV == "1" ]]; then
     echo "Install needed development packages"
-    sudo apt install -y \
+    sudo apt-get install --no-install-recommends -y \
         aspell-fr \
         colortest \
         dconf-editor \
@@ -73,6 +73,6 @@ fi
 
 if [[ $OPT == "1" ]]; then
     echo "Install packages optional for execution"
-    sudo apt install -y \
+    sudo apt-get install --no-install-recommends -y \
         numix-gtk-theme
 fi


### PR DESCRIPTION
Lets only install require package for the `guke` build process and ignore suggested other packages.

Ref:- https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends
