### PR TITLE
Update prefs.py

### DIFF
--- a/guake/prefs.py
+++ b/guake/prefs.py
@@ -64,7 +64,7 @@ log = logging.getLogger(__name__)
 
 # A regular expression to match possible python interpreters when
 # filling interpreters combo in preferences (including bpython and ipython)
-PYTHONS = re.compile(r"^[a-z]python$|^python\d\.\d$")
+PYTHONS = re.compile(r"^[a-z]python$|^python\d\.\d$|^python\d\.\d\d$")
 
 # Path to the shells file, it will be used to start to populate
 # interpreters combo, see the next variable, its important to fill the


### PR DESCRIPTION
Please follow these steps before submitting a new Pull Request to Guake:

- rebase on latest HEAD:

  ```bash
  $ git pull --rebase upstream master
  ```

- hack your change

- to execute the code styling, checks and unit tests:

  ```bash
  $ make style check reno-lint test
  ```

- describe your change in a slug file for automatic release note
  generation, using:

  ```bash
  $ make reno SLUG=<short_name_of_my_feature>
  ```

  and edit the created file in `releasenotes/notes/`.
  You can see how `reno` works using `pipenv run reno --help`.

  Please use a generic slug (eg, for translation update,
  use `translation`, for bugfix use `bugfix`,...)

- create new commit message

  ```bash
  $ <hack the code>
  $ git commit --all
  ```

- If your change is related to a GitHub issue, you can add a reference
  using `#123` where 123 is the ID of the issue.
  You can use `closes #123` to have GitHub automatically close the issue
  when your contribution get merged

- Semantic commit is supported (and recommended). Add one of the following
  line in your commit messages:

  ```
  # For a bug fix, uses:
  sem-ver: bugfix

  # For a new feature, uses:
  sem-ver: feature

  # Please do not use the 'breaking change' syntax (`sem-ver: api-break`),
  # it is reserved for really big reworks
  ```
This pull request is necessary to ensure that Python versions beginning with 3.10 are available as default shell options on the Guake terminal. Without this modification the newest Python version that would function on the Guake terminal is only Python 3.9, and Ubuntu 22.04 LTS (my host system) ships with Python 3.10 by default, causing the issue of Python 3.10 not appearing on my host system.