### PR TITLE
Fix window position drift during visibility toggles

### DIFF
--- a/guake/guake_app.py
+++ b/guake/guake_app.py
@@ -702,7 +702,10 @@ class Guake(SimpleGladeApp):
 
         # move the window even when in fullscreen-mode
         log.debug("Moving window to: %r", window_rect)
-        self.window.move(window_rect.x, window_rect.y)
+
+        # Queue layout updates and defer positioning to prevent drift
+        self.window.queue_resize()
+        GLib.idle_add(lambda: self.window.move(window_rect.x, window_rect.y) and False)
 
         # this works around an issue in fluxbox
         if not self.fullscreen_manager.is_fullscreen():

--- a/releasenotes/notes/bugfix-0850b16af94b9a4d.yaml
+++ b/releasenotes/notes/bugfix-0850b16af94b9a4d.yaml
@@ -1,0 +1,6 @@
+
+fixes:
+  - |
+    Fixed window position drift during visibility toggles. The window would
+    gradually move down and sideways with each show/hide cycle. Window positioning
+    is now properly deferred until after widget layout is complete. #2184


### PR DESCRIPTION
Defer window positioning using queue_resize() and GLib.idle_add() to ensure all widget layout calculations are complete before moving the window.

Fixes #2184

sem-ver: bugfix
