### PR TITLE
Replace ｜ with non unicode dependent |

### DIFF
--- a/guake/menus.py
+++ b/guake/menus.py
@@ -94,7 +94,7 @@ def mk_terminal_context_menu(terminal, window, settings, callback_object):
     mi = Gtk.MenuItem(_("Split ―"))
     mi.connect("activate", callback_object.on_split_horizontal)
     menu.add(mi)
-    mi = Gtk.MenuItem(_("Split ｜"))
+    mi = Gtk.MenuItem(_("Split |"))
     mi.connect("activate", callback_object.on_split_vertical)
     menu.add(mi)
     mi = Gtk.MenuItem(_("Close terminal"))


### PR DESCRIPTION
To make vertical bar render on less character encoding proficient machines

Resolving the part of #1845 that doesn't need any maybe questionable working around.