### PR TITLE
Clear up deprecations

### DIFF
--- a/guake/boxes.py
+++ b/guake/boxes.py
@@ -412,7 +412,7 @@ class TerminalBox(Gtk.Box, TerminalHolder):
     def add_scroll_bar(self):
         """Packs the scrollbar."""
         adj = self.terminal.get_vadjustment()
-        self.scroll = Gtk.VScrollbar(adj)
+        self.scroll = Gtk.Scrollbar.new(Gtk.Orientation.VERTICAL, adj)
         self.scroll.show()
         self.pack_start(self.scroll, False, False, 0)
 
@@ -636,8 +636,8 @@ class TabLabelEventBox(Gtk.EventBox):
     def __init__(self, notebook, text, settings):
         super().__init__()
         self.notebook = notebook
-        self.box = Gtk.Box(Gtk.Orientation.HORIZONTAL, 0, visible=True)
-        self.label = Gtk.Label(text, visible=True)
+        self.box = Gtk.Box(homogeneous=Gtk.Orientation.HORIZONTAL, spacing=0, visible=True)
+        self.label = Gtk.Label(label=text, visible=True)
         self.close_button = Gtk.Button(
             image=Gtk.Image.new_from_icon_name("window-close", Gtk.IconSize.MENU),
             relief=Gtk.ReliefStyle.NONE,

--- a/guake/gsettings.py
+++ b/guake/gsettings.py
@@ -277,7 +277,7 @@ class GSettingHandler:
         """
         font_name = None
         if settings.get_boolean(key):
-            gio_settings = Gio.Settings("org.gnome.desktop.interface")
+            gio_settings = Gio.Settings(schema="org.gnome.desktop.interface")
             font_name = gio_settings.get_string("monospace-font-name")
         else:
             font_name = self.settings.styleFont.get_string("style")
@@ -378,7 +378,7 @@ class GSettingHandler:
             terminals = self.guake.notebook_manager.iter_terminals()
 
         if self.settings.general.get_boolean("use-default-font"):
-            gio_settings = Gio.Settings("org.gnome.desktop.interface")
+            gio_settings = Gio.Settings(schema="org.gnome.desktop.interface")
             font_name = gio_settings.get_string("monospace-font-name")
         else:
             font_name = settings.get_string(key)

--- a/guake/guake_app.py
+++ b/guake/guake_app.py
@@ -39,7 +39,6 @@ gi.require_version("Gtk", "3.0")
 gi.require_version("Gdk", "3.0")
 gi.require_version("Keybinder", "3.0")
 from gi.repository import GLib
-from gi.repository import GObject
 from gi.repository import Gdk
 from gi.repository import Gio
 from gi.repository import Gtk
@@ -86,10 +85,8 @@ RESPONSE_BACKWARD = 1
 # Disable find feature until python-vte hasn't been updated
 enable_find = False
 
-GObject.threads_init()
-
 # Setting gobject program name
-GObject.set_prgname(NAME)
+GLib.set_prgname(NAME)
 
 GDK_WINDOW_STATE_WITHDRAWN = 1
 GDK_WINDOW_STATE_ICONIFIED = 2
@@ -308,7 +305,7 @@ class Guake(SimpleGladeApp):
                 self.hide()
                 self.show()
         else:
-            log.warn("System doesn't support transparency")
+            log.warning("System doesn't support transparency")
             self.window.transparency = False
             self.window.set_visual(screen.get_system_visual())
 

--- a/guake/keybindings.py
+++ b/guake/keybindings.py
@@ -224,7 +224,7 @@ class Keybindings:
                     filename,
                 )
         elif key == "show-focus" and not self.guake.hotkeys.bind(value, self.guake.show_focus):
-            log.warn("can't bind show-focus key")
+            log.warning("can't bind show-focus key")
 
     def activate(self, window, event):
         """If keystroke matches a key binding, activate keybinding. Otherwise, allow

--- a/guake/notebook.py
+++ b/guake/notebook.py
@@ -68,14 +68,14 @@ class TerminalNotebook(Gtk.Notebook):
             GObject.signal_new(
                 "terminal-spawned",
                 TerminalNotebook,
-                GObject.SIGNAL_RUN_LAST,
+                GObject.SignalFlags.RUN_LAST,
                 GObject.TYPE_NONE,
                 (GObject.TYPE_PYOBJECT, GObject.TYPE_INT),
             )
             GObject.signal_new(
                 "page-deleted",
                 TerminalNotebook,
-                GObject.SIGNAL_RUN_LAST,
+                GObject.SignalFlags.RUN_LAST,
                 GObject.TYPE_NONE,
                 (),
             )
@@ -511,7 +511,7 @@ class NotebookManager(GObject.Object):
             GObject.signal_new(
                 "notebook-created",
                 self,
-                GObject.SIGNAL_RUN_LAST,
+                GObject.SignalFlags.RUN_LAST,
                 GObject.TYPE_NONE,
                 (GObject.TYPE_PYOBJECT, GObject.TYPE_INT),
             )

--- a/guake/terminal.py
+++ b/guake/terminal.py
@@ -230,13 +230,13 @@ class GuakeTerminal(Vte.Terminal):
                 tag = self.match_add_regex(
                     Vte.Regex.new_for_match(expr, len(expr), VTE_REGEX_FLAGS), 0
                 )
-                self.match_set_cursor_type(tag, Gdk.CursorType.HAND2)
+                self.match_set_cursor_name(tag, "hand")
 
             for _useless, match, _otheruseless in QUICK_OPEN_MATCHERS:
                 tag = self.match_add_regex(
                     Vte.Regex.new_for_match(match, len(match), VTE_REGEX_FLAGS), 0
                 )
-                self.match_set_cursor_type(tag, Gdk.CursorType.HAND2)
+                self.match_set_cursor_name(tag, "hand")
         except (
             GLib.Error,
             AttributeError,


### PR DESCRIPTION
Clean up various deprecations raised by the test cases.

Did not change places that would cause functional changes, `set_allow_bold()` and `Gtk.StatusIcon` were left alone to be dealt with later.

The list that I worked off can be found by [looking at the pytest section of the CI tests](https://github.com/Guake/guake/runs/5953460278) for any given commit