### PR TITLE
Add pbr fallback

### DIFF
--- a/guake/__init__.py
+++ b/guake/__init__.py
@@ -27,7 +27,12 @@ def guake_version():
     try:
         import importlib.metadata as importlib_metadata
     except ImportError:
-        import importlib_metadata
+        try:
+            import importlib_metadata
+        except ImportError:
+            import pbr.version  # Fallback for python < 3.8 unable to install importlib_metadata
+
+            return pbr.version.VersionInfo("guake").version_string()
 
     return importlib_metadata.version("guake")
 

--- a/releasenotes/notes/fix_importlib-3da97c56e3fadc21.yaml
+++ b/releasenotes/notes/fix_importlib-3da97c56e3fadc21.yaml
@@ -1,0 +1,7 @@
+release_summary: >
+    Add fallback for version number finding
+
+
+fixes:
+  - |
+      - Guake suddenly not starting any more due to ModuleNotFoundError: No module named 'importlib_metadata' #1962


### PR DESCRIPTION
Resolves #1962

pbr seems to be an unused dependency after it was removed from the code, but this brings it back into use for at least until python versions < 3.8 get well and truly EOL'd