### PR TITLE
Revert "ci: no pipeline on pull_request"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@
 
 name: CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
This reverts commit 517745d3e3d07e78b1bf32c13adc7749aa223811.

Despite assurance that removing pull_request wouldn't wipe CI runs from pull requests, we can see in  #2017 that removing pull_request wipes CI runs from pull requests.