### PR TITLE
docs: update website URLs, use https://

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,7 +52,7 @@ Bugs? Information?
 ------------------
 
 - Source Code available on `GitHub <https://github.com/Guake/guake/>`_.
-- Official Homepage: http://guake-project.org
+- Official Homepage: https://guake.github.io
 - Online Documentation is hosted on `ReadTheDocs <http://guake.readthedocs.io/>`_.
 - If you are not a developer, you can still contribute to Guake by
   `improving its translations in your language <https://hosted.weblate.org/projects/guake/guake/>`_.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -43,7 +43,7 @@ Useful links
 ============
 
 - Source Code available on `GitHub <https://github.com/Guake/guake/>`_.
-- Official Homepage: http://guake-project.org
+- Official Homepage: https://guake.github.io
 - Online Documentation is hosted on `ReadTheDocs <http://guake.readthedocs.io/>`_.
 - If you are not a developer, you can still contribute to Guake by
    `improving its translations in your language <https://hosted.weblate.org/projects/guake/guake/>`_.

--- a/guake/data/about.glade
+++ b/guake/data/about.glade
@@ -13,8 +13,8 @@ Copyright 2007-2010 Lincoln de Sousa
 Copyright 2007 Gabriel Falcão</property>
     <property name="comments" translatable="yes">Guake is an easy to access
 terminal based on FPS games terminal</property>
-    <property name="website">http://guake-project.org</property>
-    <property name="website_label">http://guake-project.org</property>
+    <property name="website">https://guake.github.io</property>
+    <property name="website_label">https://guake.github.io</property>
     <property name="license">Guake is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public
 License as published by the Free Software Foundation;

--- a/guake/data/guake.desktop.metainfo.xml
+++ b/guake/data/guake.desktop.metainfo.xml
@@ -22,14 +22,14 @@
 
 	<screenshots>
 		<screenshot type="default">
-			<image>http://guake-project.org/img/screenshot.png</image>
+			<image>https://guake.github.io/img/screenshot.png</image>
 		</screenshot>
 		<screenshot>
-			<image>http://guake-project.org/img/screenshot2.jpg</image>
+			<image>https://guake.github.io/img/screenshot2.jpg</image>
 		</screenshot>
 	</screenshots>
 
-	<url type="homepage">http://guake-project.org/</url>
+	<url type="homepage">https://guake.github.io/</url>
 	<url type="bugtracker">https://github.com/Guake/guake/issues</url>
 	<url type="translate">https://hosted.weblate.org/projects/guake/guake/</url>
 </component>


### PR DESCRIPTION
1. Use `https` URLs
2. Fix Guake/guake-website#17