### PR TITLE
Generate release notes for 3.8.2

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -8,9 +8,45 @@ guake
 Release Summary
 ---------------
 
+Eliminated redundant terminal spawning on startup
+
+Security Issues
+---------------
+
+- Fixed security Issue: Exposure of sensitive function, malicious user can arbitrary command via an execute_command d-bus method. #1796 
+
+Translation Updates
+-------------------
+
+- Chinese Simplified (@kitty-panics)
+
+- Croatian (@milotype)
+
+- Dutch (@Vistaus)
+
+- German (@m1ga, @rMb93)
+
+- Indonesian (@rezaalmanda)
+
+- Polish (@piotrdrag)
+
+- Russian (@vantu5z)
+
+- Swedish (@MorganAntonsson)
+
+- Turkish (@Draconis-25, @ersen0)
+
+3.8.2.0rc1
+==========
+
+Release Summary
+---------------
+
 Fix system font application issue
 
 Add fallback for version number finding
+
+Reinstated double clicking to open new tabs
 
 Deprecated pbr
 
@@ -20,6 +56,9 @@ New Features
 ------------
 
 - --is-visible option returns 1 when visible, and 0 when not
+
+- - Double click to open a new tab, without side effects in mouse
+    enabled terminal apps
 
 Known Issues
 ------------
@@ -46,6 +85,11 @@ Notes for Package Maintainers
 -----------------------------
 
 - Switched from importlib + pbr to setuptools_scm for versioning
+
+Other
+-----
+
+- Fix for release pipeline.
 
 3.8.1
 =====

--- a/releasenotes/notes/translation-931a45cfe34f71ae.yaml
+++ b/releasenotes/notes/translation-931a45cfe34f71ae.yaml
@@ -1,0 +1,10 @@
+translations:
+  - Chinese Simplified (@kitty-panics)
+  - Croatian (@milotype)
+  - Dutch (@Vistaus)
+  - German (@m1ga, @rMb93)
+  - Indonesian (@rezaalmanda)
+  - Polish (@piotrdrag)
+  - Russian (@vantu5z)
+  - Swedish (@MorganAntonsson)
+  - Turkish (@Draconis-25, @ersen0)


### PR DESCRIPTION
Hopefully the proper release this time, unless someone decides to tag rc without saying anything again for no reason

Generated with `make release-note`, which was presumably how all the other release notes were generated. Note the lack of mysteriously deleted sections, which is still the main issue with #2015.

Will tag 3.8.2 when this is merged. If you merge this and tag a release, please don't leave the description empty again.