### PR TITLE
Add file loader and tests for compute_tab_table and load_cwd_guake_yml

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -34,7 +34,6 @@ pew = "*"
 black = "==21.8b0"
 flakehell = "*"
 toml = "*"
-dataclasses = {markers="python_version < '3.7'","version >" = "0.1.3"}
 
 [packages]
 pbr = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "6a79b91c9cf1d9dba7468310968b7c2996c4102ec02f285107c8269d8b7bfe1a"
+            "sha256": "db17cdb4a1f7621cfed5e66c92df1ea73f1e94a8b587952fcebad77360157600"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -91,11 +91,11 @@
         },
         "astroid": {
             "hashes": [
-                "sha256:8d0a30fe6481ce919f56690076eafbb2fb649142a89dc874f1ec0e7a011492d0",
-                "sha256:cc8cc0d2d916c42d0a7c476c57550a4557a083081976bf42a73414322a6411d9"
+                "sha256:4e5ba10571e197785e312966ea5efb2f5783176d4c1a73fa922d474ae2be59f7",
+                "sha256:f1af57483cd17e963b2eddce8361e00fc593d1520fe19948488e94ff6476bd71"
             ],
             "index": "pypi",
-            "version": "==2.11.2"
+            "version": "==2.11.3"
         },
         "attrs": {
             "hashes": [
@@ -318,10 +318,8 @@
                 "sha256:0201d89fa866f68c8ebd9d08ee6ff50c0b255f8ec63a71c16fda7af82bb887bf",
                 "sha256:8479067f342acf957dc82ec415d355ab5edb7e7646b90dc6e2fd1d96ad084c97"
             ],
-            "index": "pypi",
             "markers": "python_version < '3.7'",
-            "version": "==0.8",
-            "version >": "0.1.3"
+            "version": "==0.8"
         },
         "dill": {
             "hashes": [
@@ -465,7 +463,7 @@
                 "sha256:6f62d78e2f89b4500b080fe3a81690850cd254227f27f75c3a0c491a1f351ba7",
                 "sha256:e8443a5e7a020e9d7f97f1d7d9cd17c88bcb3bc7e218bf9cf5095fe550be2951"
             ],
-            "markers": "python_version < '4.0' and python_full_version >= '3.6.1'",
+            "markers": "python_version < '4' and python_full_version >= '3.6.1'",
             "version": "==5.10.1"
         },
         "jeepney": {
@@ -775,11 +773,11 @@
         },
         "pylint": {
             "hashes": [
-                "sha256:c149694cfdeaee1aa2465e6eaab84c87a881a7d55e6e93e09466be7164764d1e",
-                "sha256:dab221658368c7a05242e673c275c488670144123f4bd262b2777249c1c0de9b"
+                "sha256:8b1265173abaf37c2e7a21989d05fd6b0f8032c6772f85abe3b0652903aac66c",
+                "sha256:939e67253d1b8569a4c827d933debf603f999ba745775c66e36463922d4e320b"
             ],
             "index": "pypi",
-            "version": "==2.13.5"
+            "version": "==2.13.6"
         },
         "pyparsing": {
             "hashes": [
@@ -1184,7 +1182,7 @@
                 "sha256:44ece4d53fb1706f667c9bd1c648f5469a2ec925fcf3a776667042d645472c14",
                 "sha256:aabaf16477806a5e1dd19aa41f8c2b7950dd3c746362d7e3223dbe6de6ac448e"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4.0'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
             "version": "==1.26.9"
         },
         "virtualenv": {

--- a/guake/keybindings.py
+++ b/guake/keybindings.py
@@ -17,8 +17,9 @@ License along with this program; if not, write to the
 Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
 Boston, MA 02110-1301 USA
 """
-from collections import defaultdict
 import logging
+
+from collections import defaultdict
 
 import gi
 

--- a/guake/tests/__init__.py
+++ b/guake/tests/__init__.py
@@ -1,4 +1,5 @@
 import builtins
+
 from locale import gettext
 
 builtins.__dict__["_"] = gettext

--- a/guake/tests/test_utils.py
+++ b/guake/tests/test_utils.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=redefined-outer-name
+
+from guake.utils import FileManager
+
+
+def test_file_manager(fs):
+    fs.create_file("/foo/bar", contents="test")
+    fm = FileManager()
+    assert fm.read("/foo/bar") == "test"
+
+
+def test_file_manager_hit(fs):
+    f = fs.create_file("/foo/bar", contents="test")
+
+    fm = FileManager(delta=9999)
+    assert fm.read("/foo/bar") == "test"
+    f.set_contents("changed")
+    assert fm.read("/foo/bar") == "test"
+
+
+def test_file_manager_miss(fs):
+    f = fs.create_file("/foo/bar", contents="test")
+
+    fm = FileManager(delta=0.0)
+    assert fm.read("/foo/bar") == "test"
+    f.set_contents("changed")
+    assert fm.read("/foo/bar") == "changed"
+
+
+def test_file_manager_clear(fs):
+    f = fs.create_file("/foo/bar", contents="test")
+
+    fm = FileManager(delta=9999)
+    assert fm.read("/foo/bar") == "test"
+    f.set_contents("changed")
+    assert fm.read("/foo/bar") == "test"
+    fm.clear()
+    assert fm.read("/foo/bar") == "changed"

--- a/guake/utils.py
+++ b/guake/utils.py
@@ -21,9 +21,10 @@ Boston, MA 02110-1301 USA
 """
 import enum
 import logging
+import os
 import subprocess
 import time
-import os
+import yaml
 
 import cairo
 
@@ -107,6 +108,46 @@ def restore_preferences(filename):
         prefs = f.read()
     with subprocess.Popen(["dconf", "load", "/apps/guake/"], stdin=subprocess.PIPE) as p:
         p.communicate(input=prefs)
+
+
+class FileManager:
+    def __init__(self, delta=1.0):
+        self._cache = {}
+        self._delta = max(0.0, delta)
+
+    def clear(self):
+        self._cache.clear()
+
+    def read_yaml(self, filename: str):
+
+        content = None
+
+        try:
+            content = self.read(filename)
+        except PermissionError:
+            log.debug("PermissionError while reading %s.", filename)
+        except FileNotFoundError:
+            log.debug("File %s does not exists.", filename)
+        except UnicodeDecodeError:
+            log.debug("Encoding error %s (we assume is utf-8).", filename)
+
+        if content is not None:
+            try:
+                content = yaml.safe_load(content)
+            except yaml.YAMLError:
+                log.debug("YAMLError reading %s.", filename)
+                content = None
+        return content
+
+    def read(self, filename: str) -> str:
+        # Return the content of a file from the fs or from cache.
+        if (
+            filename not in self._cache
+            or self._cache[filename]["time"] + self._delta < time.monotonic()
+        ):
+            with open(filename, mode="r", encoding="utf-8") as fd:
+                self._cache[filename] = {"time": time.monotonic(), "content": fd.read()}
+        return self._cache[filename]["content"]
 
 
 class TabNameUtils:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,9 +15,8 @@ astroid
 autopep8
 black==21.8b0
 colorlog
-dataclasses
 fiximports>=0.1.18
-flake8
+flake8>=3.8.0,<4.0.0
 flakehell
 mock>=2.0.0
 pathlib2


### PR DESCRIPTION
This is a continuation of #1759. Test for compute_tab_title and load_cwd_guake_yml are added and a class that controls the cache is added to utils.py (FileManager) tests for that class are also included. There are no new functionalities here, just more tests and a cleaner cache control. Also dataclasses are not used in the code that's why I removed ir from the Pipfile.