### PR TITLE
Generate release notes for 3.8.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -424,7 +424,7 @@ release-note-github: reno-lint
 	@echo "-------- copy / paste from here --------"
 	@# markdown_github to be avoided => gfm output comes in pandoc 2.0.4 release dec 2017
 	@pipenv run reno report 2>/dev/null | \
-		pandoc -f rst -t markdown --atx-headers --wrap=none --tab-stop 2 | \
+		pandoc -f rst -t markdown --markdown-headings=atx --wrap=none --tab-stop 2 | \
 		tr '\n' '\r' | \
 			sed 's/\r<!-- -->\r//g' | \
 			sed 's/\r\-\ \r\r\ /\r-/g' | \

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -2,15 +2,24 @@
 guake
 =====
 
-(unreleased yet)
-================
+3.8.2
+=====
 
 Release Summary
 ---------------
 
 Fix system font application issue
 
+Add fallback for version number finding
+
+Deprecated pbr
+
 Use keycodes instead of keyvals for keybindings. This allow to use keybindings with different keyboard layouts.
+
+New Features
+------------
+
+- --is-visible option returns 1 when visible, and 0 when not
 
 Known Issues
 ------------
@@ -20,7 +29,23 @@ Known Issues
 Bug Fixes
 ---------
 
+- Changed Toggle Hide on Lose Focus Shortcut to Shift-Ctrl-F1.
+  Instead of change Go to tab1 shortcut, because Ctrl-F1 is in the pool Ctrl-Fn of change to tabs.
+
+- Fix issue Ctrl+F1 does two jobs in Keyboard Shortcuts Page
+
+- - Add environment variable GUAKE_ENABLE_WAYLAND, fixed #1934
+
 - - System font aplied only for last tab #1947 
+
+- - Guake suddenly not starting any more due to ModuleNotFoundError: No module named 'importlib_metadata' #1962
+
+- - Fix vte spawn_sync runtime check failed: ((spawn_flags & ignored_spawn_flags()) == 0)
+
+Notes for Package Maintainers
+-----------------------------
+
+- Switched from importlib + pbr to setuptools_scm for versioning
 
 3.8.1
 =====


### PR DESCRIPTION
Also replaced a deprecated pandoc flag

Once this is merged, I'll tag the release. This has the upload to pypi on tag GA trigger, so hopefully this will finally update the pypi package. If there's any other changes that we want to add before we put the bow on this and push it out, I can regen the release notes after merging them. Off the top of my head, there might be some translation changes banked up in weblate that @gsemet might want to get in.