### PR TITLE
Fix vte spawn_sync runtime check failed

### DIFF
--- a/guake/terminal.py
+++ b/guake/terminal.py
@@ -569,7 +569,7 @@ class GuakeTerminal(Vte.Terminal):
             directory,
             argv,
             self.envv,
-            GLib.SpawnFlags(Vte.SPAWN_NO_PARENT_ENVV | GLib.SpawnFlags.DO_NOT_REAP_CHILD),
+            GLib.SpawnFlags(Vte.SPAWN_NO_PARENT_ENVV),
             None,
             None,
             None,

--- a/releasenotes/notes/fragment_name-2a5a482a34398a59.yaml
+++ b/releasenotes/notes/fragment_name-2a5a482a34398a59.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+     - Fix vte spawn_sync runtime check failed: ((spawn_flags & ignored_spawn_flags()) == 0)


### PR DESCRIPTION
When running Guake, `spawn_sync` shows runtime check failed:

```
$ guake
...
(guake:193534): VTE-WARNING **: 10:57:38.556: (../vte/src/vtepty.cc:667):bool
_vte_pty_spawn_sync(VtePty*, const char*, const char* const*,
                    const char* const*, GSpawnFlags, GSpawnChildSetupFunc,
                    gpointer, GDestroyNotify, GPid*, int,
                    GCancellable*, GError**):
runtime check failed: ((spawn_flags & ignored_spawn_flags()) == 0)
...
```

This is cause by setting `DO_NOT_REAP_CHILD` flag in it.

As shown in vte document & source code, `DO_NOT_REAP_CHILD` is
the default behavior for `spawn_sync`, so we don't need to pass
it when we try to `spawn_sync`.