### PR TITLE
Switch default for hide tab bar if only one tab to disabled

### DIFF
--- a/guake/data/org.guake.gschema.xml
+++ b/guake/data/org.guake.gschema.xml
@@ -117,7 +117,7 @@
 		  <description>When true, the tab bar will hide when is in fullscreen</description>
 		</key>
 		<key name="hide-tabs-if-one-tab" type="b">
-		  <default>true</default>
+		  <default>false</default>
 		  <summary>Hide tab bar if there is only one tab</summary>
 		  <description>When true, the tab bar will hide when there is only one tab</description>
 		</key>

--- a/guake/tests/test_guake.py
+++ b/guake/tests/test_guake.py
@@ -186,5 +186,6 @@ def test_guake_hide_tab_bar_if_one_tab(mocker, g, fs):
     # Set hide-tabs-if-one-tab to True
     mocker.patch.object(g.settings.general, "get_boolean", return_value=True)
 
+    g.settings.general.set_boolean("hide-tabs-if-one-tab", True)
     assert g.get_notebook().get_n_pages() == 1
     assert g.get_notebook().get_property("show-tabs") is False


### PR DESCRIPTION
Resolves #1978

Probably, mostly, anyone who defies the default to enable it shouldn't be confused by it happening