### PR TITLE
Include names of processes in PromptQuitDialog

### DIFF
--- a/guake/dialogs.py
+++ b/guake/dialogs.py
@@ -64,15 +64,20 @@ class PromptQuitDialog(Gtk.MessageDialog):
             else:
                 notebooks_str = ""
 
-        if procs == 0:
+        if not procs:
             proc_str = _("There are no processes running")
-        elif procs == 1:
+        elif len(procs) == 1:
             proc_str = _("There is a process still running")
         else:
-            proc_str = _("There are {0} processes still running").format(procs)
+            proc_str = _("There are {0} processes still running").format(len(procs))
+
+        if procs:
+            proc_list = "\n\n" + "\n".join(f"{name} ({pid})" for pid, name in procs)
+        else:
+            proc_list = ""
 
         self.set_markup(primary_msg)
-        self.format_secondary_markup(f"<b>{proc_str}{tab_str}{notebooks_str}.</b>")
+        self.format_secondary_markup(f"<b>{proc_str}{tab_str}{notebooks_str}.</b>{proc_list}")
 
     def quit(self):
         """Run the "are you sure" dialog for quitting Guake"""

--- a/guake/globals.py
+++ b/guake/globals.py
@@ -70,6 +70,7 @@ NAME = "guake"
 ALIGN_CENTER, ALIGN_LEFT, ALIGN_RIGHT = range(3)
 ALIGN_TOP, ALIGN_BOTTOM = range(2)
 ALWAYS_ON_PRIMARY = -1
+PROMPT_NEVER, PROMPT_PROCESSES, PROMPT_ALWAYS = range(3)
 
 # TODO this is not as fancy as as it could be
 # pylint: disable=anomalous-backslash-in-string

--- a/guake/guake_app.py
+++ b/guake/guake_app.py
@@ -54,6 +54,8 @@ from guake.common import pixmapfile
 from guake.dialogs import PromptQuitDialog
 from guake.globals import MAX_TRANSPARENCY
 from guake.globals import NAME
+from guake.globals import PROMPT_ALWAYS
+from guake.globals import PROMPT_PROCESSES
 from guake.globals import TABS_SESSION_SCHEMA_VERSION
 from guake.gsettings import GSettingHandler
 from guake.keybindings import Keybindings
@@ -906,13 +908,17 @@ class Guake(SimpleGladeApp):
 
     def accel_quit(self, *args):
         """Callback to prompt the user whether to quit Guake or not."""
-        procs = self.notebook_manager.get_running_fg_processes_count()
+        procs = self.notebook_manager.get_running_fg_processes()
         tabs = self.notebook_manager.get_n_pages()
         notebooks = self.notebook_manager.get_n_notebooks()
         prompt_cfg = self.settings.general.get_boolean("prompt-on-quit")
         prompt_tab_cfg = self.settings.general.get_int("prompt-on-close-tab")
         # "Prompt on tab close" config overrides "prompt on quit" config
-        if prompt_cfg or (prompt_tab_cfg == 1 and procs > 0) or (prompt_tab_cfg == 2):
+        if (
+            prompt_cfg
+            or (prompt_tab_cfg == PROMPT_PROCESSES and procs)
+            or (prompt_tab_cfg == PROMPT_ALWAYS)
+        ):
             log.debug("Remaining procs=%r", procs)
             if PromptQuitDialog(self.window, procs, tabs, notebooks).quit():
                 log.info("Quitting Guake")

--- a/guake/tests/test_utils.py
+++ b/guake/tests/test_utils.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=redefined-outer-name
+import os
 
 from guake.utils import FileManager
+from guake.utils import get_process_name
 
 
 def test_file_manager(fs):
@@ -37,3 +39,7 @@ def test_file_manager_clear(fs):
     assert fm.read("/foo/bar") == "test"
     fm.clear()
     assert fm.read("/foo/bar") == "changed"
+
+
+def test_process_name():
+    assert get_process_name(os.getpid())

--- a/guake/utils.py
+++ b/guake/utils.py
@@ -22,6 +22,7 @@ Boston, MA 02110-1301 USA
 import enum
 import logging
 import os
+import re
 import subprocess
 import time
 import yaml
@@ -524,3 +525,16 @@ class BackgroundImageManager:
             cr.paint()
 
         cr.restore()
+
+
+def get_process_name(pid):
+    stat_file = f"/proc/{pid}/stat"
+    try:
+        with open(stat_file, "r", encoding="utf-8") as fp:
+            status = fp.read()
+    except IOError as ex:
+        log.debug("Unable to read %s: %s", stat_file, ex)
+        status = ""
+
+    match = re.match(r"\d+ \(([^)]+)\)", status)
+    return match.group(1) if match else None

--- a/releasenotes/notes/prompt-quit-process-names-32a4e1b37eb36037.yaml
+++ b/releasenotes/notes/prompt-quit-process-names-32a4e1b37eb36037.yaml
@@ -1,0 +1,6 @@
+release_summary: >
+  The "are you sure you want to close" dialog will now include names of any running processes.
+
+features:
+  - |
+    - Include names of any processes in PromptQuitDialog, closes #256


### PR DESCRIPTION
Include names and pids of running processes in PromptQuitDialog. Closes #256.

For example:

![image](https://user-images.githubusercontent.com/195070/196931851-01b45f90-b83d-413a-a9dd-7d4f663b6103.png)
![image](https://user-images.githubusercontent.com/195070/196932208-c6897576-1c5a-43ba-9332-e4fd17f47dc0.png)
