### PR TITLE
Fix module gi not found when make run 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ dev-no-pipenv: clean
 	. .venv/bin/activate && pip install -r requirements.txt -r requirements-dev.txt -e .
 
 pipenv-install-dev:
-	PIPENV_IGNORE_VIRTUALENVS=1 pipenv install --dev --python $(PYTHON_INTERPRETER)
+	PIPENV_IGNORE_VIRTUALENVS=1 pipenv install --dev --python $(PYTHON_INTERPRETER) --site-packages
 
 ln-venv:
 	# use that to configure a symbolic link to the virtualenv in .venv

--- a/releasenotes/notes/bugfix-gi-not-found-when-make-run-c30cf8be36345384.yaml
+++ b/releasenotes/notes/bugfix-gi-not-found-when-make-run-c30cf8be36345384.yaml
@@ -1,0 +1,3 @@
+fixes:
+    - Fix issue, At local execution of guake (without system-wide install), at start up, it break showing that cant found module named 'gi' #1971
+

--- a/scripts/bootstrap-dev-pip.sh
+++ b/scripts/bootstrap-dev-pip.sh
@@ -10,7 +10,7 @@ fi
 
 python3 -m pip install $op --upgrade \
     'pip==20.0.2' \
-    'pipenv==2018.11.26' \
+    'pipenv==2021.11.23' \
     || echo "you may need to sudo me !"
 
 echo "Please ensure your local bin directory is in your path"


### PR DESCRIPTION
Please follow these steps before submitting a new Pull Request to Guake:

- rebase on latest HEAD:

  ```bash
  $ git pull --rebase upstream master
  ```

- hack your change

- to execute the code styling, checks and unit tests:

  ```bash
  $ make style check reno-lint test
  ```

- describe your change in a slug file for automatic release note
  generation, using:

  ```bash
  $ make reno SLUG=<short_name_of_my_feature>
  ```

  and edit the created file in `releasenotes/notes/`.
  You can see how `reno` works using `pipenv run reno --help`.

  Please use a generic slug (eg, for translation update,
  use `translation`, for bugfix use `bugfix`,...)

- create new commit message

  ```bash
  $ <hack the code>
  $ git commit --all
  ```

- If your change is related to a GitHub issue, you can add a reference
  using `#123` where 123 is the ID of the issue.
  You can use `closes #123` to have GitHub automatically close the issue
  when your contribution get merged

- Semantic commit is supported (and recommended). Add one of the following
  line in your commit messages:
  
  ```
  # For a bug fix, uses:
  sem-ver: bugfix
  
  # For a new feature, uses:
  sem-ver: feature
  
  # Please do not use the 'breaking change' syntax (`sem-ver: api-break`), 
  # it is reserved for really big reworks
  ```
