### PR TITLE
Enable the use of AyatanaAppIndicator

### DIFF
--- a/guake/guake_app.py
+++ b/guake/guake_app.py
@@ -153,14 +153,14 @@ class Guake(SimpleGladeApp):
         try:
             try:
                 gi.require_version("AyatanaAppIndicator3", "0.1")
-                from gi.repository import (
+                from gi.repository import (  # pylint: disable=import-outside-toplevel
                     AyatanaAppIndicator3 as appindicator,
-                )  # pylint: disable=import-outside-toplevel
+                )
             except (ValueError, ImportError):
                 gi.require_version("AppIndicator3", "0.1")
-                from gi.repository import (
+                from gi.repository import (  # pylint: disable=import-outside-toplevel
                     AppIndicator3 as appindicator,
-                )  # pylint: disable=import-outside-toplevel
+                )
         except (ValueError, ImportError):
             self.tray_icon = Gtk.StatusIcon()
             self.tray_icon.set_from_file(img)

--- a/guake/guake_app.py
+++ b/guake/guake_app.py
@@ -153,10 +153,14 @@ class Guake(SimpleGladeApp):
         try:
             try:
                 gi.require_version("AyatanaAppIndicator3", "0.1")
-                from gi.repository import AyatanaAppIndicator3 as appindicator # pylint: disable=import-outside-toplevel
+                from gi.repository import (
+                    AyatanaAppIndicator3 as appindicator,
+                )  # pylint: disable=import-outside-toplevel
             except (ValueError, ImportError):
                 gi.require_version("AppIndicator3", "0.1")
-                from gi.repository import AppIndicator3 as appindicator # pylint: disable=import-outside-toplevel
+                from gi.repository import (
+                    AppIndicator3 as appindicator,
+                )  # pylint: disable=import-outside-toplevel
         except (ValueError, ImportError):
             self.tray_icon = Gtk.StatusIcon()
             self.tray_icon.set_from_file(img)

--- a/guake/guake_app.py
+++ b/guake/guake_app.py
@@ -151,8 +151,13 @@ class Guake(SimpleGladeApp):
         # trayicon!
         img = pixmapfile("guake-tray.png")
         try:
-            import appindicator  # pylint: disable=import-outside-toplevel
-        except ImportError:
+            try:
+                gi.require_version("AyatanaAppIndicator3", "0.1")
+                from gi.repository import AyatanaAppIndicator3 as appindicator # pylint: disable=import-outside-toplevel
+            except (ValueError, ImportError):
+                gi.require_version("AppIndicator3", "0.1")
+                from gi.repository import AppIndicator3 as appindicator # pylint: disable=import-outside-toplevel
+        except (ValueError, ImportError):
             self.tray_icon = Gtk.StatusIcon()
             self.tray_icon.set_from_file(img)
             self.tray_icon.set_tooltip_text(_("Guake Terminal"))
@@ -160,11 +165,11 @@ class Guake(SimpleGladeApp):
             self.tray_icon.connect("activate", self.show_hide)
         else:
             # TODO PORT test this on a system with app indicator
-            self.tray_icon = appindicator.Indicator(
-                _("guake-indicator"), _("guake-tray"), appindicator.CATEGORY_OTHER
+            self.tray_icon = appindicator.Indicator.new(
+                "guake-indicator", "guake-tray", appindicator.IndicatorCategory.APPLICATION_STATUS
             )
-            self.tray_icon.set_icon(img)
-            self.tray_icon.set_status(appindicator.STATUS_ACTIVE)
+            self.tray_icon.set_icon_full("guake-tray", _("Guake Terminal"))
+            self.tray_icon.set_status(appindicator.IndicatorStatus.ACTIVE)
             menu = self.get_widget("tray-menu")
             show = Gtk.MenuItem(_("Show"))
             show.set_sensitive(True)

--- a/releasenotes/notes/enable_using_ayatanaappindicator-2a75f68951b2b95c.yaml
+++ b/releasenotes/notes/enable_using_ayatanaappindicator-2a75f68951b2b95c.yaml
@@ -1,0 +1,6 @@
+release_summary: >
+  Enables the use of AyatanaAppIndicator for the tray icon
+
+fixes:
+  - |
+      - tray icon broken with AppIndicator #433


### PR DESCRIPTION
This uses the newer successor to AppIndicator3 for the tray icon implementation, with a fallback to the older AppIndicator3 if the Ayatana version is not found. AyatanaAppIndicator is backwards compatible with AppIndicator3, so the API remains the same. The icon is also fixed.

Tested on Solus 4.4 with Budgie Desktop 10.8.

Ref https://github.com/BuddiesOfBudgie/budgie-desktop/issues/446
Fixes #433 