### PR TITLE
fix fullscreen using pointer on several monitors

### DIFF
--- a/guake/utils.py
+++ b/guake/utils.py
@@ -39,7 +39,6 @@ from guake.globals import ALIGN_CENTER
 from guake.globals import ALIGN_LEFT
 from guake.globals import ALIGN_RIGHT
 from guake.globals import ALIGN_TOP
-from guake.globals import ALWAYS_ON_PRIMARY
 
 try:
     from gi.repository import GdkX11
@@ -230,9 +229,8 @@ class RectCalculator:
         log.debug("  vdisplacement = %s", vdisplacement)
 
         # get the rectangle just from the destination monitor
-        screen = window.get_screen()
         monitor = cls.get_final_window_monitor(settings, window)
-        window_rect = screen.get_monitor_geometry(monitor)
+        window_rect = monitor.get_workarea()
         log.debug("Current monitor geometry")
         log.debug("  window_rect.x: %s", window_rect.x)
         log.debug("  window_rect.y: %s", window_rect.y)
@@ -285,34 +283,29 @@ class RectCalculator:
 
     @classmethod
     def get_final_window_monitor(cls, settings, window):
-        """Gets the final screen number for the main window of guake."""
+        """Gets the final monitor for the main window of guake."""
 
-        screen = window.get_screen()
+        display = window.get_display()
 
         # fetch settings
         use_mouse = settings.general.get_boolean("mouse-display")
-        dest_screen = settings.general.get_int("display-n")
+        num_monitor = settings.general.get_int("display-n")
 
         if use_mouse:
+            pointer = display.get_default_seat().get_pointer()
+            if pointer is None:
+                monitor = display.get_primary_monitor()
+            else:
+                _, x, y = pointer.get_position()
+                monitor = display.get_monitor_at_point(x, y)
+        else:
+            monitor = display.get_monitor(num_monitor)
+            if monitor is None:
+                # monitor not found or num_monitor is wrong
+                # by default we use the primary monitor
+                monitor = display.get_primary_monitor()
 
-            # TODO PORT get_pointer is deprecated
-            # https://developer.gnome.org/gtk3/stable/GtkWidget.html#gtk-widget-get-pointer
-            win, x, y, _ = screen.get_root_window().get_pointer()
-            dest_screen = screen.get_monitor_at_point(x, y)
-
-        # If Guake is configured to use a screen that is not currently attached,
-        # default to 'primary display' option.
-        n_screens = screen.get_n_monitors()
-        if dest_screen > n_screens - 1:
-            settings.general.set_boolean("mouse-display", False)
-            settings.general.set_int("display-n", dest_screen)
-            dest_screen = screen.get_primary_monitor()
-
-        # Use primary display if configured
-        if dest_screen == ALWAYS_ON_PRIMARY:
-            dest_screen = screen.get_primary_monitor()
-
-        return dest_screen
+        return monitor
 
 
 class ImageLayoutMode(enum.IntEnum):
@@ -421,7 +414,9 @@ class BackgroundImageManager:
         # Step 1. Get target surface
         #         (paint background image into widget size surface by layout mode)
         surface = self.render_target(
-            widget.get_allocated_width(), widget.get_allocated_height(), self.layout_mode
+            widget.get_allocated_width(),
+            widget.get_allocated_height(),
+            self.layout_mode,
         )
 
         cr.save()
@@ -440,7 +435,9 @@ class BackgroundImageManager:
         #
         child = widget.get_child()
         child_surface = cr.get_target().create_similar(
-            cairo.CONTENT_COLOR_ALPHA, child.get_allocated_width(), child.get_allocated_height()
+            cairo.CONTENT_COLOR_ALPHA,
+            child.get_allocated_width(),
+            child.get_allocated_height(),
         )
         child_cr = cairo.Context(child_surface)
 

--- a/releasenotes/notes/bugfix-fullscreen-not-working-on-pointer-8fe1518e5e5dc67f.yaml
+++ b/releasenotes/notes/bugfix-fullscreen-not-working-on-pointer-8fe1518e5e5dc67f.yaml
@@ -1,0 +1,4 @@
+fixes:
+  - |
+    Fix fullscreen window is not working on multiple monitors when using
+    "appear on mouse display" option #928


### PR DESCRIPTION
This PR fixes the problem described in https://github.com/Guake/guake/issues/928 (at least on my computer)

I'm using several monitors with **dock bar** on all monitors and **top bar** on the main monitor.

It seems that when the guake's window height is larger than the height of the monitor excluding top/dock bars height, the monitor is sometimes "ignored" by gdk. If I'm resizing the guake window to be smaller than this height, it works.

The bug is at [`screen.get_monitor_at_point(x, y)`](https://github.com/Guake/guake/blob/master/guake/utils.py#L301).

It returns the number of the wrong monitor when I'm encountering the problem.

In this PR, I've reworked the method `get_final_window_monitor` to use latest gdk APIs (as pointed out by the TODO in the code) and instead of using [`.get_geometry()`](https://lazka.github.io/pgi-docs/Gdk-3.0/classes/Monitor.html#Gdk.Monitor.get_geometry), I'm using method [`.get_workarea()`](https://lazka.github.io/pgi-docs/Gdk-3.0/classes/Monitor.html#Gdk.Monitor.get_workarea) which seems to return the rectangle "usable" by an application (without dock / top bars or else)

I've also tested manually all guake's options of "Appear on mouse display" on single/multiple monitors and it works as expected.

I'm not used to guake and gdk libs so I don't know if it can break things or if you have specific "integration" tests to do other than tests in the lib ? 