### PR TITLE
Reinstate double click to open tabs

### DIFF
--- a/guake/notebook.py
+++ b/guake/notebook.py
@@ -120,6 +120,13 @@ class TerminalNotebook(Gtk.Notebook):
             except AttributeError:
                 # Gtk 3.18 fallback ("'Menu' object has no attribute 'popup_at_pointer'")
                 menu.popup(None, None, None, None, event.button, event.time)
+        elif (
+            event.type == Gdk.EventType.DOUBLE_BUTTON_PRESS
+            and event.button == 1
+            and event.window.get_height() < 60
+        ):
+            # event.window.get_height() reports the height of the clicked frame
+            self.new_page_with_focus()
 
         return False
 

--- a/releasenotes/notes/restore_double_click_open_tab-c4dfc824ce4b5e85.yaml
+++ b/releasenotes/notes/restore_double_click_open_tab-c4dfc824ce4b5e85.yaml
@@ -1,0 +1,7 @@
+release_summary: >
+  Reinstated double clicking to open new tabs
+
+features:
+  - |
+      - Double click to open a new tab, without side effects in mouse
+        enabled terminal apps


### PR DESCRIPTION
With an additional condition to attempt to check that we're clicking on the tab bar to resolve the original issue that led to the removal of the feature.

Resolves #1980