### PR TITLE
Add global hotkey instructions to docs

### DIFF
--- a/docs/source/user/installing.rst
+++ b/docs/source/user/installing.rst
@@ -5,7 +5,18 @@ Installing Guake
 System-wide installation
 ========================
 
-Always prefere using your package manager to install guake.
+On wayland systems, you will need to set the hotkey for opening Guake from your window manager's global settings.
+
+For GNOME:
+
+1. Open Gnome Settings
+2. Go to Devices -> Keyboard
+3. Scroll in the list of the keyboard shorcuts all way down to Custom Shortcuts
+4. Press + to add a custom shortcut
+5. In the Add Custom Shortcut dialog type guake-toggle for command
+6. Enter the name and specify a shortcut, then press Add
+
+Always prefer using your package manager to install guake.
 
 Debian / Ubuntu
 ---------------

--- a/guake/dbusiface.py
+++ b/guake/dbusiface.py
@@ -202,6 +202,16 @@ class DbusManager(dbus.service.Object):
     def h_split_current_terminal(self):
         self.guake.get_notebook().get_current_terminal().get_parent().split_h()
 
+    @dbus.service.method(DBUS_NAME, in_signature="s")
+    def v_split_current_terminal_with_command(self, command):
+        self.guake.get_notebook().get_current_terminal().get_parent().split_v()
+        self.guake.execute_command(command)
+
+    @dbus.service.method(DBUS_NAME, in_signature="s")
+    def h_split_current_terminal_with_command(self, command):
+        self.guake.get_notebook().get_current_terminal().get_parent().split_h()
+        self.guake.execute_command(command)
+
     @dbus.service.method(DBUS_NAME, in_signature="s", out_signature="i")
     def get_index_from_uuid(self, tab_uuid):
         return self.guake.get_index_from_uuid(tab_uuid)

--- a/guake/main.py
+++ b/guake/main.py
@@ -542,11 +542,17 @@ def main():
         only_show_hide = options.show
 
     if options.split_vertical:
-        remote_object.v_split_current_terminal()
+        if options.command:
+            remote_object.v_split_current_terminal_with_command(options.command)
+        else:
+            remote_object.v_split_current_terminal()
         only_show_hide = options.show
 
     if options.split_horizontal:
-        remote_object.h_split_current_terminal()
+        if options.command:
+            remote_object.h_split_current_terminal_with_command(options.command)
+        else:
+            remote_object.h_split_current_terminal()
         only_show_hide = options.show
 
     if options.selected_terminal:
@@ -563,7 +569,7 @@ def main():
             sys.stderr.write(f"invalid index: {selected}\n")
         only_show_hide = options.show
 
-    if options.command:
+    if options.command and not (options.split_vertical or options.split_horizontal):
         remote_object.execute_command(options.command)
         only_show_hide = options.show
 

--- a/releasenotes/notes/execute_split_tabs-44ea0b6657ea45a7.yaml
+++ b/releasenotes/notes/execute_split_tabs-44ea0b6657ea45a7.yaml
@@ -1,0 +1,8 @@
+release_summary: >
+  execute command flag now runs commands in new split tabs if --split-vertical or --split-horizontal are also provided.
+
+
+fixes:
+  - |
+
+      - Options --select-tab, --split-vertical (--split-horizontal) and -execute-command not working as before (v. 3.8.4). #2167


### PR DESCRIPTION
Global hotkeys being inacessible to programs under wayland means that a hotkey now needs to be added in the window manager's settings to invoke `guake-toggle`. This has come up quite frequently, and should probably be added to the installation instructions in docs.