### PR TITLE
Makefile: ensure that schema source files are in place before schema recompilation occurs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,6 @@ uninstall-dev-locale:
 	@rm -rf guake/po
 
 install-schemas:
-	if [ $(COMPILE_SCHEMA) = 1 ]; then glib-compile-schemas $(DESTDIR)$(SCHEMA_DIR); fi
 	install -dm755                                       "$(DESTDIR)$(datadir)/applications"
 	install -Dm644 "$(DEV_DATA_DIR)/guake.desktop"       "$(DESTDIR)$(datadir)/applications/"
 	install -Dm644 "$(DEV_DATA_DIR)/guake-prefs.desktop" "$(DESTDIR)$(datadir)/applications/"
@@ -143,6 +142,7 @@ install-schemas:
 	install -Dm644 "$(DEV_DATA_DIR)"/*.glade "$(DESTDIR)$(GLADE_DIR)/"
 	install -dm755                                         "$(DESTDIR)$(SCHEMA_DIR)"
 	install -Dm644 "$(DEV_DATA_DIR)/org.guake.gschema.xml" "$(DESTDIR)$(SCHEMA_DIR)/"
+	if [ $(COMPILE_SCHEMA) = 1 ]; then glib-compile-schemas $(DESTDIR)$(SCHEMA_DIR); fi
 
 uninstall-system: uninstall-schemas uninstall-locale
 	$(SHELL) -c $(PYTHON_SITEDIRS_FOR_PREFIX) \

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ ln-venv:
 clean-ln-venv:
 	@rm -f .venv
 
-install-system: install-schemas compile-shemas install-locale install-guake
+install-system: install-schemas install-locale install-guake
 
 install-guake:
 	# you probably want to execute this target with sudo:
@@ -126,6 +126,7 @@ uninstall-dev-locale:
 	@rm -rf guake/po
 
 install-schemas:
+	if [ $(COMPILE_SCHEMA) = 1 ]; then glib-compile-schemas $(DESTDIR)$(SCHEMA_DIR); fi
 	install -dm755                                       "$(DESTDIR)$(datadir)/applications"
 	install -Dm644 "$(DEV_DATA_DIR)/guake.desktop"       "$(DESTDIR)$(datadir)/applications/"
 	install -Dm644 "$(DEV_DATA_DIR)/guake-prefs.desktop" "$(DESTDIR)$(datadir)/applications/"
@@ -142,9 +143,6 @@ install-schemas:
 	install -Dm644 "$(DEV_DATA_DIR)"/*.glade "$(DESTDIR)$(GLADE_DIR)/"
 	install -dm755                                         "$(DESTDIR)$(SCHEMA_DIR)"
 	install -Dm644 "$(DEV_DATA_DIR)/org.guake.gschema.xml" "$(DESTDIR)$(SCHEMA_DIR)/"
-
-compile-shemas:
-	if [ $(COMPILE_SCHEMA) = 1 ]; then glib-compile-schemas $(DESTDIR)$(gsettingsschemadir); fi
 
 uninstall-system: uninstall-schemas uninstall-locale
 	$(SHELL) -c $(PYTHON_SITEDIRS_FOR_PREFIX) \

--- a/releasenotes/notes/schema-compilation-race-condition-fix-4e637a29a86126ae.yaml
+++ b/releasenotes/notes/schema-compilation-race-condition-fix-4e637a29a86126ae.yaml
@@ -2,4 +2,5 @@ release_summary: >
   Fix a build race condition between compilation/installation of GSettings schemas
 
 fixes:
-  - Ensure that guake's GSettings XML schemas are installed before requesting their (re)compilation #2219
+  - |
+      - Ensure that guake's GSettings XML schemas are installed before requesting their (re)compilation #2219

--- a/releasenotes/notes/schema-compilation-race-condition-fix-4e637a29a86126ae.yaml
+++ b/releasenotes/notes/schema-compilation-race-condition-fix-4e637a29a86126ae.yaml
@@ -1,0 +1,5 @@
+release_summary: >
+  Fix a build race condition between compilation/installation of GSettings schemas
+
+fixes:
+  - Ensure that guake's GSettings XML schemas are installed before requesting their (re)compilation #2219


### PR DESCRIPTION
When `make` is invoked in parallel mode (`-j` parameter), the dependencies of an individual makefile target may be resolved in unpredictable order.

That meant that sometimes, `compile-schemas` would incorrectly begin to run before all of the `gschema` XML files had been written to the schema destination directory.

This change relocates the `glib-compile-schemas` step to ensure that it occurs after the schema files have been written.

In addition, the existing `SCHEMA_DIR` variable is used instead of `gsettingsschemadir` to refer to the schema directory.

Resolves #2219

Edit: 20240914: redraft this description for brevity.