### PR TITLE
Fix system font only being applied to last tab

### DIFF
--- a/guake/gsettings.py
+++ b/guake/gsettings.py
@@ -377,7 +377,13 @@ class GSettingHandler:
         else:
             terminals = self.guake.notebook_manager.iter_terminals()
 
-        font = Pango.FontDescription(settings.get_string(key))
+        if self.settings.general.get_boolean("use-default-font"):
+            gio_settings = Gio.Settings("org.gnome.desktop.interface")
+            font_name = gio_settings.get_string("monospace-font-name")
+        else:
+            font_name = settings.get_string(key)
+
+        font = Pango.FontDescription(font_name)
         for i in terminals:
             i.set_font(font)
 

--- a/releasenotes/notes/fix_default_font_when_creating_tabs-ab0f827aa4e3955c.yaml
+++ b/releasenotes/notes/fix_default_font_when_creating_tabs-ab0f827aa4e3955c.yaml
@@ -1,0 +1,6 @@
+release_summary: >
+    Fix system font application issue
+
+fixes:
+  - |
+      - System font aplied only for last tab #1947 


### PR DESCRIPTION
Resolves #1947

Still don't know why this broke between 3.7 -> 3.8, but added a check that resolves this.