### PR TITLE
Fix window width on multi-monitor setups with different resolutions

### DIFF
--- a/guake/guake_app.py
+++ b/guake/guake_app.py
@@ -822,7 +822,7 @@ class Guake(SimpleGladeApp):
         self.settings.general.triggerOnChangedValue(
             self.settings.general, "window-ontop", user_data=user_data
         )
-        if not self.fullscreen_manager.is_fullscreen():
+        if not self.fullscreen_manager.is_fullscreen() and not terminal_uuid:
             self.settings.general.triggerOnChangedValue(
                 self.settings.general, "window-height", user_data=user_data
             )

--- a/guake/utils.py
+++ b/guake/utils.py
@@ -317,8 +317,17 @@ class RectCalculator:
             log.debug("  window_rect.height: %s", window_rect.height)
             log.debug("  window_rect.width: %s", window_rect.width)
             # Note: move_resize is only on GTK3
-            window.resize(window_rect.width, window_rect.height)
-            window.move(window_rect.x, window_rect.y)
+            gdk_window = window.get_window()
+            if gdk_window is not None:
+                gdk_window.move_resize(
+                    window_rect.x,
+                    window_rect.y,
+                    window_rect.width,
+                    window_rect.height,
+                )
+            else:
+                window.move(window_rect.x, window_rect.y)
+                window.resize(window_rect.width, window_rect.height)
             log.debug("Updated window position: %r", window.get_position())
 
         return window_rect


### PR DESCRIPTION
## Summary

On multi-monitor setups with different widths, Guake would sometimes open or resize to the wrong width.

## Tab spawn issue

When creating a new Tab, there would be a high chance of the window width not matching the current monitor

## Hide/Show issue

When hiding and showing the window, it would sometimes shows with a width not matching the current monitor

## Test

I manually tested this issue on a multi-monitor setup (1920x1200 and 2560x1440).

  - WM/Compositor: **Sway** `1.11`
  - Session: **Wayland** `(GDK_BACKEND=wayland)`
  - GTK: `3.24.52`
  - VTE `0.84.0`

sem-ver: bugfix