### PR TITLE
Reintroduce execute_command dbus hook

### DIFF
--- a/guake/dbusiface.py
+++ b/guake/dbusiface.py
@@ -153,6 +153,11 @@ class DbusManager(dbus.service.Object):
         self.guake.reset_terminal_custom_colors(current_terminal=True)
         self.guake.set_colors_from_settings_on_page(current_terminal_only=True)
 
+    @dbus.service.method(DBUS_NAME, in_signature="s")
+    def execute_command(self, command):
+        self.guake.add_tab()
+        self.guake.execute_command(command)
+
     @dbus.service.method(DBUS_NAME, in_signature="i", out_signature="s")
     def get_tab_name(self, tab_index=0):
         return self.guake.get_notebook().get_tab_text_index(tab_index)

--- a/guake/main.py
+++ b/guake/main.py
@@ -243,7 +243,7 @@ def main():
         dest="command",
         action="store",
         default="",
-        help=_("Execute an arbitrary command in the selected tab."),
+        help=_("Execute an arbitrary command in a new tab."),
     )
 
     parser.add_option(

--- a/releasenotes/notes/execute_in_new_tab-6161bba1822b644c.yaml
+++ b/releasenotes/notes/execute_in_new_tab-6161bba1822b644c.yaml
@@ -1,0 +1,6 @@
+release_summary: >
+  -e command reinstated and now only runs in new tabs
+  
+security:
+  - |
+    guake with the -e flag now always opens a new tab to run commands in


### PR DESCRIPTION
Command now always creates a new tab to execute the command in

Alternate resolution to #2042 decided upon after some amount of discussion.