### PR TITLE
feat(prefs): add word characters preference

### DIFF
--- a/guake/data/prefs.glade
+++ b/guake/data/prefs.glade
@@ -3597,10 +3597,29 @@ For example, use &lt;b&gt;subl %(file_path)s:%(line_number)s&lt;/b&gt; for Subli
                                   </packing>
                                 </child>
                                 <child>
-                                  <placeholder/>
+                                  <object class="GtkLabel" id="word_chars_label">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="label" translatable="yes">Word _characters:</property>
+                                    <property name="use-underline">True</property>
+                                    <property name="xalign">0</property>
+                                    <property name="mnemonic-widget">word_chars_entry</property>
+                                  </object>
+                                  <packing>
+                                    <property name="left-attach">0</property>
+                                    <property name="top-attach">2</property>
+                                  </packing>
                                 </child>
                                 <child>
-                                  <placeholder/>
+                                  <object class="GtkEntry" id="word_chars_entry">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <signal name="changed" handler="on_word_chars_changed" swapped="no"/>
+                                  </object>
+                                  <packing>
+                                    <property name="left-attach">1</property>
+                                    <property name="top-attach">2</property>
+                                  </packing>
                                 </child>
                                 <child>
                                   <placeholder/>

--- a/guake/data/prefs.glade
+++ b/guake/data/prefs.glade
@@ -3600,7 +3600,7 @@ For example, use &lt;b&gt;subl %(file_path)s:%(line_number)s&lt;/b&gt; for Subli
                                   <object class="GtkLabel" id="word_chars_label">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
-                                    <property name="label" translatable="yes">Word _characters:</property>
+                                    <property name="label" translatable="yes">_Word characters:</property>
                                     <property name="use-underline">True</property>
                                     <property name="xalign">0</property>
                                     <property name="mnemonic-widget">word_chars_entry</property>

--- a/guake/gsettings.py
+++ b/guake/gsettings.py
@@ -85,6 +85,7 @@ class GSettingHandler:
 
         settings.general.onChangedValue("compat-backspace", self.backspace_changed)
         settings.general.onChangedValue("compat-delete", self.delete_changed)
+        settings.general.onChangedValue("word-chars", self.word_chars_changed)
         settings.general.onChangedValue("custom-command_file", self.custom_command_file_changed)
         settings.general.onChangedValue("max-tab-name-length", self.max_tab_name_length_changed)
         settings.general.onChangedValue("display-tab-names", self.display_tab_names_changed)
@@ -177,6 +178,17 @@ class GSettingHandler:
         terminals = (terminal,) if terminal else self.guake.notebook_manager.iter_terminals()
         for term in terminals:
             term.set_property("cursor-shape", settings.get_int(key))
+
+    def word_chars_changed(self, settings, key, user_data):
+        word_chars = settings.get_string(key)
+        terminal = (
+            self.guake.notebook_manager.get_terminal_by_uuid(user_data.get("terminal_uuid"))
+            if user_data
+            else None
+        )
+        terminals = (terminal,) if terminal else self.guake.notebook_manager.iter_terminals()
+        for term in terminals:
+            term.set_word_char_exceptions(word_chars)
 
     def background_image_file_changed(self, settings, key, user_data):
         """Called when the background image file settings has been changed"""

--- a/guake/prefs.py
+++ b/guake/prefs.py
@@ -589,6 +589,10 @@ class PrefsCallbacks:
         val = combo.get_active_text()
         self.settings.general.set_string("compat-delete", ERASE_BINDINGS[val])
 
+    def on_word_chars_changed(self, entry):
+        """Changes the value of word-chars in dconf"""
+        self.settings.general.set_string("word-chars", entry.get_text())
+
     def on_custom_command_file_chooser_file_changed(self, filechooser):
         self.settings.general.set_string("custom-command-file", filechooser.get_filename())
 
@@ -872,13 +876,12 @@ class PrefsDialog(SimpleGladeApp):
         self.get_widget("lbl_max_tab_name_length").set_sensitive(do_use_vte_titles)
 
     def on_reset_compat_defaults_clicked(self, bnt):
-        """Reset default values to compat_{backspace,delete} dconf
-        keys. The default values are retrivied from the guake.schemas
-        file.
-        """
+        """Reset default values to compatibility dconf keys."""
         self.settings.general.reset("compat-backspace")
         self.settings.general.reset("compat-delete")
+        self.settings.general.reset("word-chars")
         self.reload_erase_combos()
+        self.get_widget("word_chars_entry").set_text(self.settings.general.get_string("word-chars"))
 
     def on_palette_name_changed(self, combo):
         """Changes the value of palette in dconf"""
@@ -1328,6 +1331,8 @@ class PrefsDialog(SimpleGladeApp):
 
         # it's a separated method, to be reused.
         self.reload_erase_combos()
+
+        self.get_widget("word_chars_entry").set_text(self.settings.general.get_string("word-chars"))
 
         # custom command context-menu configuration file
         custom_command_file = self.settings.general.get_string("custom-command-file")

--- a/releasenotes/notes/word-chars-preference-9fc892802ca01441.yaml
+++ b/releasenotes/notes/word-chars-preference-9fc892802ca01441.yaml
@@ -1,0 +1,2 @@
+features:
+  - Add a Preferences field for configuring word characters used during text selection. (#2304)


### PR DESCRIPTION
### What

Add a new Preferences field for configuring the `word-chars` setting.

### Why

Issue #2304 points out that users currently have no way to configure the `word-chars` value from the Preferences window.

This also makes the setting easier to manage when using `--save-preferences` and `--load-preferences`.

### How

- Add a new `word_chars_entry` field to `guake/data/prefs.glade`.
- Load, update, and reset the `word-chars` setting in `guake/prefs.py`.
- Add a release note in `releasenotes/notes/word-chars-preference-9fc892802ca01441.yaml`.

### Testing

- Ran `make style`.
- Ran `make check`.
- Ran `make test` (30 tests passed).
- Verified that changing the field updates the `word-chars` setting.
- Verified that resetting Compatibility preferences restores the default `word-chars` value.

### Screenshot

The new **Word characters** preference available in the **Compatibility** section.

<img width="987" height="788" alt="Word characters preference" src="https://github.com/user-attachments/assets/42f1d6df-2cd9-4a97-810f-efb389a365b0" />

Closes #2304