### PR TITLE
Fix split terminal did not preverse font scale #1747

### DIFF
--- a/guake/boxes.py
+++ b/guake/boxes.py
@@ -481,6 +481,10 @@ class TerminalBox(Gtk.Box, TerminalHolder):
         dual_terminal_box.set_child_second(terminal_box)
         terminal_box.show()
         dual_terminal_box.show()
+        if self.terminal is not None:
+            # preserve font and font_scale in the new terminal
+            terminal.set_font(self.terminal.font)
+            terminal.font_scale = self.terminal.font_scale
         notebook.terminal_attached(terminal)
 
         return dual_terminal_box

--- a/guake/terminal.py
+++ b/guake/terminal.py
@@ -492,7 +492,7 @@ class GuakeTerminal(Vte.Terminal):
 
     def set_font(self, font):
         self.font = font
-        self.set_font_scale_index(0)
+        self.set_font_scale_index(self.font_scale)
 
     def set_font_scale_index(self, scale_index):
         self.font_scale_index = clamp(scale_index, -6, 12)

--- a/releasenotes/notes/bugfix-bfcece2fed005b98.yaml
+++ b/releasenotes/notes/bugfix-bfcece2fed005b98.yaml
@@ -1,0 +1,7 @@
+release_summary: >
+  Fix issue #1747 - Splitting terminal should not reset font size
+
+fixes:
+  - |
+    fixed issue #1747. Now font size is not reset after a terminal split
+


### PR DESCRIPTION
Following https://github.com/Guake/guake/issues/1747, i saved the current font scale so when a terminal is split the font scale is not resized to default value.

