### PR TITLE
Added functionality for multiple equal tabs.  Regarding Issue #2238

### DIFF
--- a/guake/boxes.py
+++ b/guake/boxes.py
@@ -457,6 +457,37 @@ class TerminalBox(Gtk.Box, TerminalHolder):
     def split_v(self, split_percentage: int = 50):
         return self.split(DualTerminalBox.ORIENT_H, split_percentage)
 
+    def split_h_n(self, n: int = 2):
+        return self.split_n_no_save(DualTerminalBox.ORIENT_V, n)
+
+    def split_v_n(self, n: int = 2):
+        return self.split_n_no_save(DualTerminalBox.ORIENT_H, n)
+
+
+    def split_n_no_save(self, orientation, n: int):
+        if n is None:
+            return None
+        if n < 2:
+            raise ValueError("N must be >= 2")
+
+        box_to_split: TerminalBox = self
+        last_dual = None
+
+        for k in range(n, 1, -1):
+            # Make the NEW pane 1/k of the current box (so repeated splits yield equal sizes)
+            split_pct_new = max(1, min(99, round(100 / k)))
+
+            last_dual = box_to_split.split_no_save(orientation, split_pct_new)
+            if self.terminal is not None:
+                # Grabs focus to the original terminal to continue splitting
+                self.terminal.grab_focus()
+
+        # Let GTK update allocations before next split
+            while Gtk.events_pending():
+                Gtk.main_iteration_do(False)
+
+        return last_dual
+
     def split_h_no_save(self, split_percentage: int = 50):
         return self.split_no_save(DualTerminalBox.ORIENT_V, split_percentage)
 

--- a/guake/dbusiface.py
+++ b/guake/dbusiface.py
@@ -215,3 +215,21 @@ class DbusManager(dbus.service.Object):
     @dbus.service.method(DBUS_NAME, in_signature="s", out_signature="i")
     def get_index_from_uuid(self, tab_uuid):
         return self.guake.get_index_from_uuid(tab_uuid)
+
+    @dbus.service.method(DBUS_NAME, in_signature="i")
+    def v_split_current_terminal_into_n(self, n: int):
+        self.guake.get_notebook().get_current_terminal().get_parent().split_v_n(n)
+
+    @dbus.service.method(DBUS_NAME, in_signature="i")
+    def h_split_current_terminal_into_n(self, n: int):
+        self.guake.get_notebook().get_current_terminal().get_parent().split_h_n(n)
+
+    @dbus.service.method(DBUS_NAME, in_signature="si")
+    def v_split_current_terminal_into_n_with_command(self, command, n: int):
+        self.guake.get_notebook().get_current_terminal().get_parent().split_v_n(n)
+        self.guake.execute_command(command)
+
+    @dbus.service.method(DBUS_NAME, in_signature="si")
+    def h_split_current_terminal_into_n_with_command(self, command, n: int):
+        self.guake.get_notebook().get_current_terminal().get_parent().split_h_n(n)
+        self.guake.execute_command(command)

--- a/guake/main.py
+++ b/guake/main.py
@@ -251,6 +251,19 @@ def main():
     )
 
     parser.add_argument(
+        "--split-vertical-tabs",
+        dest="split_vertical_tabs",
+        metavar="N",
+        action="store",
+        type=int,
+        nargs="?",
+        const=2,
+        default=None,
+        help=_("Split the selected tab vertically into N equal tabs"),
+    )
+
+
+    parser.add_argument(
         "--split-horizontal",
         dest="split_horizontal",
         metavar="SPLIT_PERCENTAGE",
@@ -263,6 +276,17 @@ def main():
         help=_(
             "Split the selected tab horizontally. Optional input split percentage for the height."
         ),
+    )
+    parser.add_argument(
+        "--split-horizontal-tabs",
+        dest="split_horizontal_tabs",
+        metavar="N",
+        action="store",
+        type=int,
+        nargs="?",
+        const=2,
+        default=None,
+        help=_("Split the selected tab horizontally into N equal tabs"),
     )
 
     parser.add_argument(
@@ -561,6 +585,22 @@ def main():
         selectedIndex = remote_object.get_index_from_uuid(options.uuid_index)
         sys.stdout.write(f"{selectedIndex}\n")
         only_show_hide = options.show
+
+
+    if options.split_vertical_tabs:
+        if options.command:
+            remote_object.v_split_current_terminal_into_n_with_command(options.command, options.split_vertical_tabs)
+        else:
+            remote_object.v_split_current_terminal_into_n(options.split_vertical_tabs)
+        only_show_hide = options.show
+
+    if options.split_horizontal_tabs:
+        if options.command:
+            remote_object.h_split_current_terminal_into_n_with_command(options.command, options.split_horizontal_tabs)
+        else:
+            remote_object.h_split_current_terminal_into_n(options.split_horizontal_tabs)
+        only_show_hide = options.show
+
 
     if options.split_vertical:
         if options.command:


### PR DESCRIPTION
#2238 
Please review my code changes for this issue. Added 2 new arguments, --split-vertical-tabs and --split-vertical-tabs. Both of these arguments take in a value from 2 and greater and splits the terminal selected into an N number of equally split terminals.