### PR TITLE
Fix arbitrary execution via dbus security flaw

### DIFF
--- a/guake/dbusiface.py
+++ b/guake/dbusiface.py
@@ -153,10 +153,6 @@ class DbusManager(dbus.service.Object):
         self.guake.reset_terminal_custom_colors(current_terminal=True)
         self.guake.set_colors_from_settings_on_page(current_terminal_only=True)
 
-    @dbus.service.method(DBUS_NAME, in_signature="s")
-    def execute_command(self, command):
-        self.guake.execute_command(command)
-
     @dbus.service.method(DBUS_NAME, in_signature="i", out_signature="s")
     def get_tab_name(self, tab_index=0):
         return self.guake.get_notebook().get_tab_text_index(tab_index)
@@ -193,10 +189,6 @@ class DbusManager(dbus.service.Object):
     def get_selected_uuidtab(self):
         return self.guake.get_selected_uuidtab()
 
-    @dbus.service.method(DBUS_NAME, in_signature="ss")
-    def execute_command_by_uuid(self, tab_uuid, command):
-        self.guake.execute_command_by_uuid(tab_uuid, command)
-
     @dbus.service.method(DBUS_NAME)
     def v_split_current_terminal(self):
         self.guake.get_notebook().get_current_terminal().get_parent().split_v()
@@ -204,7 +196,3 @@ class DbusManager(dbus.service.Object):
     @dbus.service.method(DBUS_NAME)
     def h_split_current_terminal(self):
         self.guake.get_notebook().get_current_terminal().get_parent().split_h()
-
-    @dbus.service.method(DBUS_NAME, in_signature="s")
-    def execute_command_current_termbox(self, command):
-        self.guake.get_notebook().get_current_terminal().execute_command(command)

--- a/guake/guake_app.py
+++ b/guake/guake_app.py
@@ -457,14 +457,11 @@ class Guake(SimpleGladeApp):
             self.set_colors_from_settings()
 
     def execute_command(self, command, tab=None):
-        # TODO DBUS_ONLY
         """Execute the `command' in the `tab'. If tab is None, the
         command will be executed in the currently selected
         tab. Command should end with '\n', otherwise it will be
         appended to the string.
         """
-        # TODO CONTEXTMENU this has to be rewriten and only serves the
-        # dbus interface, maybe this should be moved to dbusinterface.py
         if not self.get_notebook().has_page():
             self.add_tab()
 
@@ -475,7 +472,6 @@ class Guake(SimpleGladeApp):
         terminal.feed_child(command)
 
     def execute_command_by_uuid(self, tab_uuid, command):
-        # TODO DBUS_ONLY
         """Execute the `command' in the tab whose terminal has the `tab_uuid' uuid"""
         if command[-1] != "\n":
             command += "\n"

--- a/releasenotes/notes/dbus_execution_security-fb7016c6bc40be5f.yaml
+++ b/releasenotes/notes/dbus_execution_security-fb7016c6bc40be5f.yaml
@@ -1,0 +1,3 @@
+security:
+  - |
+     Fixed security Issue: Exposure of sensitive function, malicious user can arbitrary command via an execute_command d-bus method. #1796 


### PR DESCRIPTION
Highlighted in and fixes #1796. Also removed comments that won't be true or relevant with this change. These changes orphan the `execute_command_by_uuid()` method, but the method can probably still be used elsewhere, maybe given a command line flag like what `execute_command()` has.