### PR TITLE
Fix tab shortened path #2321

### DIFF
--- a/guake/guake_app.py
+++ b/guake/guake_app.py
@@ -1125,9 +1125,13 @@ class Guake(SimpleGladeApp):
 
         # TODO NOTEBOOK this code only works if there is only one terminal in a
         # page, this need to be rewritten
-        for terminal in self.get_notebook().iter_terminals():
-            page_num = self.get_notebook().page_num(terminal.get_parent())
-            self.get_notebook().rename_page(page_num, self.compute_tab_title(terminal), False)
+        notebook = self.get_notebook()
+        for page_num in range(notebook.get_n_pages()):
+            terminals = notebook.get_terminals_for_page(page_num)
+            if terminals:
+                main_terminal = terminals[0]
+                new_title = self.compute_tab_title(main_terminal)
+                notebook.rename_page(page_num, new_title, False)
 
     def load_cwd_guake_yaml(self, vte) -> dict:
         # Read the content of .guake.yml in cwd

--- a/guake/guake_app.py
+++ b/guake/guake_app.py
@@ -1123,8 +1123,6 @@ class Guake(SimpleGladeApp):
         if not use_vte_titles:
             return
 
-        # TODO NOTEBOOK this code only works if there is only one terminal in a
-        # page, this need to be rewritten
         notebook = self.get_notebook()
         for page_num in range(notebook.get_n_pages()):
             terminals = notebook.get_terminals_for_page(page_num)

--- a/releasenotes/notes/bugfix-tab-names.yaml
+++ b/releasenotes/notes/bugfix-tab-names.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix shortened path tab names layout issue (#2321). 
+    Tabs now correctly update their shortened titles regardless of splits layout.


### PR DESCRIPTION
Fixes the layout issue where tab titles failed to update when multiple tabs or splits were active. Replaced direct terminal parent fetching with an iterative tree traversal to correctly find the notebook page index.

Closes #2321

--
RarityFan437

sem-ver: bugfix

