### PR TITLE
Prevent the use of non-image files as a background image (replaces #2206)

### DIFF
--- a/guake/prefs.py
+++ b/guake/prefs.py
@@ -536,8 +536,17 @@ class PrefsCallbacks:
         self.settings.styleFont.set_string("style", fbtn.get_font_name())
 
     def on_background_image_file_chooser_file_changed(self, fc):
+        allowed_extensions = (
+            ".jpg",
+            ".jpeg",
+            ".png",
+            ".gif",
+        )  # only allow files with these extensions
         self.settings.general.set_string(
-            "background-image-file", fc.get_filename() if fc.get_filename() else ""
+            "background-image-file",
+            fc.get_filename()
+            if fc.get_filename() and fc.get_filename().endswith(allowed_extensions)
+            else "",
         )
 
     def on_background_image_file_remove_clicked(self, btn):

--- a/releasenotes/notes/prevent_nonimage_file_as_background-46a5d468eb91b33c.yaml
+++ b/releasenotes/notes/prevent_nonimage_file_as_background-46a5d468eb91b33c.yaml
@@ -1,0 +1,7 @@
+release_summary: >
+  Prevent the use of non-image files as the background image. The following file extensions are allowed: .jpg, .jpeg, .png, .gif
+
+fixes:
+  - |
+
+      - Prevent users from setting non-image files as a background image, closes #2205


### PR DESCRIPTION
Fixes https://github.com/Guake/guake/issues/2205 and replaces PR #2206.

I had an issue with my setup so I thought it would cleaner to start over in a new branch and port my changes there.