### PR TITLE
Allow splitting with specified size using --split-vertical or --split-horizontal

### DIFF
--- a/guake/boxes.py
+++ b/guake/boxes.py
@@ -456,30 +456,30 @@ class TerminalBox(Gtk.Box, TerminalHolder):
     def unset_terminal(self, *args):
         self.terminal = None
 
-    def split_h(self):
-        return self.split(DualTerminalBox.ORIENT_V)
+    def split_h(self, split_percentage: int = 50):
+        return self.split(DualTerminalBox.ORIENT_V, split_percentage)
 
-    def split_v(self):
-        return self.split(DualTerminalBox.ORIENT_H)
+    def split_v(self, split_percentage: int = 50):
+        return self.split(DualTerminalBox.ORIENT_H, split_percentage)
 
-    def split_h_no_save(self):
-        return self.split_no_save(DualTerminalBox.ORIENT_V)
+    def split_h_no_save(self, split_percentage: int = 50):
+        return self.split_no_save(DualTerminalBox.ORIENT_V, split_percentage)
 
-    def split_v_no_save(self):
-        return self.split_no_save(DualTerminalBox.ORIENT_H)
+    def split_v_no_save(self, split_percentage: int = 50):
+        return self.split_no_save(DualTerminalBox.ORIENT_H, split_percentage)
 
     @save_tabs_when_changed
-    def split(self, orientation):
-        self.split_no_save(orientation)
+    def split(self, orientation, split_percentage: int = 50):
+        self.split_no_save(orientation, split_percentage)
 
-    def split_no_save(self, orientation):
+    def split_no_save(self, orientation, split_percentage: int = 50):
         notebook = self.get_notebook()
         parent = self.get_parent()  # RootTerminalBox
 
         if orientation == DualTerminalBox.ORIENT_H:
-            position = self.get_allocation().width / 2
+            position = self.get_allocation().width * ((100 - split_percentage) / 100)
         else:
-            position = self.get_allocation().height / 2
+            position = self.get_allocation().height * ((100 - split_percentage) / 100)
 
         terminal_box = TerminalBox()
         terminal = notebook.terminal_spawn()

--- a/guake/callbacks.py
+++ b/guake/callbacks.py
@@ -88,10 +88,10 @@ class TerminalContextMenuCallbacks:
         self.notebook.guake.accel_quit()
 
     def on_split_vertical(self, *args):
-        self.terminal.get_parent().split_v()
+        self.terminal.get_parent().split_v(50)
 
     def on_split_horizontal(self, *args):
-        self.terminal.get_parent().split_h()
+        self.terminal.get_parent().split_h(50)
 
     def on_close_terminal(self, *args):
         self.terminal.kill()

--- a/guake/dbusiface.py
+++ b/guake/dbusiface.py
@@ -194,22 +194,22 @@ class DbusManager(dbus.service.Object):
     def get_selected_uuidtab(self):
         return self.guake.get_selected_uuidtab()
 
-    @dbus.service.method(DBUS_NAME)
-    def v_split_current_terminal(self):
-        self.guake.get_notebook().get_current_terminal().get_parent().split_v()
+    @dbus.service.method(DBUS_NAME, in_signature="i")
+    def v_split_current_terminal(self, split_percentage: int):
+        self.guake.get_notebook().get_current_terminal().get_parent().split_v(split_percentage)
 
-    @dbus.service.method(DBUS_NAME)
-    def h_split_current_terminal(self):
-        self.guake.get_notebook().get_current_terminal().get_parent().split_h()
+    @dbus.service.method(DBUS_NAME, in_signature="i")
+    def h_split_current_terminal(self, split_percentage: int):
+        self.guake.get_notebook().get_current_terminal().get_parent().split_h(split_percentage)
 
