### PR TITLE
Fix typos in gschema descriptions

### DIFF
--- a/guake/data/org.guake.gschema.xml
+++ b/guake/data/org.guake.gschema.xml
@@ -94,7 +94,7 @@
         <key name="tab-ontop" type="b">
             <default>false</default>
             <summary>Tab on top.</summary>
-            <description>Makes tab bar on top of the Guake window. Per default, tabs appears below the terminal. Setting this to True will move the tab on top of the terminal. Requires a restart.</description>
+            <description>Makes tab bar on top of the Guake window. Per default, tabs appear below the terminal. Setting this to True will move the tab on top of the terminal. Requires a restart.</description>
         </key>
         <key name="new-tab-after" type="b">
             <default>false</default>

--- a/guake/data/org.guake.gschema.xml
+++ b/guake/data/org.guake.gschema.xml
@@ -94,7 +94,7 @@
         <key name="tab-ontop" type="b">
             <default>false</default>
             <summary>Tab on top.</summary>
-            <description>Makes tab bar on top of the Guake window. Per default, tabs appears bellow the terminal. Setting this to True will move the tab on top of the terminal. Requires a restart.</description>
+            <description>Makes tab bar on top of the Guake window. Per default, tabs appears below the terminal. Setting this to True will move the tab on top of the terminal. Requires a restart.</description>
         </key>
         <key name="new-tab-after" type="b">
             <default>false</default>
@@ -244,7 +244,7 @@
         <key name="compat-backspace" type="s">
             <default>'ascii-delete'</default>
             <summary>Backspace Compatibility</summary>
-            <description>Defines the behavior of backscape key.</description>
+            <description>Defines the behavior of backspace key.</description>
         </key>
         <key name="compat-delete" type="s">
             <default>'delete-sequence'</default>
@@ -269,7 +269,7 @@
         <key name="custom-command-file" type="s">
             <default>'~/.config/guake/custom_command.json'</default>
             <summary>Path to the default custom command json file.</summary>
-            <description>Path to the default custom command json file. If is blank or the json file is not in a proper format the terminal context menu will be built without custom commands. If the file is a valid json with recognized structure theterminak context menu will be buit with the commands read inside.</description>
+            <description>Path to the default custom command json file. If is blank or the json file is not in a proper format the terminal context menu will be built without custom commands. If the file is a valid json with recognized structure theterminak context menu will be built with the commands read inside.</description>
         </key>
         <key name="open-tab-cwd" type="b">
             <default>true</default>


### PR DESCRIPTION
Addressing some spelling errors in descriptions in the gschema.xml file. 