### PR TITLE
Fix save content with newer Vte

### DIFF
--- a/releasenotes/notes/bugfix-503a9fee8f80e714.yaml
+++ b/releasenotes/notes/bugfix-503a9fee8f80e714.yaml
@@ -1,0 +1,6 @@
+release_summary: >
+  Fixes Save Content feature for newer versions of Vte
+
+fixes:
+  - Save Content works for newer versions of Vte, fixes #1958
+


### PR DESCRIPTION
Fixes Save Content feature with newer versions of Vte.  The entire contents, including scrollback, will be saved.

See #1958   I left the old method there as well, in case get_text_range doesn't work for some reason.  I don't have a system with an older version of Vte to test.

