### PR TITLE
Remove GDK_BACKEND to force x11

### DIFF
--- a/guake/main.py
+++ b/guake/main.py
@@ -41,9 +41,6 @@ from optparse import OptionParser
 
 log = logging.getLogger(__name__)
 
-# Force use X11 backend under wayland before any import of GDK through dependencies
-os.environ["GDK_BACKEND"] = "x11"
-
 from guake.globals import NAME
 from guake.globals import bindtextdomain
 from guake.support import print_support

--- a/guake/terminal.py
+++ b/guake/terminal.py
@@ -121,8 +121,7 @@ class GuakeTerminal(Vte.Terminal):
 
         self.setup_drag_and_drop()
 
-        self.ENVV_EXCLUDE_LIST = ["GDK_BACKEND"]
-        self.envv = [f"{i}={os.environ[i]}" for i in os.environ if i not in self.ENVV_EXCLUDE_LIST]
+        self.envv = [f"{i}={os.environ[i]}" for i in os.environ]
         self.envv.append(f"GUAKE_TAB_UUID={self.uuid}")
 
     def setup_drag_and_drop(self):


### PR DESCRIPTION
After much feedback from the wayland users who don't want Guake to run in xwayland

Created in response to much feedback from #1934 and other related issues