### PR TITLE
Reintroduce execute_command dbus hook

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -11,6 +11,7 @@ ignore =
     E722,
     W503, # line break before binary operator
     E231, # missing whitespace after ','
+    E203,
 max-line-length = 100
 exclude = env,.direnv,docs
 max-complexity = 25

--- a/guake/globals.py
+++ b/guake/globals.py
@@ -117,3 +117,6 @@ TABS_SESSION_SCHEMA_VERSION = 2
 # Constants for vte regex matching are documented in the pcre2 api:
 #   https://www.pcre.org/current/doc/html/pcre2api.html
 PCRE2_MULTILINE = 0x00000400
+
+# Path to temp per-session dbus key
+DBUS_KEYPATH = "~/.config/guake/dbus_key"

--- a/guake/guake_app.py
+++ b/guake/guake_app.py
@@ -27,6 +27,7 @@ import time as pytime
 import traceback
 import uuid
 
+from cryptography.fernet import Fernet
 from pathlib import Path
 from threading import Thread
 from time import sleep
@@ -56,6 +57,7 @@ from guake.dialogs import PromptQuitDialog
 from guake.globals import MAX_TRANSPARENCY
 from guake.globals import NAME
 from guake.globals import TABS_SESSION_SCHEMA_VERSION
+from guake.globals import DBUS_KEYPATH
 from guake.gsettings import GSettingHandler
 from guake.keybindings import Keybindings
 from guake.notebook import NotebookManager
@@ -281,6 +283,13 @@ class Guake(SimpleGladeApp):
                 ),
                 filename,
             )
+
+        # Init session dbus key
+        self.dbus_key = Fernet.generate_key()
+        os.makedirs(os.path.expanduser(os.path.dirname(DBUS_KEYPATH)), exist_ok=True)
+        with open(os.path.expanduser(DBUS_KEYPATH), "wb") as f:
+            f.write(self.dbus_key)
+        os.chmod(os.path.expanduser(DBUS_KEYPATH), 0o600)
 
         log.info("Guake initialized")
 

--- a/releasenotes/notes/reinstate_execute_command-ab006ac3eb128b30.yaml
+++ b/releasenotes/notes/reinstate_execute_command-ab006ac3eb128b30.yaml
@@ -1,0 +1,6 @@
+release_summary: >
+  -e command reinstated with sudo requirement
+  
+security:
+  - |
+    guake with the -e flag must now be run with super user privileges.


### PR DESCRIPTION
With an added security key check to prevent the initial security flaw that led to its removal. Currently using the file permission approach mentioned in #2042. This currently prevents naive calls to the dbus interface now, but the vulnerability stills exists via the actual program: to reproduce, go into super user mode in Guake (`su -`) and from another terminal or program invoke `guake -e touch a`, which will create a file named `a` as a super user despite not having root privileges. Will come back in a bit with a reformation to this PR with something that will make `guake -e` require sudo, and also protect the key file more, but leaving this here for now for reference and discussion.