### PR TITLE
Fix upload to pypi test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           a: ${{ matrix.python-version }}
           b: 3.9
-          
+
       - name: Store dists (Python 3.9)
         if: steps.isLatest.outputs.result
         uses: actions/upload-artifact@v2

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import setuptools
-setuptools.setup(use_scm_version={"write_to": "guake/_version.py"})
+
+setuptools.setup(
+    use_scm_version={"write_to": "guake/_version.py", "local_scheme": "no-local-version"}
+)


### PR DESCRIPTION
After much discouragement from the last several unfruitful attempts to make pypi happen, I fell off a little bit and was busy elsewhere but found it in me recently to get over and take a look at the repo, which had a failing CI build that I somehow failed to notice for ages. Looking at the specifics of the failure, this seems actually encouragingly like a working pypi build is finally in reach, just need to strip out some elements from the version number that pypi can't handle.