-    @dbus.service.method(DBUS_NAME, in_signature="s")
-    def v_split_current_terminal_with_command(self, command):
-        self.guake.get_notebook().get_current_terminal().get_parent().split_v()
+    @dbus.service.method(DBUS_NAME, in_signature="si")
+    def v_split_current_terminal_with_command(self, command, split_percentage: int):
+        self.guake.get_notebook().get_current_terminal().get_parent().split_v(split_percentage)
         self.guake.execute_command(command)
 
-    @dbus.service.method(DBUS_NAME, in_signature="s")
-    def h_split_current_terminal_with_command(self, command):
-        self.guake.get_notebook().get_current_terminal().get_parent().split_h()
+    @dbus.service.method(DBUS_NAME, in_signature="si")
+    def h_split_current_terminal_with_command(self, command, split_percentage: int):
+        self.guake.get_notebook().get_current_terminal().get_parent().split_h(split_percentage)
         self.guake.execute_command(command)
 
     @dbus.service.method(DBUS_NAME, in_signature="s", out_signature="i")

--- a/guake/main.py
+++ b/guake/main.py
@@ -240,17 +240,29 @@ def main():
     parser.add_argument(
         "--split-vertical",
         dest="split_vertical",
-        action="store_true",
-        default=False,
-        help=_("Split the selected tab vertically."),
+        metavar="SPLIT_PERCENTAGE",
+        action="store",
+        type=int,
+        nargs="?",
+        const=50,
+        default=None,
+        choices=range(1, 100),
+        help=_("Split the selected tab vertically. Optional input split percentage for the width."),
     )
 
     parser.add_argument(
         "--split-horizontal",
         dest="split_horizontal",
-        action="store_true",
-        default=False,
-        help=_("Split the selected tab horizontally."),
+        metavar="SPLIT_PERCENTAGE",
+        action="store",
+        type=int,
+        nargs="?",
+        const=50,
+        default=None,
+        choices=range(1, 100),
+        help=_(
+            "Split the selected tab horizontally. Optional input split percentage for the height."
+        ),
     )
 
     parser.add_argument(
@@ -553,16 +565,20 @@ def main():
 
     if options.split_vertical:
         if options.command:
-            remote_object.v_split_current_terminal_with_command(options.command)
+            remote_object.v_split_current_terminal_with_command(
+                options.command, options.split_vertical
+            )
         else:
-            remote_object.v_split_current_terminal()
+            remote_object.v_split_current_terminal(options.split_vertical)
         only_show_hide = options.show
 
     if options.split_horizontal:
         if options.command:
-            remote_object.h_split_current_terminal_with_command(options.command)
+            remote_object.h_split_current_terminal_with_command(
+                options.command, options.split_horizontal
+            )
         else:
-            remote_object.h_split_current_terminal()
+            remote_object.h_split_current_terminal(options.split_horizontal)
         only_show_hide = options.show
 
     if options.selected_terminal:

--- a/releasenotes/notes/command_improvement-e7fcdf2a28c0e488.yaml
+++ b/releasenotes/notes/command_improvement-e7fcdf2a28c0e488.yaml
@@ -1,0 +1,6 @@
+release_summary: >
+  Improved terminal splitting: Optional specified percentage now reflects the new pane's size when using --split-vertical or --split-horizontal.
+
+features:
+  - |
+      - Allow splitting terminal to specific size with --split-vertical <Size> or --split-horizontal <Size> #1931

--- a/releasenotes/notes/save_zoom-8b8f54485b975e7c.yaml
+++ b/releasenotes/notes/save_zoom-8b8f54485b975e7c.yaml
@@ -3,5 +3,4 @@ release_summary: >
 
 fixes:
   - |
-      - Opening a new tab resets the zoom level/ #2109 
-
+      - Opening a new tab resets the zoom level/ #2109


### PR DESCRIPTION
Introduces the ability to specify split percentages when using the --split-vertical or --split-horizontal flags, as discussed in #1931. Now, users can control the size of the new pane by providing an optional split percentage, making terminal splitting more flexible and user-friendly.