### PR TITLE
Manually set encoding if system locale is absent

### DIFF
--- a/guake/main.py
+++ b/guake/main.py
@@ -33,8 +33,10 @@ import subprocess
 import sys
 import uuid
 
-from locale import gettext
+from locale import gettext, getlocale, setlocale, LC_ALL
 
+if getlocale() == (None, None):
+    setlocale(LC_ALL, "en_US.UTF-8")
 builtins.__dict__["_"] = gettext
 
 from optparse import OptionParser

--- a/guake/menus.py
+++ b/guake/menus.py
@@ -94,7 +94,7 @@ def mk_terminal_context_menu(terminal, window, settings, callback_object):
     mi = Gtk.MenuItem(_("Split ―"))
     mi.connect("activate", callback_object.on_split_horizontal)
     menu.add(mi)
-    mi = Gtk.MenuItem(_("Split ｜"))
+    mi = Gtk.MenuItem(_("Split |"))
     mi.connect("activate", callback_object.on_split_vertical)
     menu.add(mi)
     mi = Gtk.MenuItem(_("Close terminal"))

--- a/releasenotes/notes/locale_fallback-080d41dbd0c89290.yaml
+++ b/releasenotes/notes/locale_fallback-080d41dbd0c89290.yaml
@@ -1,0 +1,7 @@
+release_summary: >
+    Manually set encoding if system locale is absent
+
+
+fixes:
+  - |
+      - Minimal Right Click Menu, no copy or split screen #1845 


### PR DESCRIPTION
Fixes #1845, though does not fix the user's underlying system locale issue that may  impact their experience with other programs on their machine.