### PR TITLE
fix: disable XKB cooked accelerators to restore F12 global hotkey

### DIFF
--- a/guake/guake_app.py
+++ b/guake/guake_app.py
@@ -265,6 +265,12 @@ class Guake(SimpleGladeApp):
         # loading and setting up configuration stuff
         GSettingHandler(self)
         Keybinder.init()
+        # Disable XKB cooked accelerators to work around a keybinder
+        # library bug where FinallyGetModifiersForKeycode() returns
+        # spurious consumed modifiers for function keys (e.g. Alt for
+        # F12), causing XGrabKey to grab Alt+F12 which the X server
+        # has reserved for VT switching.
+        Keybinder.set_use_cooked_accelerators(False)
         self.hotkeys = Keybinder
         Keybindings(self)
         self.load_config()

--- a/releasenotes/notes/f12-global-hotkey-bugfix.yaml
+++ b/releasenotes/notes/f12-global-hotkey-bugfix.yaml
@@ -1,0 +1,9 @@
+release_summary: >
+  Fix F12 global hotkey not binding on certain X11 configurations
+
+fixes:
+  - |
+    F12 global hotkey now works on systems where XKB consumed-modifier
+    computation (keybinder's FinallyGetModifiersForKeycode) spuriously
+    returns Mod1/Alt for level 0, preventing the grab. Disabling XKB
+    cooked accelerators matches the approach used by Tilda terminal.


### PR DESCRIPTION
The keybinder library's XKB modifier computation (FinallyGetModifiersForKeycode) spuriously returns Mod1/Alt as a consumed modifier for F12 at level 0 on certain systems (e.g. Cinnamon/Muffin). This causes XGrabKey to attempt grabbing Alt+F12 instead of plain F12, which fails because the X server reserves Alt+Fn keys for VT switching.

Disabling cooked accelerators matches the approach used by Tilda terminal's tomboykeybinder.c, which does not use XKB at all for modifier computation. Users who need cooked accelerators can re-enable them via GSettings.

sem-ver: bugfix
