### PR TITLE
Fixed failing equality check in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,14 +60,8 @@ jobs:
           make generate-paths
           rm -rf test-rtd
 
-      - uses: Thog/action-equals@v1
-        id: isLatest
-        with:
-          a: ${{ matrix.python-version }}
-          b: 3.9
-
       - name: Store dists (Python 3.9)
-        if: steps.isLatest.outputs.result
+        if: ${{ matrix.python-version == 3.9 }}
         uses: actions/upload-artifact@v4
         with:
           name: dist


### PR DESCRIPTION
The GitHub action named `Thog/action-equals` has been removed. It seems that the developer has deleted most of their repositories, and moved to another Git provider. The built-in equality check of GitHub actions works just as well, so the dependency on a third-party action is not really necessary. As a minimal proof of concept, I created [minimal-example-of-github-actions-equality-check](https://github.com/marios-zindilis/minimal-example-of-github-actions-equality-check). You can see the proposed syntax working in action run [25597149106](https://github.com/marios-zindilis/minimal-example-of-github-actions-equality-check/actions/runs/25597149106).
