### PR TITLE
Add open link under terminal cursor

### DIFF
--- a/guake/data/org.guake.gschema.xml
+++ b/guake/data/org.guake.gschema.xml
@@ -413,6 +413,11 @@
             <summary>Search current selected text on the web</summary>
             <description>Accelerator to active function that search on the web the current selected text on the terminal.</description>
         </key>
+        <key name="open-link-under-terminal-cursor" type="s">
+            <default>'&lt;Control&gt;&lt;Shift&gt;o'</default>
+            <summary>Open link under terminal cursor</summary>
+            <description>Accelerator to active function that opens the link (URL) under the current terminal cursor.</description>
+        </key>
         <key name="move-tab-left" type="s">
             <default>'&lt;Control&gt;&lt;Shift&gt;Page_Up'</default>
             <summary>Move left current tab</summary>

--- a/guake/guake_app.py
+++ b/guake/guake_app.py
@@ -1279,6 +1279,13 @@ class Guake(SimpleGladeApp):
         terminals = self.get_notebook().get_terminals_for_page(page_num)
         return str(terminals[0].get_uuid())
 
+    def open_link_under_terminal_cursor(self, *args):
+        current_term = self.get_notebook().get_current_terminal()
+        if current_term is None:
+            return
+        url = current_term.get_link_under_terminal_cursor()
+        current_term.browse_link_under_cursor(url)
+
     def search_on_web(self, *args):
         """Search for the selected text on the web"""
         # TODO KEYBINDINGS ONLY

--- a/guake/keybindings.py
+++ b/guake/keybindings.py
@@ -82,6 +82,7 @@ class Keybindings:
             ("decrease-transparency", self.guake.accel_decrease_transparency),
             ("toggle-transparency", self.guake.accel_toggle_transparency),
             ("search-on-web", self.guake.search_on_web),
+            ("open-link-under-terminal-cursor", self.guake.open_link_under_terminal_cursor),
             ("move-tab-left", self.guake.accel_move_tab_left),
             ("move-tab-right", self.guake.accel_move_tab_right),
             ("switch-tab1", self.guake.gen_accel_switch_tabN(0)),

--- a/guake/prefs.py
+++ b/guake/prefs.py
@@ -186,7 +186,10 @@ HOTKEYS = [
         "key": "extra",
         "keys": [
             {"key": "search-on-web", "label": _("Search selected text on web")},
-            {"key": "open-link-under-terminal-cursor", "label": _("Open URL under terminal cursor")},
+            {
+                "key": "open-link-under-terminal-cursor",
+                "label": _("Open URL under terminal cursor"),
+            },
         ],
     },
 ]

--- a/guake/prefs.py
+++ b/guake/prefs.py
@@ -186,6 +186,7 @@ HOTKEYS = [
         "key": "extra",
         "keys": [
             {"key": "search-on-web", "label": _("Search selected text on web")},
+            {"key": "open-link-under-terminal-cursor", "label": _("Open URL under terminal cursor")},
         ],
     },
 ]

--- a/guake/terminal.py
+++ b/guake/terminal.py
@@ -478,6 +478,13 @@ class GuakeTerminal(Vte.Terminal):
         if value:
             return value
 
+    def get_link_under_terminal_cursor(self) -> Optional[str]:
+        cursor_position = self.get_cursor_position()
+        matched_string = self.match_check(cursor_position.column, cursor_position.row)
+        link = self.handleTerminalMatch(matched_string)
+        if link:
+            return link
+
     def get_link_under_cursor(self):
         return self.found_link
 

--- a/guake/terminal.py
+++ b/guake/terminal.py
@@ -478,7 +478,7 @@ class GuakeTerminal(Vte.Terminal):
         if value:
             return value
 
-    def get_link_under_terminal_cursor(self) -> Optional[str]:
+    def get_link_under_terminal_cursor(self):
         cursor_position = self.get_cursor_position()
         matched_string = self.match_check(cursor_position.column, cursor_position.row)
         link = self.handleTerminalMatch(matched_string)

--- a/guake/terminal.py
+++ b/guake/terminal.py
@@ -481,12 +481,13 @@ class GuakeTerminal(Vte.Terminal):
     def get_link_under_cursor(self):
         return self.found_link
 
-    def browse_link_under_cursor(self):
+    def browse_link_under_cursor(self, url=None):
         # TODO move the call to xdg-open to guake.utils
-        if not self.found_link:
+        if not self.found_link or url is None:
             return
-        log.debug("Opening link: %s", self.found_link)
-        cmd = ["xdg-open", self.found_link]
+        url = url if url is not None else self.found_link
+        log.debug("Opening link: %s", url)
+        cmd = ["xdg-open", url]
         with subprocess.Popen(cmd, shell=False):
             pass
 

--- a/guake/terminal.py
+++ b/guake/terminal.py
@@ -490,7 +490,7 @@ class GuakeTerminal(Vte.Terminal):
 
     def browse_link_under_cursor(self, url=None):
         # TODO move the call to xdg-open to guake.utils
-        if not self.found_link or url is None:
+        if not self.found_link and url is None:
             return
         url = url if url is not None else self.found_link
         log.debug("Opening link: %s", url)

--- a/releasenotes/notes/[Add_open_link_under_terminal_cursor_accelerator]-6bd83e590f8403d9.yaml
+++ b/releasenotes/notes/[Add_open_link_under_terminal_cursor_accelerator]-6bd83e590f8403d9.yaml
@@ -1,0 +1,7 @@
+release_summary: >
+  Add new accelerator to open a link or URL under the terminal cursor.
+
+features:
+  - |
+      - Add new accelerator to open a link or URL under the terminal cursor #2060
+


### PR DESCRIPTION
Add functionality to set a keyboard shortcut to open link under terminal cursor (similar to "ctrl click").

Following [2060](https://github.com/Guake/guake/issues/2060)

Status: current changes are enough to open links under cursor via a hardcoded shortcut.

Question: how to properly add a new user configurable shortcut?