### PR TITLE
Drop pbr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ ChangeLog
 guake/data/gschemas.compiled
 .pytest_cache/
 releasenotes/notes/reno.cache
+guake/_version.py
 guake/paths.py
 guake/paths.py.dev
 RELEASENOTES.rst

--- a/Makefile
+++ b/Makefile
@@ -188,7 +188,7 @@ black:
 checks: black-check flake8 pylint reno-lint
 
 black-check:
-	PIPENV_IGNORE_VIRTUALENVS=1 pipenv run black --check $(MODULE)
+	PIPENV_IGNORE_VIRTUALENVS=1 pipenv run black --check $(MODULE) --extend-exclude $(MODULE)/_version.py
 
 flake8:
 	PIPENV_IGNORE_VIRTUALENVS=1 pipenv run flake8 guake

--- a/docs/source/contributing/packaging.rst
+++ b/docs/source/contributing/packaging.rst
@@ -27,7 +27,6 @@ Here are the system dependencies of Guake for its execution:
 - ``python3-cairo``
 - ``python3-dbus``
 - ``python3-gi``
-- ``python3-pbr``
 
 Optional dependencies:
 

--- a/docs/source/user/installing.rst
+++ b/docs/source/user/installing.rst
@@ -103,7 +103,6 @@ You need to ensure the following points are met in your configuration:
    - ``python3-cairo``
    - ``python3-dbus``
    - ``python3-gi``
-   - ``python3-pbr``
    - ``python3-pip``
    - ``python3``
 

--- a/guake/__init__.py
+++ b/guake/__init__.py
@@ -22,19 +22,9 @@ Boston, MA 02110-1301 USA
 
 
 def guake_version():
-    # Do not import in the module root to speed up the dbus communication as much as possible
-    # That being said, importlib.metadata is pretty speedy unlike pbr/pkg_resources
-    try:
-        import importlib.metadata as importlib_metadata
-    except ImportError:
-        try:
-            import importlib_metadata
-        except ImportError:
-            import pbr.version  # Fallback for python < 3.8 unable to install importlib_metadata
+    from ._version import version
 
-            return pbr.version.VersionInfo("guake").version_string()
-
-    return importlib_metadata.version("guake")
+    return version
 
 
 def vte_version():

--- a/guake/main.py
+++ b/guake/main.py
@@ -408,7 +408,6 @@ def main():
             "        python3 \\\n"
             "        python3-dbus \\\n"
             "        python3-gi \\\n"
-            "        python3-pbr \\\n"
             "        python3-pip"
         )
         sys.exit(1)

--- a/releasenotes/notes/switch_versioning_setuptools_scm-6481ee944dbb5d0a.yaml
+++ b/releasenotes/notes/switch_versioning_setuptools_scm-6481ee944dbb5d0a.yaml
@@ -1,0 +1,6 @@
+release_summary: >
+    Deprecated pbr
+
+notes_for_package_maintainers:
+  - |
+    Switched from importlib + pbr to setuptools_scm for versioning

--- a/scripts/bootstrap-dev-arch.sh
+++ b/scripts/bootstrap-dev-arch.sh
@@ -42,7 +42,7 @@ if [[ $RUN == "1" ]]; then
         python-cairo \
         python-dbus \
         python-gobject \
-        python-pbr \
+        python-setuptools-scm \
         vte3
 fi
 

--- a/scripts/bootstrap-dev-debian.sh
+++ b/scripts/bootstrap-dev-debian.sh
@@ -46,7 +46,7 @@ if [[ $RUN == "1" ]]; then
         python3-cairo \
         python3-dbus \
         python3-gi \
-        python3-pbr \
+        python3-setuptools-scm \
         python3-pip \
         libgirepository1.0-dev
 fi

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,8 +25,8 @@ classifier =
 packages =
     guake
 setup_requires =
-    pbr
     setuptools>=57.5.0
+    setuptools_scm
 install_requires =
     importlib_metadata; python_version < '3.8'
     typing; python_version < '3.5'
@@ -46,9 +46,6 @@ all_files = 1
 
 [upload_sphinx]
 upload-dir = doc/build/html
-
-[pbr]
-warnerrors = True
 
 [wheel]
 universal = 1

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
     typing; python_version < '3.5'
 
 [options.data_files]
-share/guake/po = po/*
+share/guake/po = po/*.mo
 
 [options.entry_points]
 console_scripts =

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,13 +26,13 @@ packages =
     guake
 setup_requires =
     pbr
+    setuptools>=57.5.0
 install_requires =
     importlib_metadata; python_version < '3.8'
     typing; python_version < '3.5'
 
-[files]
-data_files =
-    share/guake/po = po/*
+[options.data_files]
+share/guake/po = po/*
 
 [options.entry_points]
 console_scripts =

--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 import setuptools
-
-# In python < 2.7.4, a lazy loading of package `pbr` will break
-# setuptools if some other modules registered functions in `atexit`.
-# solution from: http://bugs.python.org/issue15881#msg170215
-try:
-    import multiprocessing  # noqa
-except ImportError:
-    pass
-
-setuptools.setup(pbr=True)
+setuptools.setup(use_scm_version={"write_to": "guake/_version.py"})


### PR DESCRIPTION
This migrates off of the final two features of pbr that were still in use after #1883

- setuptools data files now natively supports globbing. Require a recent enough version of setuptools during the build.
- Switch from pbr's git versioning to the popular setuptools_scm.
  - maintained by PyPA
  - has dedicated scope to do one thing (SCM versioning) and do it well
  - fixes the bug where pbr reimplemented `git describe` by manually parsing commit logs and got the wrong answer
  - future versions of setuptools_scm will transparently support `git archive` generated tarballs